### PR TITLE
Fix CVE-2026-35030: bump litellm >= 1.83.0

### DIFF
--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -36,7 +36,7 @@ anthropic = ["anthropic>=0.20"]
 cohere = ["cohere>=5.0"]
 sentence-transformers = ["sentence-transformers>=2.0"]
 pdf = ["pypdf>=5.0"]
-litellm = ["litellm>=1.40"]
+litellm = ["litellm>=1.83.0"]
 openrouter = ["openai>=1.0"]
 fastcoref = ["fastcoref>=2.0"]
 spacy = ["spacy>=3.0"]
@@ -46,7 +46,7 @@ all = [
     "cohere>=5.0",
     "sentence-transformers>=2.0",
     "pypdf>=5.0",
-    "litellm>=1.40",
+    "litellm>=1.83.0",
 ]
 dev = [
     "pytest>=8.0",


### PR DESCRIPTION
## Summary
- Bumps `litellm` minimum version from `>=1.40` to `>=1.83.0` in both the optional `[litellm]` extra and the `[all]` extra
- Addresses Dependabot alert #131 — critical OIDC userinfo cache key collision auth bypass (CVE-2026-35030)
- This SDK doesn't use JWT/OIDC auth so practical risk is low, but users installing the `litellm` extra should not get a vulnerable version

## Test plan
- [ ] `pip install -e ".[litellm]"` resolves to litellm >=1.83.0
- [ ] Existing tests pass without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)