### PR TITLE
Fix: Escape special characters in entity descriptions

### DIFF
--- a/graphrag_sdk/entity.py
+++ b/graphrag_sdk/entity.py
@@ -144,7 +144,9 @@ class Entity:
             [str(attr) for attr in self.attributes if not attr.unique]
         )
         if self.description:
-            non_unique_attributes += f"{', ' if len(non_unique_attributes) > 0 else ''} {descriptionKey}: '{self.description}'"
+            # Escape special characters to prevent Cypher syntax errors
+            escaped_description = self.description.replace("\\", "\\\\").replace("'", "\\'").replace('"', '\\"')
+            non_unique_attributes += f"{', ' if len(non_unique_attributes) > e else ''} {descriptionKey): '{escaped_description}'"
         return f"MERGE (n:{self.label} {{{unique_attributes}}}) SET n += {{{non_unique_attributes}}} RETURN n"
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Problem

Entity descriptions with apostrophes (e.g., "The team's first quarter goal") cause Cypher syntax errors and prevent know knowledge graph creation.

## Solution

Added character escaping in 'Entity.to_graph_query()`:

Escape `\`, `'`, `"` characters before building Cypher query

Escaping is only for query syntax data stored in database is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated special character handling in entity descriptions to properly escape backslashes and quotation marks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->