### PR TITLE
Slim extraction prompt: remove unused fields, tighten descriptions

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -273,8 +273,10 @@ class GraphExtraction(ExtractionStrategy):
                     # Carry over spans/confidence from step 1 entities
                     step1_ents = chunk_entities[chunk_idx]
                     self._merge_step1_metadata(
-                        verified_ents, step1_ents,
-                        chunk_texts[chunk_idx], chunk.uid,
+                        verified_ents,
+                        step1_ents,
+                        chunk_texts[chunk_idx],
+                        chunk.uid,
                     )
                     all_entities.extend(verified_ents)
                 else:
@@ -347,10 +349,12 @@ class GraphExtraction(ExtractionStrategy):
                 if s1_conf is not None:
                     ent.confidence = s1_conf  # type: ignore[attr-defined]
             else:
-                # Entity is new from step 2 — compute spans via text.find()
-                idx = chunk_text.find(ent.name)
+                # Entity is new from step 2 — compute spans via case-insensitive search
+                idx = chunk_text.lower().find(ent.name.lower())
                 if idx >= 0:
-                    ent.spans = {source_chunk_id: [{"start": idx, "end": idx + len(ent.name)}]}  # type: ignore[attr-defined]
+                    ent.spans = {  # type: ignore[attr-defined]
+                        source_chunk_id: [{"start": idx, "end": idx + len(ent.name)}]
+                    }
 
     # ── Step 2 Response Parsing ──────────────────────────────────
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -52,34 +52,24 @@ VERIFY_EXTRACT_RELS_PROMPT = (
     "{text}\n\n"
     "## Instructions\n\n"
     "### Entities\n"
-    "- For each verified entity provide a rich description that captures "
-    "key attributes, roles, and context from the text. This description is "
-    "used for search and retrieval — make it informative.\n"
-    "- span_start: the character offset in the text where the entity name "
-    "first appears.\n"
-    "- span_end: the character offset where the entity name ends.\n\n"
+    "- For each verified entity provide a concise 1-2 sentence description "
+    "capturing key attributes and roles from the text. This description is "
+    "embedded for semantic search.\n\n"
     "### Relationships\n"
     "- Extract ALL factual connections stated or implied in the text.\n"
     "- source and target must be entity names from the verified entity list.\n"
     "- type: a descriptive relationship label in UPPER_SNAKE_CASE "
     "(e.g. WORKS_AT, MARRIED_TO, LOCATED_IN, CREATED_BY, PART_OF).\n"
-    "- description: a concise sentence describing the relationship as a "
+    "- description: one sentence describing the relationship as a "
     "standalone fact. This is embedded for semantic search — it must be "
     "self-contained and understandable without the original text.\n"
-    "- keywords: comma-separated terms that characterize this relationship "
-    "(e.g. 'employment, career' or 'family, parentage'). Used for "
-    "fulltext search.\n"
-    "- weight: a float 0-1 indicating confidence (1.0 = explicitly stated, "
-    "0.5 = implied, 0.2 = weak inference).\n"
     "- span_start: the character offset in the text where the evidence "
     "sentence for this relationship starts.\n"
     "- span_end: the character offset where the evidence sentence ends.\n\n"
     "Return ONLY a JSON object with two arrays:\n"
-    '{{"entities": [{{"name": "...", "type": "...", "description": "...", '
-    '"span_start": 0, "span_end": 5}}], '
+    '{{"entities": [{{"name": "...", "type": "...", "description": "..."}}], '
     '"relationships": [{{"source": "...", "target": "...", "type": "...", '
-    '"description": "...", "keywords": "...", "weight": 0.9, '
-    '"span_start": 0, "span_end": 50}}]}}\n\n'
+    '"description": "...", "span_start": 0, "span_end": 50}}]}}\n\n'
     "Return ONLY valid JSON, nothing else."
 )
 
@@ -282,7 +272,10 @@ class GraphExtraction(ExtractionStrategy):
                 if verified_ents:
                     # Carry over spans/confidence from step 1 entities
                     step1_ents = chunk_entities[chunk_idx]
-                    self._merge_step1_metadata(verified_ents, step1_ents)
+                    self._merge_step1_metadata(
+                        verified_ents, step1_ents,
+                        chunk_texts[chunk_idx], chunk.uid,
+                    )
                     all_entities.extend(verified_ents)
                 else:
                     # LLM returned no entities — use step 1 entities
