### PR TITLE
Strip parentheses/brackets from extracted keywords to fix entity disc…

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
@@ -313,7 +313,7 @@ class MultiPathRetrieval(RetrievalStrategy):
 
     async def _extract_keywords(self, query: str) -> tuple[list[str], list[str]]:
         """Extract simple + LLM-based keywords from the query."""
-        words = re.sub(r"[?.!,;:'\"-]", " ", query.lower()).split()
+        words = re.sub(r"[?.!,;:'\"\-()\[\]]", " ", query.lower()).split()
         simple = [w for w in words if w not in self._STOP_WORDS and len(w) > 2][:12]
 
         llm_kw: list[str] = []
@@ -325,7 +325,7 @@ class MultiPathRetrieval(RetrievalStrategy):
                 f"Question: {query}\n\nNames: "
             )
             llm_kw = [
-                k.strip().strip("'\"")
+                k.strip().strip("'\"").rstrip("()").strip()
                 for k in response.content.split(",")
                 if k.strip() and len(k.strip()) > 1
             ]


### PR DESCRIPTION
This pull request makes improvements to the keyword extraction logic in the `multi_path.py` retrieval strategy. The changes enhance how keywords are parsed from user queries and LLM responses, leading to more accurate and cleaner keyword lists for downstream retrieval.

**Keyword extraction improvements:**

* The regular expression for splitting queries into words now removes parentheses and square brackets in addition to previous punctuation, resulting in better tokenization of queries.
* When extracting LLM-based keywords, each keyword is now further cleaned by stripping trailing parentheses (in addition to quotes), reducing noise in the extracted keyword list.