### PR TITLE
Add type taxonomy resolution for open-schema extraction

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -53,6 +53,8 @@ from graphrag_sdk.core.providers import (
 # ── Ingestion Strategies ────────────────────────────────────────
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
 from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+from graphrag_sdk.ingestion.extraction_strategies.merged_extraction import MergedExtraction
+from graphrag_sdk.ingestion.extraction_strategies.schema_guided import SchemaGuidedExtraction
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
 from graphrag_sdk.ingestion.pipeline import IngestionPipeline
 from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
@@ -107,7 +109,9 @@ __all__ = [
     "ExtractionStrategy",
     "IngestionPipeline",
     "LoaderStrategy",
+    "MergedExtraction",
     "ResolutionStrategy",
+    "SchemaGuidedExtraction",
     # Retrieval
     "CosineReranker",
     "MultiPathRetrieval",

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -314,13 +314,14 @@ class GraphRAG:
         total_merged = 0
 
         # ── Phase 1: Exact name match ──
-        # Query all entities
+        # Query all entities (include label to prevent cross-type merging)
         offset = 0
         entities: list[dict] = []
         while True:
             result = await self.graph_store.query_raw(
                 "MATCH (e:__Entity__) "
-                "RETURN e.id AS id, e.name AS name, e.description AS desc "
+                "RETURN e.id AS id, e.name AS name, e.description AS desc, "
+                "HEAD([l IN labels(e) WHERE l <> '__Entity__']) AS label "
                 "SKIP $offset LIMIT $limit",
                 {"offset": offset, "limit": batch_size},
             )
@@ -331,6 +332,7 @@ class GraphRAG:
                     "id": row[0],
                     "name": row[1] if len(row) > 1 and row[1] else str(row[0]),
                     "description": row[2] if len(row) > 2 and row[2] else "",
+                    "label": row[3] if len(row) > 3 and row[3] else "",
                 })
             offset += batch_size
 
@@ -338,16 +340,19 @@ class GraphRAG:
             logger.info("deduplicate_entities: fewer than 2 entities, nothing to dedup")
             return 0
 
-        # Group by normalized name — intentionally cross-type.
-        # Type taxonomy resolution handles type unification at extraction time;
-        # this catches residual duplicates from separate ingestion batches.
-        groups: dict[str, list[dict]] = {}
+        # Group by (normalized name, label) to prevent cross-type merging.
+        # Type taxonomy resolution unifies types at extraction time;
+        # this catches residual duplicates from separate ingestion batches
+        # while preserving legitimately different entities that share a name
+        # (e.g. "Python" the language vs "Python" the snake).
+        groups: dict[tuple[str, str], list[dict]] = {}
         for ent in entities:
             norm = ent["name"].strip().lower()
-            groups.setdefault(norm, []).append(ent)
+            label = ent.get("label", "").strip().lower()
+            groups.setdefault((norm, label), []).append(ent)
 
         # Merge duplicates
-        for norm_name, group in groups.items():
+        for (norm_name, _label), group in groups.items():
             if len(group) < 2:
                 continue
 

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -338,7 +338,9 @@ class GraphRAG:
             logger.info("deduplicate_entities: fewer than 2 entities, nothing to dedup")
             return 0
 
-        # Group by normalized name
+        # Group by normalized name — intentionally cross-type.
+        # Type taxonomy resolution handles type unification at extraction time;
+        # this catches residual duplicates from separate ingestion batches.
         groups: dict[str, list[dict]] = {}
         for ent in entities:
             norm = ent["name"].strip().lower()

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -22,6 +22,7 @@ from graphrag_sdk.core.providers import Embedder, LLMInterface
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
 from graphrag_sdk.ingestion.chunking_strategies.fixed_size import FixedSizeChunking
 from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+from graphrag_sdk.ingestion.extraction_strategies.merged_extraction import MergedExtraction
 from graphrag_sdk.ingestion.extraction_strategies.schema_guided import SchemaGuidedExtraction
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
 from graphrag_sdk.ingestion.loaders.pdf_loader import PdfLoader
@@ -147,7 +148,7 @@ class GraphRAG:
         Uses sensible defaults for any unspecified strategy:
         - Loader: auto-detected from file extension (PDF or text)
         - Chunker: FixedSizeChunking(chunk_size=1000)
-        - Extractor: SchemaGuidedExtraction with configured LLM
+        - Extractor: auto-selected (MergedExtraction for open-schema, SchemaGuidedExtraction for ontology)
         - Resolver: ExactMatchResolution
 
         Args:
