### PR TITLE
fix `ValueError` in `AttributeType.from_string()`

### DIFF
--- a/graphrag_sdk/attribute.py
+++ b/graphrag_sdk/attribute.py
@@ -35,7 +35,7 @@ class AttributeType(Enum):
             ValueError: If the provided attribute type is invalid.
         """
         # Graph representation of the attribute type
-        normalized_txt = txt.lower()
+        normalized_txt = txt.lstrip('AttributeType.').lower()
         
         # Find the matching attribute type
         if normalized_txt in _SYNONYMS:


### PR DESCRIPTION
Remove the 'AttributeType.' prefix to avoid 'Invalid attribute type' error