### PR TITLE
Add sibling entity expansion for enumeration queries

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
@@ -11,8 +11,8 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _ENUMERATION_RE = re.compile(
-    r"\b(all|every|each|complete list|full list|list all|list of all"
-    r"|enumerate|name all|name every)\b",
+    r"\b(every|each|complete list|full list|list all|list of all"
+    r"|enumerate|name all|name every|all the|all of the)\b",
     re.IGNORECASE,
 )
 
@@ -150,11 +150,11 @@ async def expand_sibling_entities(
 ) -> int:
     """Expand discovered entities by finding graph siblings.
 
-    A sibling is an entity that shares both a non-__Entity__ label AND a
-    1-hop graph neighbor with at least 2 already-discovered entities.
-    This catches structurally related entities (e.g. ``list.remove`` when
-    ``list.dedup``, ``list.insert``, ``list.sort`` are already found)
-    that may have been missed by vector similarity.
+    Finds hub entities (``__Entity__`` nodes connected to 2+ already-
+    discovered entities), then returns their other ``__Entity__``
+    neighbours.  This catches structurally related entities (e.g.
+    ``list.remove`` when ``list.dedup``, ``list.insert``, ``list.sort``
+    are already found) that may have been missed by vector similarity.
 
     Mutates *found_entities* and *found_sources* in place.
     Returns the number of new entities added.
@@ -168,12 +168,14 @@ async def expand_sibling_entities(
     try:
         result = await graph_store.query_raw(
             "MATCH (e:__Entity__) WHERE e.id IN $found_ids "
-            "MATCH (e)-[]-(hub)-[]-(sibling:__Entity__) "
-            "WHERE NOT sibling.id IN $found_ids "
-            "WITH sibling, collect(DISTINCT e.id) AS via "
+            "MATCH (e)-[]-(hub:__Entity__) "
+            "WITH hub, collect(DISTINCT e.id) AS via "
             "WHERE size(via) >= 2 "
+            "MATCH (hub)-[]-(sibling:__Entity__) "
+            "WHERE NOT sibling.id IN $found_ids "
             "RETURN DISTINCT sibling.id AS id, sibling.name AS name, "
             "sibling.description AS desc "
+            "ORDER BY sibling.name "
             "LIMIT $limit",
             {"found_ids": found_ids, "limit": max_siblings},
         )

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
@@ -1,12 +1,25 @@
 # GraphRAG SDK 2.0 — Retrieval: Entity Discovery
-# 2-path entity discovery: Cypher CONTAINS + fulltext search.
+# 2-path entity discovery: Cypher CONTAINS + fulltext search,
+# with optional sibling expansion for enumeration queries.
 
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+_ENUMERATION_RE = re.compile(
+    r"\b(all|every|each|complete list|full list|list all|list of all"
+    r"|enumerate|name all|name every)\b",
+    re.IGNORECASE,
+)
+
+
+def is_enumeration_query(query: str) -> bool:
+    """Return True if the query asks to list/enumerate all items."""
+    return bool(_ENUMERATION_RE.search(query))
 
 
 async def search_relates_edges(
@@ -127,3 +140,53 @@ async def discover_entities(
             logger.debug("Entity fulltext search failed for '%s': %s", kw, exc)
 
     return found, sources
+
+
+async def expand_sibling_entities(
+    graph_store: Any,
+    found_entities: dict[str, dict],
+    found_sources: dict[str, str],
+    max_siblings: int = 20,
+) -> int:
+    """Expand discovered entities by finding graph siblings.
+
+    A sibling is an entity that shares both a non-__Entity__ label AND a
+    1-hop graph neighbor with at least 2 already-discovered entities.
+    This catches structurally related entities (e.g. ``list.remove`` when
+    ``list.dedup``, ``list.insert``, ``list.sort`` are already found)
+    that may have been missed by vector similarity.
+
+    Mutates *found_entities* and *found_sources* in place.
+    Returns the number of new entities added.
+    """
+    if len(found_entities) < 2:
+        return 0
+
+    found_ids = list(found_entities.keys())
+    added = 0
+
+    try:
+        result = await graph_store.query_raw(
+            "MATCH (e:__Entity__) WHERE e.id IN $found_ids "
+            "MATCH (e)-[]-(hub)-[]-(sibling:__Entity__) "
+            "WHERE NOT sibling.id IN $found_ids "
+            "WITH sibling, collect(DISTINCT e.id) AS via "
+            "WHERE size(via) >= 2 "
+            "RETURN DISTINCT sibling.id AS id, sibling.name AS name, "
+            "sibling.description AS desc "
+            "LIMIT $limit",
+            {"found_ids": found_ids, "limit": max_siblings},
+        )
+        for row in result.result_set:
+            eid = row[0]
+            if eid and eid not in found_entities:
+                found_entities[eid] = {
+                    "name": row[1] if len(row) > 1 else "",
+                    "description": row[2] if len(row) > 2 else "",
+                }
+                found_sources[eid] = "sibling_expansion"
+                added += 1
+    except Exception as exc:
+        logger.debug("Sibling entity expansion failed: %s", exc)
+
+    return added

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
@@ -242,9 +242,7 @@ class MultiPathRetrieval(RetrievalStrategy):
 
         # 4b. Sibling expansion for enumeration queries
         if is_enumeration_query(query):
-            n_siblings = await expand_sibling_entities(
-                self._graph, found_entities, entity_sources
-            )
+            n_siblings = await expand_sibling_entities(self._graph, found_entities, entity_sources)
             if n_siblings:
                 ctx.log(
                     f"MultiPath [4b/9]: +{n_siblings} sibling entities "

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
@@ -24,6 +24,8 @@ from graphrag_sdk.retrieval.strategies.chunk_retrieval import (
 )
 from graphrag_sdk.retrieval.strategies.entity_discovery import (
     discover_entities,
+    expand_sibling_entities,
+    is_enumeration_query,
     search_relates_edges,
 )
 from graphrag_sdk.retrieval.strategies.relationship_expansion import (
@@ -237,6 +239,17 @@ class MultiPathRetrieval(RetrievalStrategy):
                 found_entities[eid] = einfo
                 entity_sources[eid] = "cypher"
         ctx.log(f"MultiPath [4/9]: {len(found_entities)} entities discovered")
+
+        # 4b. Sibling expansion for enumeration queries
+        if is_enumeration_query(query):
+            n_siblings = await expand_sibling_entities(
+                self._graph, found_entities, entity_sources
+            )
+            if n_siblings:
+                ctx.log(
+                    f"MultiPath [4b/9]: +{n_siblings} sibling entities "
+                    f"({len(found_entities)} total)"
+                )
 
         # 5. Relationship expansion
         entity_list = list(found_entities.items())[: self._max_entities]

--- a/graphrag_sdk/tests/test_multi_path_retrieval.py
+++ b/graphrag_sdk/tests/test_multi_path_retrieval.py
@@ -11,6 +11,10 @@ from graphrag_sdk.core.models import (
     RawSearchResult,
     RetrieverResult,
 )
+from graphrag_sdk.retrieval.strategies.entity_discovery import (
+    expand_sibling_entities,
+    is_enumeration_query,
+)
 from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval
 
 from .conftest import MockEmbedder, MockLLM
@@ -527,3 +531,173 @@ class TestSearchRelatesEdges:
         # "alice" should appear only once in entities
         alice_count = sum(1 for eid in entities if eid == "alice")
         assert alice_count == 1
+
+
+class TestIsEnumerationQuery:
+    """Tests for is_enumeration_query heuristic."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "What are ALL the FalkorDB-specific list functions?",
+            "List every function in the API",
+            "Name all the sorting algorithms",
+            "Give me the complete list of endpoints",
+            "Enumerate each parameter",
+            "What are all the methods?",
+            "Show me all of the supported types",
+        ],
+    )
+    def test_positive(self, query):
+        assert is_enumeration_query(query)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "What is the default parameter for list.remove?",
+            "How does FalkorDB handle indexing?",
+            "Tell me all about Alice",
+            "Who is Alice?",
+            "Where is Acme located?",
+        ],
+    )
+    def test_negative(self, query):
+        assert not is_enumeration_query(query)
+
+
+class TestExpandSiblingEntities:
+    """Tests for expand_sibling_entities."""
+
+    async def test_expands_siblings_via_shared_hub(self):
+        """Should find sibling entities through a shared hub entity."""
+        graph_store = MagicMock()
+        graph_store.query_raw = AsyncMock(
+            return_value=MagicMock(
+                result_set=[
+                    ["id_remove", "list.remove", "Removes elements from a list"],
+                ]
+            )
+        )
+
+        found = {
+            "id_dedup": {"name": "list.dedup", "description": ""},
+            "id_insert": {"name": "list.insert", "description": ""},
+            "id_sort": {"name": "list.sort", "description": ""},
+        }
+        sources: dict[str, str] = {}
+
+        added = await expand_sibling_entities(graph_store, found, sources)
+
+        assert added == 1
+        assert "id_remove" in found
+        assert found["id_remove"]["name"] == "list.remove"
+        assert sources["id_remove"] == "sibling_expansion"
+
+    async def test_skips_when_fewer_than_2_entities(self):
+        """Should not query the graph when fewer than 2 entities are found."""
+        graph_store = MagicMock()
+        graph_store.query_raw = AsyncMock()
+
+        found = {"id_only": {"name": "only_entity", "description": ""}}
+        sources: dict[str, str] = {}
+
+        added = await expand_sibling_entities(graph_store, found, sources)
+
+        assert added == 0
+        graph_store.query_raw.assert_not_called()
+
+    async def test_handles_query_failure(self):
+        """Should return 0 and not raise on graph query failure."""
+        graph_store = MagicMock()
+        graph_store.query_raw = AsyncMock(side_effect=Exception("connection error"))
+
+        found = {
+            "id_a": {"name": "A", "description": ""},
+            "id_b": {"name": "B", "description": ""},
+        }
+        sources: dict[str, str] = {}
+
+        added = await expand_sibling_entities(graph_store, found, sources)
+        assert added == 0
+
+    async def test_does_not_duplicate_found_entities(self):
+        """Should not re-add entities already in the found set."""
+        graph_store = MagicMock()
+        graph_store.query_raw = AsyncMock(
+            return_value=MagicMock(
+                result_set=[
+                    ["id_dedup", "list.dedup", "Already found"],
+                    ["id_new", "list.new", "New entity"],
+                ]
+            )
+        )
+
+        found = {
+            "id_dedup": {"name": "list.dedup", "description": ""},
+            "id_insert": {"name": "list.insert", "description": ""},
+        }
+        sources: dict[str, str] = {}
+
+        added = await expand_sibling_entities(graph_store, found, sources)
+        assert added == 1
+        assert "id_new" in found
+
+
+class TestSiblingExpansionIntegration:
+    """Integration: sibling expansion triggers only for enumeration queries."""
+
+    async def test_enumeration_query_triggers_expansion(
+        self, mp_graph_store, mp_vector_store, mp_embedder, mp_llm
+    ):
+        """An enumeration query should issue a sibling-expansion Cypher query."""
+        queries_seen = []
+
+        async def capture_query(cypher, params=None):
+            queries_seen.append(cypher)
+            result = MagicMock()
+            result.result_set = []
+            return result
+
+        mp_graph_store.query_raw = AsyncMock(side_effect=capture_query)
+        mp_vector_store.search_relationships = AsyncMock(
+            return_value=[
+                {"src_name": "list.dedup", "type": "BELONGS_TO", "tgt_name": "FalkorDB", "fact": "", "score": 0.9},
+                {"src_name": "list.insert", "type": "BELONGS_TO", "tgt_name": "FalkorDB", "fact": "", "score": 0.85},
+            ]
+        )
+
+        s = MultiPathRetrieval(
+            graph_store=mp_graph_store,
+            vector_store=mp_vector_store,
+            embedder=mp_embedder,
+            llm=mp_llm,
+        )
+        await s.search("What are all the FalkorDB list functions?")
+
+        sibling_queries = [q for q in queries_seen if "hub" in q.lower() and "sibling" in q.lower()]
+        assert len(sibling_queries) >= 1
+
+    async def test_non_enumeration_query_skips_expansion(
+        self, mp_graph_store, mp_vector_store, mp_embedder, mp_llm
+    ):
+        """A non-enumeration query should NOT issue a sibling-expansion query."""
+        queries_seen = []
+
+        async def capture_query(cypher, params=None):
+            queries_seen.append(cypher)
+            result = MagicMock()
+            result.result_set = []
+            return result
+
+        mp_graph_store.query_raw = AsyncMock(side_effect=capture_query)
+
+        s = MultiPathRetrieval(
+            graph_store=mp_graph_store,
+            vector_store=mp_vector_store,
+            embedder=mp_embedder,
+            llm=mp_llm,
+        )
+        await s.search("What is the default parameter for list.remove?")
+
+        sibling_queries = [q for q in queries_seen if "hub" in q.lower() and "sibling" in q.lower()]
+        assert len(sibling_queries) == 0


### PR DESCRIPTION
When a "list all" question is detected, expand discovered entities by traversing the graph for siblings that share a hub neighbor with 2+ already-found entities. Fixes non-deterministic recall for entity families (e.g. list.remove missed when list.dedup/insert/sort found).