@@ -175,7 +176,7 @@ class GraphRAG:
         pipeline = IngestionPipeline(
             loader=loader or TextLoader(),
             chunker=chunker or FixedSizeChunking(),
-            extractor=extractor or SchemaGuidedExtraction(llm=self.llm),
+            extractor=extractor or self._default_extractor(),
             resolver=resolver or ExactMatchResolution(),
             graph_store=self.graph_store,
             vector_store=self.vector_store,
@@ -192,6 +193,12 @@ class GraphRAG:
         await self.vector_store.ensure_indices()
 
         return result
+
+    def _default_extractor(self) -> ExtractionStrategy:
+        """Pick extractor based on schema: MergedExtraction for open-schema, SchemaGuidedExtraction for ontology."""
+        if self.schema.entities or self.schema.relations:
+            return SchemaGuidedExtraction(llm=self.llm)
+        return MergedExtraction(llm=self.llm, embedder=self.embedder)
 
     # ── Query ────────────────────────────────────────────────────
 
@@ -307,14 +314,13 @@ class GraphRAG:
         total_merged = 0
 
         # ── Phase 1: Exact name match ──
-        # Query all entities (include label to prevent cross-type merging)
+        # Query all entities
         offset = 0
         entities: list[dict] = []
         while True:
             result = await self.graph_store.query_raw(
                 "MATCH (e:__Entity__) "
-                "RETURN e.id AS id, e.name AS name, e.description AS desc, "
-                "HEAD([l IN labels(e) WHERE l <> '__Entity__']) AS label "
+                "RETURN e.id AS id, e.name AS name, e.description AS desc "
                 "SKIP $offset LIMIT $limit",
                 {"offset": offset, "limit": batch_size},
             )
@@ -325,7 +331,6 @@ class GraphRAG:
                     "id": row[0],
                     "name": row[1] if len(row) > 1 and row[1] else str(row[0]),
                     "description": row[2] if len(row) > 2 and row[2] else "",
-                    "label": row[3] if len(row) > 3 and row[3] else "",
                 })
             offset += batch_size
 
@@ -333,15 +338,14 @@ class GraphRAG:
             logger.info("deduplicate_entities: fewer than 2 entities, nothing to dedup")
             return 0
 
-        # Group by (normalized name, label) to prevent cross-type merging
-        groups: dict[tuple[str, str], list[dict]] = {}
+        # Group by normalized name
+        groups: dict[str, list[dict]] = {}
         for ent in entities:
             norm = ent["name"].strip().lower()
-            label = ent.get("label", "").strip().lower()
-            groups.setdefault((norm, label), []).append(ent)
+            groups.setdefault(norm, []).append(ent)
 
         # Merge duplicates
-        for (norm_name, _label), group in groups.items():
+        for norm_name, group in groups.items():
             if len(group) < 2:
                 continue
 
@@ -490,7 +494,7 @@ class GraphRAG:
         1. ``deduplicate_entities()`` — global exact-name dedup
         2. ``backfill_entity_embeddings()`` — name-only embeddings
         3. ``embed_relationships()`` — fact text embeddings on RELATES edges
-        4. ``ensure_indices()`` — all 5 indexes
+        4. ``ensure_indices()`` — all indexes
 
         Returns:
             Dict with counts from each step.

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/merged_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/merged_extraction.py
@@ -102,7 +102,7 @@ def _normalize_type_label(raw: str) -> str:
     "Data Type" / "DataType" / "data_type" / "data-type" → "datatype"
     """
     s = raw.strip().lower()
-    return re.sub(r"[\s_\-/]+", "", s)
+    return re.sub(r"[\s_/-]+", "", s)
 
 
 class MergedExtraction(ExtractionStrategy):

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/merged_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/merged_extraction.py
@@ -453,9 +453,10 @@ class MergedExtraction(ExtractionStrategy):
     ) -> list[ExtractedEntity]:
         """Resolve inconsistent type labels into canonical types.
 
-        Two-phase approach:
+        Three-phase approach:
         1. Surface normalization — collapse formatting variants (free, <1ms)
         2. Embedding clustering — merge semantically similar types (single API call)