@@ -327,13 +320,14 @@ class GraphExtraction(ExtractionStrategy):
     def _merge_step1_metadata(
         verified: list[ExtractedEntity],
         step1: list[ExtractedEntity],
+        chunk_text: str,
+        source_chunk_id: str,
     ) -> None:
         """Carry over spans and confidence from step 1 entities into step 2 verified entities.
 
-        Matches by normalized name. Step 1 spans (from GLiNER2) take
-        priority over step 2 spans (from LLM) since GLiNER2 character
-        offsets are more precise. Step 2 spans are kept for entities
-        that GLiNER2 didn't find.
+        Matches by normalized name. Step 1 spans (from GLiNER2) are used
+        directly. For entities the LLM discovered (not in step 1), spans
+        are computed via ``str.find()`` on the chunk text.
         """
         # Build lookup: normalized name → step 1 entity
         s1_lookup: dict[str, ExtractedEntity] = {}
@@ -352,7 +346,11 @@ class GraphExtraction(ExtractionStrategy):
                 s1_conf = getattr(s1, "confidence", None)
                 if s1_conf is not None:
                     ent.confidence = s1_conf  # type: ignore[attr-defined]
-            # else: entity is new from step 2 — keep its own spans if present
+            else:
+                # Entity is new from step 2 — compute spans via text.find()
+                idx = chunk_text.find(ent.name)
+                if idx >= 0:
+                    ent.spans = {source_chunk_id: [{"start": idx, "end": idx + len(ent.name)}]}  # type: ignore[attr-defined]
 
     # ── Step 2 Response Parsing ──────────────────────────────────
 
@@ -388,18 +386,12 @@ class GraphExtraction(ExtractionStrategy):
             etype = label_for_type(raw_type, entity_types)
             description = str(item.get("description", "")).strip()
 
-            extra: dict[str, Any] = {}
-            spans = _build_spans(item, source_chunk_id, "span_start", "span_end")
-            if spans:
-                extra["spans"] = spans
-
             entities.append(
                 ExtractedEntity(
                     name=name,
                     type=etype,
                     description=description,
                     source_chunk_ids=[source_chunk_id],
-                    **extra,
                 )
             )
 
@@ -416,14 +408,7 @@ class GraphExtraction(ExtractionStrategy):
             if not is_valid_entity_name(source) or not is_valid_entity_name(target):
                 continue
 
-            weight = 1.0
-            try:
-                weight = float(item.get("weight", 1.0))
-            except (ValueError, TypeError):
-                weight = 1.0
-
             description = str(item.get("description", "")).strip()
-            keywords = str(item.get("keywords", "")).strip()
 
             extra: dict[str, Any] = {}
             spans = _build_spans(item, source_chunk_id, "span_start", "span_end")
@@ -435,9 +420,7 @@ class GraphExtraction(ExtractionStrategy):
                     source=source,
                     target=target,
                     type=rel_type,
-                    keywords=keywords,
                     description=description,
-                    weight=weight,
                     source_chunk_ids=[source_chunk_id],
                     **extra,
                 )
@@ -522,9 +505,7 @@ class GraphExtraction(ExtractionStrategy):
                     source=rel.source,
                     target=rel.target,
                     type=rel.type,
-                    keywords=rel.keywords,
                     description=rel.description,
-                    weight=rel.weight,
                     source_chunk_ids=list(rel.source_chunk_ids),
                     **_optional_extras(rel),
                 )
@@ -577,9 +558,6 @@ class GraphExtraction(ExtractionStrategy):
             props: dict[str, Any] = {
                 "rel_type": rel.type,
                 "fact": fact,
-                "keywords": rel.keywords,
-                "description": rel.description,
-                "weight": rel.weight,
                 "source_chunk_ids": rel.source_chunk_ids,
                 "src_name": rel.source,
                 "tgt_name": rel.target,

--- a/graphrag_sdk/tests/test_graph_extraction.py
+++ b/graphrag_sdk/tests/test_graph_extraction.py
@@ -427,6 +427,23 @@ class TestSpansMerging:
         assert hasattr(acme, "spans")
         assert acme.spans["chunk-0"] == [{"start": 15, "end": 24}]
 
+    def test_llm_discovered_entity_case_insensitive_spans(self):
+        """text.find() spans should be case-insensitive."""
+        step1: list[ExtractedEntity] = []
+        verified = [
+            ExtractedEntity(
+                name="ACME Corp", type="Organization",
+                description="A tech company",
+                source_chunk_ids=["chunk-0"],
+            ),
+        ]
+        chunk_text = "Alice works at Acme Corp as an engineer."
+        GraphExtraction._merge_step1_metadata(verified, step1, chunk_text, "chunk-0")
+
+        acme = verified[0]
+        assert hasattr(acme, "spans")
+        assert acme.spans["chunk-0"] == [{"start": 15, "end": 24}]
+
     def test_aggregate_merges_spans_across_chunks(self):
         """Spans from different chunks should merge during aggregation."""
         ent1 = ExtractedEntity(

--- a/graphrag_sdk/tests/test_graph_extraction.py
+++ b/graphrag_sdk/tests/test_graph_extraction.py
@@ -96,11 +96,6 @@ class TestGraphExtractionSmoke:
             assert "tgt_name" in rel.properties
             # Used by PPR expansion (Phase 2)
             assert "rel_type" in rel.properties
-            assert "description" in rel.properties
-            # Used for fulltext search
-            assert "keywords" in rel.properties
-            # Used for scoring
-            assert "weight" in rel.properties
 
     async def test_produces_mentions(self, extractor, ctx):
         chunks = _make_chunks("Alice is a software engineer at Acme Corp.")
@@ -383,7 +378,8 @@ class TestSpansMerging:
                 source_chunk_ids=["chunk-0"],
             ),
         ]
-        GraphExtraction._merge_step1_metadata(verified, step1)
+        chunk_text = "Alice and Bob work together at Acme Corp."
+        GraphExtraction._merge_step1_metadata(verified, step1, chunk_text, "chunk-0")
 
         alice = next(e for e in verified if e.name == "Alice")
         assert hasattr(alice, "spans")
@@ -395,6 +391,41 @@ class TestSpansMerging:
         bob = next(e for e in verified if e.name == "Bob")
         assert bob.spans["chunk-0"] == [{"start": 10, "end": 13}]
         assert bob.confidence == 0.88
+
+    def test_llm_discovered_entity_gets_text_find_spans(self):
+        """Entities found by LLM (not in step 1) get spans via text.find()."""
+        step1 = [
+            ExtractedEntity(
+                name="Alice", type="Person", description="",
+                source_chunk_ids=["chunk-0"],
+                spans={"chunk-0": [{"start": 0, "end": 5}]},
+                confidence=0.95,
+            ),
+        ]
+        # LLM discovered "Acme Corp" which GLiNER missed
+        verified = [
+            ExtractedEntity(
+                name="Alice", type="Person",
+                description="A software engineer",
+                source_chunk_ids=["chunk-0"],
+            ),
+            ExtractedEntity(
+                name="Acme Corp", type="Organization",
+                description="A tech company",
+                source_chunk_ids=["chunk-0"],
+            ),
+        ]
+        chunk_text = "Alice works at Acme Corp as an engineer."
+        GraphExtraction._merge_step1_metadata(verified, step1, chunk_text, "chunk-0")
+
+        # Alice should get GLiNER spans
+        alice = next(e for e in verified if e.name == "Alice")
+        assert alice.spans["chunk-0"] == [{"start": 0, "end": 5}]
+
+        # Acme Corp should get text.find() spans
+        acme = next(e for e in verified if e.name == "Acme Corp")
+        assert hasattr(acme, "spans")
+        assert acme.spans["chunk-0"] == [{"start": 15, "end": 24}]
 
     def test_aggregate_merges_spans_across_chunks(self):
         """Spans from different chunks should merge during aggregation."""


### PR DESCRIPTION
Remove keywords, weight, and entity spans from the LLM extraction prompt to reduce output tokens by ~25-40%. Entity spans are now computed via text.find() for LLM-discovered entities (GLiNER spans still used for step 1 entities). Drop redundant description property from relationship edges (only fact is used in retrieval). Tighten entity/relationship description instructions for conciseness.