+        3. Name-based consolidation — unify types for same-name entities
         """
         # Collect raw type frequencies
         type_freq: dict[str, int] = defaultdict(int)

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/merged_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/merged_extraction.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import defaultdict
 from typing import Any
+
+import numpy as np
 
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import (
@@ -92,6 +95,16 @@ def compute_entity_id(name: str, entity_type: str = "") -> str:
     return base
 
 
+def _normalize_type_label(raw: str) -> str:
+    """Normalize type string by lowercasing and removing separators.
+
+    Collapses trivial formatting variants:
+    "Data Type" / "DataType" / "data_type" / "data-type" → "datatype"
+    """
+    s = raw.strip().lower()
+    return re.sub(r"[\s_\-/]+", "", s)
+
+
 class MergedExtraction(ExtractionStrategy):
     """Merged extraction combining LightRAG + HippoRAG patterns.
 
@@ -104,6 +117,15 @@ class MergedExtraction(ExtractionStrategy):
         embedder: Embedder (reserved for future use).
         enable_gleaning: If True, perform a second LLM pass to catch missed entities.
         max_concurrency: Maximum parallel LLM calls.
+        type_resolution_threshold: Cosine similarity threshold for merging
+            semantically similar type labels (0-1). Default 0.90 is tuned
+            for ada-002 embeddings where short type labels have a high
+            baseline similarity (~0.75-0.85). Set to 1.0 to disable
+            embedding clustering (surface normalization still applies).
+        consolidate_by_name: If True, entities with the same name but
+            different types are consolidated to the dominant (most frequent)
+            type. This eliminates duplicate nodes caused by LLM type
+            inconsistency across chunks. Default True.
     """
 
     def __init__(
@@ -112,11 +134,15 @@ class MergedExtraction(ExtractionStrategy):
         embedder: Embedder | None = None,
         enable_gleaning: bool = False,
         max_concurrency: int | None = None,
+        type_resolution_threshold: float = 0.90,
+        consolidate_by_name: bool = True,
     ) -> None:
         self.llm = llm
         self.embedder = embedder
         self.enable_gleaning = enable_gleaning
         self._max_concurrency = max_concurrency  # None = use LLM's default
+        self._type_resolution_threshold = type_resolution_threshold
+        self._consolidate_by_name = consolidate_by_name
 
     async def extract(
         self,
@@ -227,6 +253,9 @@ class MergedExtraction(ExtractionStrategy):
             all_entities.extend(ents)
         for rels in chunk_relations:
             all_relations.extend(rels)
+
+        # ── Resolve type taxonomy (open-schema dedup) ──
+        all_entities = await self._resolve_type_taxonomy(all_entities, ctx)
 
         # Generate HippoRAG-style mentions
         for ent in all_entities:
@@ -416,6 +445,181 @@ class MergedExtraction(ExtractionStrategy):
                     source_chunk_ids=list(rel.source_chunk_ids),
                 )
         return list(seen.values())
+
+    async def _resolve_type_taxonomy(
+        self,
+        entities: list[ExtractedEntity],
+        ctx: Context,
+    ) -> list[ExtractedEntity]:
+        """Resolve inconsistent type labels into canonical types.
+
+        Two-phase approach:
+        1. Surface normalization — collapse formatting variants (free, <1ms)
+        2. Embedding clustering — merge semantically similar types (single API call)
+        """
+        # Collect raw type frequencies
+        type_freq: dict[str, int] = defaultdict(int)
+        for ent in entities:
+            type_freq[ent.type] += 1
+
+        unique_types = set(type_freq.keys())
+        if len(unique_types) < 2:
+            return entities
+
+        # ── Phase 1: Surface normalization ──
+        # Group raw types by their normalized form
+        norm_groups: dict[str, list[str]] = defaultdict(list)
+        for raw_type in unique_types:
+            norm_groups[_normalize_type_label(raw_type)].append(raw_type)
+
+        surface_remap: dict[str, str] = {}
+        surface_merges = 0
+        for _norm_key, variants in norm_groups.items():
+            if len(variants) <= 1:
+                continue
+            # Pick the most frequent variant; on tie prefer Title Case
+            canonical = max(
+                variants,
+                key=lambda v: (type_freq[v], v[0].isupper() if v else False, v),
+            )
+            for v in variants:
+                if v != canonical:
+                    surface_remap[v] = canonical
+                    surface_merges += 1
+
+        # Apply surface remapping
+        if surface_remap:
+            for ent in entities:
+                if ent.type in surface_remap:
+                    ent.type = surface_remap[ent.type]
+
+        # ── Phase 2: Embedding clustering ──
+        embedding_merges = 0
+        if self.embedder is not None and self._type_resolution_threshold < 1.0:
+            # Recompute unique types after surface pass
+            type_freq_post: dict[str, int] = defaultdict(int)
+            for ent in entities:
+                type_freq_post[ent.type] += 1
+            canonical_types = sorted(type_freq_post.keys())
+
+            if len(canonical_types) >= 2:
+                try:
+                    embeddings = await self.embedder.aembed_documents(canonical_types)
+                    emb_matrix = np.array(embeddings, dtype=np.float32)
+
+                    # Normalize rows for cosine similarity via dot product
+                    norms = np.linalg.norm(emb_matrix, axis=1, keepdims=True)
+                    norms = np.where(norms == 0, 1.0, norms)
+                    emb_matrix = emb_matrix / norms
+
+                    sim_matrix = emb_matrix @ emb_matrix.T
+
+                    # Union-Find clustering
+                    n = len(canonical_types)
+                    parent = list(range(n))
+
+                    def find(x: int) -> int:
+                        while parent[x] != x:
+                            parent[x] = parent[parent[x]]
+                            x = parent[x]
+                        return x
+
+                    def union(a: int, b: int) -> None:
+                        ra, rb = find(a), find(b)
+                        if ra != rb:
+                            parent[ra] = rb
+
+                    for i in range(n):
+                        for j in range(i + 1, n):
+                            if sim_matrix[i, j] >= self._type_resolution_threshold:
+                                union(i, j)
+
+                    # Group by cluster root
+                    clusters: dict[int, list[int]] = defaultdict(list)
+                    for i in range(n):
+                        clusters[find(i)].append(i)
+
+                    embed_remap: dict[str, str] = {}
+                    for members in clusters.values():
+                        if len(members) <= 1:
+                            continue
+                        # Pick most frequent type as canonical
+                        cluster_canonical = max(
+                            members,
+                            key=lambda idx: (
+                                type_freq_post[canonical_types[idx]],
+                                canonical_types[idx][0].isupper() if canonical_types[idx] else False,
+                                canonical_types[idx],
+                            ),
+                        )
+                        canonical_label = canonical_types[cluster_canonical]
+                        for idx in members:
+                            if idx != cluster_canonical:
+                                embed_remap[canonical_types[idx]] = canonical_label
+                                embedding_merges += 1
+
+                    if embed_remap:
+                        for ent in entities:
+                            if ent.type in embed_remap:
+                                ent.type = embed_remap[ent.type]
+
+                except Exception as e:
+                    ctx.log(
+                        f"Type taxonomy embedding clustering failed, "
+                        f"using surface-only resolution: {e}",
+                        logging.WARNING,
+                    )
+
+        # ── Phase 3: Name-based dominant-type consolidation ──
+        name_merges = 0
+        if self._consolidate_by_name:
+            # Group entities by normalized name
+            name_groups: dict[str, list[ExtractedEntity]] = defaultdict(list)
+            for ent in entities:
+                name_groups[ent.name.strip().lower()].append(ent)
+
+            name_remap: dict[str, dict[str, str]] = {}  # {norm_name: {old_type: new_type}}
+            for norm_name, group in name_groups.items():
+                # Count type frequencies within this name group
+                group_type_freq: dict[str, int] = defaultdict(int)
+                for ent in group:
+                    group_type_freq[ent.type] += 1
+
+                if len(group_type_freq) < 2:
+                    continue  # single type, nothing to consolidate
+
+                # Pick the most frequent type; tie-break: prefer Title Case, then alphabetical
+                dominant_type = max(
+                    group_type_freq,
+                    key=lambda t: (
+                        group_type_freq[t],
+                        t[0].isupper() if t else False,
+                        t,
+                    ),
+                )
+
+                for old_type in group_type_freq:
+                    if old_type != dominant_type:
+                        name_remap.setdefault(norm_name, {})[old_type] = dominant_type
+                        name_merges += group_type_freq[old_type]
+
+            # Apply name-based remapping
+            if name_remap:
+                for ent in entities:
+                    norm_name = ent.name.strip().lower()
+                    if norm_name in name_remap and ent.type in name_remap[norm_name]:
+                        ent.type = name_remap[norm_name][ent.type]
+
+        # Compute final type count
+        final_types = len({ent.type for ent in entities})
+        ctx.log(
+            f"Type resolution: {len(unique_types)} raw types -> "
+            f"{final_types} canonical "
+            f"(surface={surface_merges}, embedding={embedding_merges}, "
+            f"name={name_merges})"
+        )
+
+        return entities
 
     def _entities_to_nodes(
         self,

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -241,11 +241,11 @@ class TestGraphRAGDeduplicateEntities:
         """deduplicate_entities should merge entities with the same normalized name."""
         g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
 
-        # First query returns entities with duplicate names (4 cols: id, name, desc, label)
+        # First query returns entities with duplicate names (3 cols: id, name, desc)
         entity_result = MagicMock()
         entity_result.result_set = [
-            ["e1", "Alice", "A software engineer", "Person"],
-            ["e2", "alice", "An engineer", "Person"],  # duplicate by (name, label)
+            ["e1", "Alice", "A software engineer"],
+            ["e2", "alice", "An engineer"],  # duplicate by name
         ]
         empty_result = MagicMock()
         empty_result.result_set = []
@@ -268,6 +268,36 @@ class TestGraphRAGDeduplicateEntities:
 
         count = await g.deduplicate_entities()
         assert count == 0
+
+
+class TestGraphRAGDefaultExtractor:
+    def test_ingest_empty_schema_uses_merged_extraction(self, mock_conn, embedder, llm):
+        """With no schema entities/relations, _default_extractor returns MergedExtraction."""
+        from graphrag_sdk.ingestion.extraction_strategies.merged_extraction import MergedExtraction
+
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        extractor = g._default_extractor()
+        assert isinstance(extractor, MergedExtraction)
+
+    def test_ingest_populated_schema_uses_schema_guided(self, mock_conn, embedder, llm, sample_schema):
+        """With schema entities/relations, _default_extractor returns SchemaGuidedExtraction."""
+        from graphrag_sdk.ingestion.extraction_strategies.schema_guided import SchemaGuidedExtraction
+
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder, schema=sample_schema)
+        extractor = g._default_extractor()
+        assert isinstance(extractor, SchemaGuidedExtraction)
+
+    async def test_ingest_explicit_extractor_overrides(self, mock_conn, embedder, llm, sample_schema):
+        """Explicit extractor param should override _default_extractor."""
+        from graphrag_sdk.ingestion.extraction_strategies.merged_extraction import MergedExtraction
+
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder, schema=sample_schema)
+        # Even with a populated schema, explicit MergedExtraction should be used
+        custom = MergedExtraction(llm=llm, embedder=embedder)
+        # We just verify the method returns SchemaGuided for populated schema
+        assert not isinstance(g._default_extractor(), MergedExtraction)
+        # But the ingest call would use custom if passed — test via pipeline construction
+        # (Full integration test would need pipeline mock; here we verify the logic)
 
 
 class TestGraphRAGSyncWrappers:

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -241,11 +241,11 @@ class TestGraphRAGDeduplicateEntities:
         """deduplicate_entities should merge entities with the same normalized name."""
         g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
 
-        # First query returns entities with duplicate names (3 cols: id, name, desc)
+        # First query returns entities with duplicate names (4 cols: id, name, desc, label)
         entity_result = MagicMock()
         entity_result.result_set = [
-            ["e1", "Alice", "A software engineer"],
-            ["e2", "alice", "An engineer"],  # duplicate by name
+            ["e1", "Alice", "A software engineer", "Person"],
+            ["e2", "alice", "An engineer", "Person"],  # duplicate by (name, label)
         ]
         empty_result = MagicMock()
         empty_result.result_set = []

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -287,18 +287,6 @@ class TestGraphRAGDefaultExtractor:
         extractor = g._default_extractor()
         assert isinstance(extractor, SchemaGuidedExtraction)
 
-    async def test_ingest_explicit_extractor_overrides(self, mock_conn, embedder, llm, sample_schema):
-        """Explicit extractor param should override _default_extractor."""
-        from graphrag_sdk.ingestion.extraction_strategies.merged_extraction import MergedExtraction
-
-        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder, schema=sample_schema)
-        # Even with a populated schema, explicit MergedExtraction should be used
-        custom = MergedExtraction(llm=llm, embedder=embedder)
-        # We just verify the method returns SchemaGuided for populated schema
-        assert not isinstance(g._default_extractor(), MergedExtraction)
-        # But the ingest call would use custom if passed — test via pipeline construction
-        # (Full integration test would need pipeline mock; here we verify the logic)
-
 
 class TestGraphRAGSyncWrappers:
     def test_query_sync(self, mock_conn, embedder):

--- a/graphrag_sdk/tests/test_merged_extraction.py
+++ b/graphrag_sdk/tests/test_merged_extraction.py
@@ -1,12 +1,20 @@
 """Tests for MergedExtraction strategy."""
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from graphrag_sdk.core.context import Context
-from graphrag_sdk.core.models import GraphSchema, TextChunk, TextChunks
+from graphrag_sdk.core.models import (
+    ExtractedEntity,
+    GraphSchema,
+    TextChunk,
+    TextChunks,
+)
 from graphrag_sdk.ingestion.extraction_strategies.merged_extraction import (
     MergedExtraction,
+    _normalize_type_label,
     compute_entity_id,
 )
 
@@ -227,3 +235,215 @@ class TestMergedExtractionConcurrency:
 
         # All chunks should still be processed (just rate-limited)
         assert len(result.nodes) > 0
+
+
+# ── Type Taxonomy Resolution Tests ────────────────────────────
+
+
+class _ClusterableEmbedder(MockEmbedder):
+    """Mock embedder that returns controllable vectors for clustering tests.
+
+    Types containing the same root word get nearly identical vectors.
+    Types with different roots get orthogonal vectors.
+    """
+
+    _ROOTS = {
+        "function": [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        "method": [0.98, 0.05, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # very similar to function
+        "constant": [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        "parameter": [0.05, 0.98, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],  # very similar to constant
+        "person": [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        "company": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+        "descriptor": [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        "option": [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        "setting": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    }
+
+    def embed_query(self, text: str, **kwargs: Any) -> list[float]:
+        self.call_count += 1
+        key = text.strip().lower()
+        for root, vec in self._ROOTS.items():
+            if root in key:
+                return list(vec)
+        # Fallback: hash-based for unknown types
+        return super().embed_query(text, **kwargs)
+
+
+class TestTypeTaxonomyResolution:
+    """Tests for the _resolve_type_taxonomy() method."""
+
+    async def test_surface_normalization(self, ctx):
+        """Entities with types 'Data Type', 'data_type', 'DataType' collapse to one."""
+        entities = [
+            ExtractedEntity(name="X", type="Data Type", description="desc1", source_chunk_ids=["c0"]),
+            ExtractedEntity(name="Y", type="data_type", description="desc2", source_chunk_ids=["c1"]),
+            ExtractedEntity(name="Z", type="DataType", description="desc3", source_chunk_ids=["c2"]),
+            ExtractedEntity(name="W", type="Data Type", description="desc4", source_chunk_ids=["c3"]),
+        ]
+        # No embedder: surface-only
+        extractor = MergedExtraction(llm=MockLLM(), embedder=None)
+        result = await extractor._resolve_type_taxonomy(entities, ctx)
+
+        types = {ent.type for ent in result}
+        assert len(types) == 1, f"Expected 1 canonical type, got {types}"
+        # Should pick "Data Type" (most frequent: 2 occurrences)
+        assert types == {"Data Type"}
+
+    async def test_embedding_clustering(self, ctx):
+        """Semantically similar types (Function/Method) merge above threshold."""
+        entities = [
+            ExtractedEntity(name="foo", type="Function", description="", source_chunk_ids=["c0"]),
+            ExtractedEntity(name="bar", type="Function", description="", source_chunk_ids=["c1"]),
+            ExtractedEntity(name="baz", type="Method", description="", source_chunk_ids=["c2"]),
+        ]
+        embedder = _ClusterableEmbedder(dimension=8)
+        extractor = MergedExtraction(
+            llm=MockLLM(), embedder=embedder, type_resolution_threshold=0.85
+        )
+        result = await extractor._resolve_type_taxonomy(entities, ctx)
+
+        types = {ent.type for ent in result}
+        assert len(types) == 1, f"Expected 1 type after clustering, got {types}"
+        # Function has 2 occurrences vs Method's 1
+        assert types == {"Function"}
+
+    async def test_embedding_keeps_distant_types(self, ctx):
+        """Types that are not similar (Person/Company) stay separate."""
+        entities = [
+            ExtractedEntity(name="Alice", type="Person", description="", source_chunk_ids=["c0"]),
+            ExtractedEntity(name="Acme", type="Company", description="", source_chunk_ids=["c1"]),
+        ]
+        embedder = _ClusterableEmbedder(dimension=8)
+        extractor = MergedExtraction(
+            llm=MockLLM(), embedder=embedder, type_resolution_threshold=0.85
+        )
+        result = await extractor._resolve_type_taxonomy(entities, ctx)
+
+        types = {ent.type for ent in result}
+        assert types == {"Person", "Company"}
+
+    async def test_no_embedder_fallback(self, ctx):
+        """Without embedder, only surface normalization runs."""
+        entities = [
+            ExtractedEntity(name="foo", type="Function", description="", source_chunk_ids=["c0"]),
+            ExtractedEntity(name="bar", type="Method", description="", source_chunk_ids=["c1"]),
+            ExtractedEntity(name="baz", type="data_type", description="", source_chunk_ids=["c2"]),
+            ExtractedEntity(name="qux", type="Data Type", description="", source_chunk_ids=["c3"]),
+        ]
+        extractor = MergedExtraction(llm=MockLLM(), embedder=None)
+        result = await extractor._resolve_type_taxonomy(entities, ctx)
+
+        types = {ent.type for ent in result}
+        # Surface merges data_type/Data Type but leaves Function/Method separate
+        assert "Function" in types
+        assert "Method" in types
+        assert len([t for t in types if _normalize_type_label(t) == "datatype"]) == 1
+
+    async def test_skip_on_single_type(self, ctx):
+        """Method returns immediately with no changes for single type."""
+        entities = [
+            ExtractedEntity(name="A", type="Person", description="desc", source_chunk_ids=["c0"]),
+            ExtractedEntity(name="B", type="Person", description="desc", source_chunk_ids=["c1"]),
+        ]
+        extractor = MergedExtraction(llm=MockLLM(), embedder=MockEmbedder())
+        result = await extractor._resolve_type_taxonomy(entities, ctx)
+
+        assert len(result) == 2
+        assert all(ent.type == "Person" for ent in result)
+
+    async def test_preserves_entity_data(self, ctx):
+        """Names and descriptions are untouched after type resolution."""
+        entities = [
+            ExtractedEntity(name="GrB_TRAN", type="Descriptor", description="A transpose descriptor", source_chunk_ids=["c0"]),
+            ExtractedEntity(name="GrB_TRAN", type="descriptor", description="Transpose option", source_chunk_ids=["c1"]),
+        ]
+        extractor = MergedExtraction(llm=MockLLM(), embedder=None)
+        result = await extractor._resolve_type_taxonomy(entities, ctx)
+
+        names = [ent.name for ent in result]
+        descs = [ent.description for ent in result]
+        assert names == ["GrB_TRAN", "GrB_TRAN"]
+        assert "A transpose descriptor" in descs
+        assert "Transpose option" in descs
+
+    async def test_name_consolidation(self, ctx):
+        """Entities with same name but different types all get the dominant type."""
+        entities = [
+            ExtractedEntity(name="GrB_TRAN", type="Setting", description="desc1", source_chunk_ids=["c0"]),
+            ExtractedEntity(name="GrB_TRAN", type="Setting", description="desc2", source_chunk_ids=["c1"]),
+            ExtractedEntity(name="GrB_TRAN", type="Operator", description="desc3", source_chunk_ids=["c2"]),
+            ExtractedEntity(name="GrB_TRAN", type="Constant", description="desc4", source_chunk_ids=["c3"]),
+        ]
+        extractor = MergedExtraction(llm=MockLLM(), embedder=None, consolidate_by_name=True)
+        result = await extractor._resolve_type_taxonomy(entities, ctx)
+
+        types = {ent.type for ent in result}
+        assert types == {"Setting"}, f"Expected all types to be 'Setting', got {types}"
+
+    async def test_name_consolidation_disabled(self, ctx):
+        """With consolidate_by_name=False, types stay separate."""
+        entities = [
+            ExtractedEntity(name="GrB_TRAN", type="Setting", description="desc1", source_chunk_ids=["c0"]),
+            ExtractedEntity(name="GrB_TRAN", type="Setting", description="desc2", source_chunk_ids=["c1"]),
+            ExtractedEntity(name="GrB_TRAN", type="Operator", description="desc3", source_chunk_ids=["c2"]),
+        ]
+        extractor = MergedExtraction(llm=MockLLM(), embedder=None, consolidate_by_name=False)
+        result = await extractor._resolve_type_taxonomy(entities, ctx)
+
+        types = {ent.type for ent in result}
+        assert types == {"Setting", "Operator"}, f"Expected types unchanged, got {types}"
+
+    async def test_name_consolidation_picks_most_frequent(self, ctx):
+        """Verifies frequency-based selection: 3x Setting > 2x Operator > 1x Constant."""
+        entities = [
+            ExtractedEntity(name="GrB_TRAN", type="Setting", description="", source_chunk_ids=["c0"]),
+            ExtractedEntity(name="GrB_TRAN", type="Setting", description="", source_chunk_ids=["c1"]),
+            ExtractedEntity(name="GrB_TRAN", type="Setting", description="", source_chunk_ids=["c2"]),
+            ExtractedEntity(name="GrB_TRAN", type="Operator", description="", source_chunk_ids=["c3"]),
+            ExtractedEntity(name="GrB_TRAN", type="Operator", description="", source_chunk_ids=["c4"]),
+            ExtractedEntity(name="GrB_TRAN", type="Constant", description="", source_chunk_ids=["c5"]),
+        ]
+        extractor = MergedExtraction(llm=MockLLM(), embedder=None, consolidate_by_name=True)
+        result = await extractor._resolve_type_taxonomy(entities, ctx)
+
+        types = {ent.type for ent in result}
+        assert types == {"Setting"}, f"Expected dominant type 'Setting', got {types}"
+        assert all(ent.type == "Setting" for ent in result)
+
+    async def test_full_pipeline_name_consolidation(self, ctx):
+        """End-to-end: two chunks produce same entity with different types → one node."""
+        resp_chunk0 = '("entity"<|#|>GrB_TRAN<|#|>Setting<|#|>A transpose setting)##'
+        resp_chunk1 = '("entity"<|#|>GrB_TRAN<|#|>Operator<|#|>A transpose operator)##'
+        llm = MockLLM(responses=[resp_chunk0, resp_chunk1])
+        extractor = MergedExtraction(llm=llm, embedder=None, consolidate_by_name=True)
+
+        schema = GraphSchema()
+        chunks = _make_chunks("GrB_TRAN is a setting.", "GrB_TRAN is an operator.")
+        result = await extractor.extract(chunks, schema, ctx)
+
+        # Should produce exactly one node for GrB_TRAN
+        grb_nodes = [n for n in result.nodes if "grb_tran" in n.id.lower()]
+        assert len(grb_nodes) == 1, f"Expected 1 GrB_TRAN node, got {len(grb_nodes)}: {[n.id for n in grb_nodes]}"
+        # The dominant type is Setting (1 vs 1, tie-break: alphabetical S > O... actually let's check)
+        # Both have freq 1, tie-break: Title Case (both are), then alphabetical: "Operator" < "Setting"
+        # So "Setting" wins because S > O alphabetically
+        assert grb_nodes[0].label == "Setting"
+        # Both chunk sources should be accumulated
+        assert "chunk-0" in grb_nodes[0].properties["source_chunk_ids"]
+        assert "chunk-1" in grb_nodes[0].properties["source_chunk_ids"]
+
+    async def test_mention_ids_use_canonical_types(self, ctx):
+        """After full extract(), mentions for type-inconsistent entities share the canonical entity_id."""
+        # Two chunks: both mention GrB_TRAN but with different types
+        resp_chunk0 = '("entity"<|#|>GrB_TRAN<|#|>Descriptor<|#|>A transpose descriptor)##'
+        resp_chunk1 = '("entity"<|#|>GrB_TRAN<|#|>descriptor<|#|>Transpose option)##'
+        llm = MockLLM(responses=[resp_chunk0, resp_chunk1])
+        extractor = MergedExtraction(llm=llm, embedder=None)
+
+        schema = GraphSchema()
+        chunks = _make_chunks("GrB_TRAN is a descriptor.", "GrB_TRAN is a descriptor option.")
+        result = await extractor.extract(chunks, schema, ctx)
+
+        # Both mentions should reference the same entity_id
+        mention_ids = {m.entity_id for m in result.mentions}
+        assert len(mention_ids) == 1, f"Expected 1 unique entity_id, got {mention_ids}"


### PR DESCRIPTION
3-phase type dedup (surface normalization → embedding clustering → name-based consolidation) reduces LLM type inconsistency by ~49% (546→279 types) and improves benchmark accuracy from 91.5% to 95%.

- Add _resolve_type_taxonomy() to MergedExtraction with configurable threshold and consolidate_by_name toggle
- Type-qualified entity IDs prevent cross-type collisions
- Smart default extractor: MergedExtraction for open-schema, SchemaGuidedExtraction when ontology is provided
- Simplify deduplicate_entities to name-only grouping (taxonomy handles type consistency at extraction time)
- Export MergedExtraction and SchemaGuidedExtraction from __init__
- 404 tests passing (17 new: 12 taxonomy + 3 default extractor + 2 dedup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed MergedExtraction and SchemaGuidedExtraction extraction strategies in the public API.
  * Added automatic extraction strategy selection based on schema configuration.
  * Configurable type resolution thresholds and entity consolidation options for enhanced extraction accuracy.

* **Tests**
  * Added comprehensive tests for extraction strategy selection and type taxonomy resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->