### PR TITLE
feat: v1.0.0 release — API overhaul, parallel ingest, graph config node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.12"
       - run: pip install ruff
       - name: Ruff check (src)
-        run: ruff check src/ --ignore I001,E501
+        run: ruff check src/
       - name: Ruff format check (src)
         run: ruff format --check src/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Circuit breaker**: Resilient FalkorDB connection with automatic failure detection and recovery.
 - **Multi-tenant support**: `Context` with tenant isolation, distributed tracing, and latency budgeting.
 - **Parallel multi-source ingestion**: `ingest()` accepts `str | list[str]` with `max_concurrent` parameter for bounded parallel ingestion.
-- **Retrieve/completion split**: `retrieve()` for retrieval-only (no LLM call); `completion()` for full RAG pipeline with optional conversation history.
+- **Retrieve/completion split**: `retrieve()` for retrieval-only (no LLM call); `completion()` for full RAG pipeline with conversation history support.
+- **Native multi-turn conversations**: `completion(history=[...])` passes messages natively to the LLM provider's chat API (not string-stuffed into a single prompt). History accepts `ChatMessage` objects or `{"role": ..., "content": ...}` dicts with validated roles (`system`, `user`, `assistant`).
+- **`ChatMessage` model**: Pydantic-validated message type with `role: Literal["system", "user", "assistant"]` and `content: str`. Exported from the top-level package.
+- **`LLMInterface.ainvoke_messages()`**: New method for multi-turn message-based LLM calls. Default implementation falls back to `ainvoke()` (string concatenation), so custom providers work without changes. `LiteLLM` and `OpenRouterLLM` override with native implementations.
 - **Graph config node**: `__GraphRAGConfig__` singleton stores the embedding model and dimension used to build the graph; mismatches are caught on retrieval.
 - **Embedder.model_name**: Abstract property on the `Embedder` ABC for identifying the embedding model.
-- **547 tests**: Comprehensive unit and integration test suite with mock providers.
+- **556 tests**: Comprehensive unit and integration test suite with mock providers.
 - **Full documentation**: Architecture, strategies, configuration, providers, benchmark, and API reference.
 - **4 examples**: Quickstart, PDF with schema, custom strategies, and custom provider.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0a1] - 2026-03-24
+## [1.0.0] - 2026-04-09
 
 ### Added
 
@@ -13,13 +13,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Multi-path retrieval**: Entity discovery via vector + fulltext search, relationship expansion, chunk retrieval, cosine reranking, and LLM-based answer generation.
 - **Strategy pattern**: Swappable algorithms for every pipeline concern — chunking, extraction, resolution, retrieval, and reranking — each behind an abstract base class.
 - **GraphExtraction strategy**: Two-step extraction using GLiNER2 for entity recognition (step 1) and LLM for relationship extraction and verification (step 2).
-- **Resolution strategies**: ExactMatchResolution, DescriptionMergeResolution (LLM-assisted), and SemanticResolution (embedding-based).
+- **Resolution strategies**: ExactMatchResolution, DescriptionMergeResolution (LLM-assisted), SemanticResolution (embedding-based), and LLMVerifiedResolution.
 - **LiteLLM provider**: Supports Azure OpenAI, OpenAI, Anthropic, Cohere, and 100+ LLM providers.
 - **OpenRouter provider**: Alternative LLM/embedder provider via OpenRouter API.
 - **PDF ingestion**: `PdfLoader` for processing PDF documents.
 - **Entity deduplication**: `finalize()` post-ingestion step for dedup, embedding backfill, and index creation.
 - **Circuit breaker**: Resilient FalkorDB connection with automatic failure detection and recovery.
 - **Multi-tenant support**: `Context` with tenant isolation, distributed tracing, and latency budgeting.
-- **491 tests**: Comprehensive unit and integration test suite with mock providers.
+- **Parallel multi-source ingestion**: `ingest()` accepts `str | list[str]` with `max_concurrent` parameter for bounded parallel ingestion.
+- **Retrieve/completion split**: `retrieve()` for retrieval-only (no LLM call); `completion()` for full RAG pipeline with optional conversation history.
+- **Graph config node**: `__GraphRAGConfig__` singleton stores the embedding model and dimension used to build the graph; mismatches are caught on retrieval.
+- **Embedder.model_name**: Abstract property on the `Embedder` ABC for identifying the embedding model.
+- **547 tests**: Comprehensive unit and integration test suite with mock providers.
 - **Full documentation**: Architecture, strategies, configuration, providers, benchmark, and API reference.
 - **4 examples**: Quickstart, PDF with schema, custom strategies, and custom provider.
+
+### Changed
+
+- `query()` is deprecated — use `retrieve()` for retrieval-only or `completion()` for full RAG.
+- `query_sync()` is deprecated — use `retrieve_sync()` or `completion_sync()`.
+- `ConnectionConfig.password` field is hidden from `repr()` output.
+- Dependency version bounds tightened: `numpy<3`, `scipy<2`, `falkordb<2`, `gliner<1`.
+- `pypdf` minimum bumped to `>=6.9.2` (CVE fixes).
+- Development status classifier changed from Alpha to Production/Stable.
+
+### Fixed
+
+- `hnswlib` import guard in SemanticResolution and LLMVerifiedResolution — raises clear `ImportError` instead of `AttributeError` when hnswlib is not installed.
+- 14 ruff lint errors (import sorting, line length) resolved; CI no longer ignores lint rules.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ print(answer.answer)
 
 ### Multi-Turn Conversations
 
-`completion()` supports native multi-turn conversations. History messages are passed directly to the LLM provider's chat API as structured messages, not concatenated into a single prompt.
+`completion()` supports multi-turn conversations. With the built-in providers (`LiteLLM`, `OpenRouterLLM`), history messages are passed natively to the LLM's chat API. Custom providers that only implement `invoke()` get automatic fallback via message concatenation.
 
 ```python
 from graphrag_sdk import ChatMessage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GraphRAG SDK v2
+# GraphRAG SDK
 
-GraphRAG SDK v2 is a production-grade Python SDK for building and querying knowledge graphs using Graph-based Retrieval Augmented Generation (GraphRAG). It uses [FalkorDB](https://www.falkordb.com/) as the graph database and supports any LLM/embedder provider through a pluggable provider interface.
+GraphRAG SDK is a production-grade Python SDK for building and querying knowledge graphs using Graph-based Retrieval Augmented Generation (GraphRAG). It uses [FalkorDB](https://www.falkordb.com/) as the graph database and supports any LLM/embedder provider through a pluggable provider interface.
 
 ## Key Features
 
@@ -48,7 +48,7 @@ async def main():
     await rag.finalize()
 
     # Query
-    answer = await rag.query("What is the main topic?")
+    answer = await rag.completion("What is the main topic?")
     print(answer.answer)
 
 asyncio.run(main())
@@ -114,7 +114,7 @@ await rag.finalize()
 ### Querying the Graph
 
 ```python
-answer = await rag.query("Who are the main characters in the story?")
+answer = await rag.completion("Who are the main characters in the story?")
 print(answer.answer)
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,40 @@ await rag.finalize()
 ### Querying the Graph
 
 ```python
+# Retrieve context only (no LLM call)
+context = await rag.retrieve("Who are the main characters?")
+
+# Full RAG: retrieve + generate answer
 answer = await rag.completion("Who are the main characters in the story?")
 print(answer.answer)
+```
+
+### Multi-Turn Conversations
+
+`completion()` supports native multi-turn conversations. History messages are passed directly to the LLM provider's chat API as structured messages, not concatenated into a single prompt.
+
+```python
+from graphrag_sdk import ChatMessage
+
+answer = await rag.completion(
+    "What happened to her after that?",
+    history=[
+        ChatMessage(role="user", content="Who is Alice?"),
+        ChatMessage(role="assistant", content="Alice is a software engineer at Acme Corp."),
+    ],
+)
+```
+
+You can also pass history as plain dicts — roles are validated automatically:
+
+```python
+answer = await rag.completion(
+    "Tell me more about that.",
+    history=[
+        {"role": "user", "content": "What is Acme Corp?"},
+        {"role": "assistant", "content": "Acme Corp is a tech company."},
+    ],
+)
 ```
 
 ## Architecture Overview

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 2.0.x   | Yes                |
-| < 2.0   | No                 |
+| 1.0.x   | Yes                |
+| < 1.0   | No                 |
 
 ## Reporting a Vulnerability
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -126,7 +126,7 @@ Full RAG pipeline: retrieve context and generate an answer. When `history` is pr
 | `history` | `list[ChatMessage \| dict] \| None` | `None` | Conversation history (see below) |
 | `strategy` | `RetrievalStrategy \| None` | `None` | Override retrieval strategy |
 | `reranker` | `RerankingStrategy \| None` | `None` | Optional reranking after retrieval |
-| `prompt_template` | `str \| None` | `None` | Custom prompt (must contain `{context}` and `{question}`) |
+| `prompt_template` | `str \| None` | `None` | Custom prompt for single-turn (must contain `{context}` and `{question}`). Ignored when `history` is provided. |
 | `return_context` | `bool` | `False` | Include retriever results in output |
 | `ctx` | `Context \| None` | `None` | Execution context |
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,7 +21,7 @@ Complete reference for all public classes and methods exported by `graphrag_sdk`
 
 ## GraphRAG (Facade)
 
-The main entry point. Two primary operations: `ingest()` and `query()`.
+The main entry point. Three primary operations: `ingest()`, `retrieve()`, and `completion()`.
 
 ```python
 from graphrag_sdk import GraphRAG
@@ -53,37 +53,63 @@ GraphRAG(
 
 ```python
 async def ingest(
-    source: str,
+    source: str | list[str],
     *,
     text: str | None = None,
     loader: LoaderStrategy | None = None,
     chunker: ChunkingStrategy | None = None,
     extractor: ExtractionStrategy | None = None,
     resolver: ResolutionStrategy | None = None,
+    max_concurrent: int = 3,
     ctx: Context | None = None,
-) -> IngestionResult
+) -> IngestionResult | list[IngestionResult]
 ```
 
-Build a knowledge graph from a source. Auto-detects loader from file extension.
+Build a knowledge graph from one or more sources. Auto-detects loader from file extension. When a list of sources is provided, documents are ingested in parallel with bounded concurrency.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `source` | `str` | required | File path, URL, or source identifier |
-| `text` | `str \| None` | `None` | Raw text (skips loader if provided) |
+| `source` | `str \| list[str]` | required | File path (or list of paths) for ingestion |
+| `text` | `str \| None` | `None` | Raw text (single source only; skips loader) |
 | `loader` | `LoaderStrategy \| None` | `None` | Custom loader (auto-detect if None) |
 | `chunker` | `ChunkingStrategy \| None` | `None` | Custom chunker (FixedSizeChunking(1000) if None) |
 | `extractor` | `ExtractionStrategy \| None` | `None` | Custom extractor (GraphExtraction if None) |
 | `resolver` | `ResolutionStrategy \| None` | `None` | Custom resolver (ExactMatchResolution if None) |
+| `max_concurrent` | `int` | `3` | Max parallel ingestions (list input only) |
 | `ctx` | `Context \| None` | `None` | Execution context |
 
-**Returns:** `IngestionResult`
+**Returns:** `IngestionResult` for a single source, `list[IngestionResult]` for multiple sources.
 
-### query()
+### retrieve()
 
 ```python
-async def query(
+async def retrieve(
     question: str,
     *,
+    strategy: RetrievalStrategy | None = None,
+    reranker: RerankingStrategy | None = None,
+    ctx: Context | None = None,
+) -> RetrieverResult
+```
+
+Retrieve context from the knowledge graph without generating an answer. Use this to inspect retrieved context or pass it to your own LLM.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `question` | `str` | required | The user's question |
+| `strategy` | `RetrievalStrategy \| None` | `None` | Override retrieval strategy |
+| `reranker` | `RerankingStrategy \| None` | `None` | Optional reranking after retrieval |
+| `ctx` | `Context \| None` | `None` | Execution context |
+
+**Returns:** `RetrieverResult`
+
+### completion()
+
+```python
+async def completion(
+    question: str,
+    *,
+    history: list[ChatMessage | dict[str, str]] | None = None,
     strategy: RetrievalStrategy | None = None,
     reranker: RerankingStrategy | None = None,
     prompt_template: str | None = None,
@@ -92,11 +118,12 @@ async def query(
 ) -> RagResult
 ```
 
-Query the knowledge graph and generate an answer.
+Full RAG pipeline: retrieve context and generate an answer. When `history` is provided, messages are passed natively to the LLM provider's multi-turn chat API.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `question` | `str` | required | The user's question |
+| `history` | `list[ChatMessage \| dict] \| None` | `None` | Conversation history (see below) |
 | `strategy` | `RetrievalStrategy \| None` | `None` | Override retrieval strategy |
 | `reranker` | `RerankingStrategy \| None` | `None` | Optional reranking after retrieval |
 | `prompt_template` | `str \| None` | `None` | Custom prompt (must contain `{context}` and `{question}`) |
@@ -104,6 +131,42 @@ Query the knowledge graph and generate an answer.
 | `ctx` | `Context \| None` | `None` | Execution context |
 
 **Returns:** `RagResult`
+
+**Conversation history:**
+
+History accepts a list of `ChatMessage` objects or plain dicts with `role` and `content` keys. Supported roles: `"system"`, `"user"`, `"assistant"`. Invalid roles raise `ValueError`.
+
+```python
+from graphrag_sdk import ChatMessage
+
+# Using ChatMessage objects
+result = await rag.completion(
+    "What happened next?",
+    history=[
+        ChatMessage(role="user", content="Who is Alice?"),
+        ChatMessage(role="assistant", content="Alice is an engineer."),
+    ],
+)
+
+# Using plain dicts
+result = await rag.completion(
+    "Tell me more.",
+    history=[
+        {"role": "user", "content": "What is Acme?"},
+        {"role": "assistant", "content": "A tech company."},
+    ],
+)
+```
+
+When history is provided, `completion()` builds a native messages list: `[system_prompt, *history, user_question]` and calls `LLMInterface.ainvoke_messages()`. Without history, it uses the single-turn `ainvoke()` path.
+
+### query() (deprecated)
+
+```python
+async def query(question: str, **kwargs) -> RagResult
+```
+
+**Deprecated.** Use `completion()` for the full RAG pipeline or `retrieve()` for retrieval-only. Emits a `DeprecationWarning` and delegates to `completion()`.
 
 ### deduplicate_entities()
 
@@ -142,9 +205,11 @@ Run all post-ingestion steps after all documents are ingested. Bundles:
 ### Sync Wrappers
 
 ```python
-def query_sync(question: str, **kwargs) -> RagResult
-def ingest_sync(source: str, **kwargs) -> IngestionResult
+def retrieve_sync(question: str, **kwargs) -> RetrieverResult
+def completion_sync(question: str, **kwargs) -> RagResult
+def ingest_sync(source: str | list[str], **kwargs) -> IngestionResult | list[IngestionResult]
 def finalize_sync() -> dict[str, Any]
+def query_sync(question: str, **kwargs) -> RagResult  # deprecated
 ```
 
 Convenience methods that run the async versions in `asyncio.run()`.
@@ -205,14 +270,18 @@ LLMInterface(model_name: str, model_params: dict | None = None, max_concurrency:
 |--------|-----------|-------------|
 | `invoke` | `(prompt: str, **kwargs) -> LLMResponse` | Sync text generation (abstract) |
 | `ainvoke` | `(prompt: str, *, max_retries=3, **kwargs) -> LLMResponse` | Async with retry + backoff |
+| `ainvoke_messages` | `(messages: list[ChatMessage], *, max_retries=3, **kwargs) -> LLMResponse` | Multi-turn native messages (see below) |
 | `invoke_with_model` | `(prompt: str, response_model: Type[BaseModel], **kwargs) -> BaseModel` | Structured output |
 | `ainvoke_with_model` | `(prompt: str, response_model: Type[BaseModel], *, max_retries=3) -> BaseModel` | Async structured output |
 | `abatch_invoke` | `(prompts: list[str], *, max_concurrency=None, max_retries=3) -> list[LLMBatchItem]` | Concurrent batch |
+
+`ainvoke_messages()` is used by `completion()` when conversation history is provided. The default implementation concatenates messages into a single prompt string and calls `ainvoke()`, so custom providers work without changes. `LiteLLM` and `OpenRouterLLM` override this with native multi-turn implementations.
 
 ### Embedder (ABC)
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
+| `model_name` | `@property -> str` | Embedding model identifier (abstract) |
 | `embed_query` | `(text: str, **kwargs) -> list[float]` | Single text embedding (abstract) |
 | `aembed_query` | `(text: str, **kwargs) -> list[float]` | Async single (default: thread pool) |
 | `embed_documents` | `(texts: list[str], **kwargs) -> list[list[float]]` | Batch (default: sequential) |
@@ -378,6 +447,22 @@ class ResolutionResult(DataModel):
     relationships: list[GraphRelationship] = []
     merged_count: int = 0
 ```
+
+### ChatMessage
+
+```python
+from graphrag_sdk import ChatMessage
+
+class ChatMessage(DataModel):
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+    def to_dict(self) -> dict[str, str]  # {"role": ..., "content": ...}
+```
+
+Validated message type for multi-turn conversations. Used by `completion(history=...)` and `LLMInterface.ainvoke_messages()`. Invalid roles raise a validation error on construction.
+
+`LLMMessage` is a backward-compatible alias for `ChatMessage`.
 
 ### LLMResponse
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -275,7 +275,7 @@ async def main():
 
     for i, q in enumerate(questions):
         t0 = time.time()
-        result = await rag.query(q["question"])
+        result = await rag.completion(q["question"])
         latency = time.time() - t0
 
         # LLM-as-Judge scoring
@@ -377,11 +377,11 @@ await rag.finalize()  # dedup + entity embeddings + relationship embeddings + in
 
 ```python
 # Query uses the default MultiPathRetrieval (configured automatically)
-result = await rag.query("What happened to character X?")
+result = await rag.completion("What happened to character X?")
 print(result.answer)
 
 # With context inspection:
-result = await rag.query("What happened to character X?", return_context=True)
+result = await rag.completion("What happened to character X?", return_context=True)
 print(result.retriever_result.items)  # See retrieved entities, facts, passages
 ```
 
@@ -398,7 +398,7 @@ print(result.retriever_result.items)  # See retrieved entities, facts, passages
 
 1. **Ingestion**: All 20 Project Gutenberg novel excerpts were ingested using `GraphExtraction` (GLiNER2 NER + LLM relationship extraction) with `DescriptionMergeResolution` and `FixedSizeChunking(1500, 200)`.
 2. **Finalize**: `rag.finalize()` was called to deduplicate entities, backfill embeddings, and create all vector/fulltext indexes.
-3. **Evaluation**: Each of the 100 questions was queried via `rag.query()` using the default `MultiPathRetrieval` strategy. The generated answer was scored against the ground-truth reference by GPT-4.1 as an LLM-as-Judge (0-10 scale).
+3. **Evaluation**: Each of the 100 questions was queried via `rag.completion()` using the default `MultiPathRetrieval` strategy. The generated answer was scored against the ground-truth reference by GPT-4.1 as an LLM-as-Judge (0-10 scale).
 4. **Scoring**: The final accuracy is the mean of all 100 individual scores.
 
 Results may vary slightly between runs (~2-3% variance) due to LLM non-determinism, even with `temperature=0`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -494,7 +494,7 @@ retriever = MultiPathRetrieval(
     keyword_limit=12,         # extract more keywords
 )
 
-result = await rag.query("What happened?", strategy=retriever)
+result = await rag.completion("What happened?", strategy=retriever)
 ```
 
 ### Retrieval Pipeline (9 Steps)
@@ -517,7 +517,7 @@ Pass a custom strategy to individual queries or set it as the default:
 
 ```python
 # Per-query override
-result = await rag.query("...", strategy=my_custom_retriever)
+result = await rag.completion("...", strategy=my_custom_retriever)
 
 # Default at init time
 rag = GraphRAG(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started with GraphRAG SDK v2
+# Getting Started with GraphRAG SDK
 
 A step-by-step tutorial for building a knowledge graph from documents and querying it with natural language.
 
@@ -134,10 +134,22 @@ The ingestion pipeline runs a 9-step process: Load, Chunk, Lexical Graph, Extrac
 
 ## 8. Query the Knowledge Graph
 
-### Basic query
+### Retrieve context only
+
+Use `retrieve()` when you want to inspect the context or use your own LLM:
 
 ```python
-result = await rag.query("Who works at Acme Corp?")
+context = await rag.retrieve("Who works at Acme Corp?")
+for item in context.items:
+    print(f"[{item.score:.2f}] {item.content[:100]}...")
+```
+
+### Generate an answer
+
+Use `completion()` for the full RAG pipeline — retrieval + answer generation:
+
+```python
+result = await rag.completion("Who works at Acme Corp?")
 print(result.answer)
 ```
 
@@ -146,12 +158,41 @@ print(result.answer)
 Pass `return_context=True` to see which chunks and entities the retriever used to build the answer:
 
 ```python
-result = await rag.query("Who works at Acme Corp?", return_context=True)
+result = await rag.completion("Who works at Acme Corp?", return_context=True)
 for item in result.retriever_result.items:
     print(f"[{item.metadata.get('section', '')}] {item.content[:100]}...")
 ```
 
-This is useful for debugging retrieval quality and understanding which parts of your documents contribute to the answer.
+### Multi-turn conversations
+
+`completion()` supports native multi-turn conversations. Messages are passed directly to the LLM's chat API as structured messages:
+
+```python
+from graphrag_sdk import ChatMessage
+
+result = await rag.completion(
+    "What happened to her after that?",
+    history=[
+        ChatMessage(role="user", content="Who works at Acme Corp?"),
+        ChatMessage(role="assistant", content="Jane Doe works at Acme Corp."),
+    ],
+)
+print(result.answer)
+```
+
+You can also pass history as plain dicts:
+
+```python
+result = await rag.completion(
+    "Tell me more.",
+    history=[
+        {"role": "user", "content": "Who founded Acme?"},
+        {"role": "assistant", "content": "Jane Doe founded Acme in 1985."},
+    ],
+)
+```
+
+Supported roles: `"system"`, `"user"`, `"assistant"`. Invalid roles raise `ValueError`.
 
 ---
 
@@ -202,7 +243,8 @@ If you are not in an async context, use the synchronous convenience methods:
 
 ```python
 result = rag.ingest_sync("path/to/document.txt")
-result = rag.query_sync("Who works at Acme Corp?")
+context = rag.retrieve_sync("Who works at Acme Corp?")
+result = rag.completion_sync("Who works at Acme Corp?")
 results = rag.finalize_sync()
 ```
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -138,9 +138,28 @@ class MyLLM(LLMInterface):
 | Method | Default Behavior | Override When |
 |--------|-----------------|--------------|
 | `ainvoke(prompt, max_retries=3)` | Runs `invoke()` in a thread pool with retry | You have a native async client |
+| `ainvoke_messages(messages, max_retries=3)` | Concatenates messages into a single prompt and calls `ainvoke()` | You have a native multi-turn chat API |
 | `invoke_with_model(prompt, response_model)` | Calls `invoke()` and parses JSON into Pydantic model | Your provider has native structured output |
 | `ainvoke_with_model(prompt, response_model)` | Calls `ainvoke()` and parses JSON | Same, async version |
 | `abatch_invoke(prompts, max_concurrency)` | Concurrent `ainvoke()` with semaphore | You have a native batch API |
+
+`ainvoke_messages()` is called by `completion()` when conversation history is provided. Override it to pass messages natively to your LLM's chat API for proper multi-turn handling:
+
+```python
+from graphrag_sdk.core.models import ChatMessage, LLMResponse
+
+class MyLLM(LLMInterface):
+    def invoke(self, prompt: str, **kwargs) -> LLMResponse:
+        response = my_client.generate(prompt)
+        return LLMResponse(content=response.text)
+
+    async def ainvoke_messages(self, messages: list[ChatMessage], *, max_retries=3, **kwargs) -> LLMResponse:
+        """Native multi-turn — pass messages directly to your chat API."""
+        response = await my_client.chat(
+            messages=[m.to_dict() for m in messages],
+        )
+        return LLMResponse(content=response.text)
+```
 
 ### Constructor Parameters
 
@@ -154,16 +173,23 @@ LLMInterface.__init__(
 
 ## Embedder ABC
 
-### Required Method
+### Required Methods
 
 ```python
 from graphrag_sdk import Embedder
 
 class MyEmbedder(Embedder):
+    @property
+    def model_name(self) -> str:
+        """Identifier for the embedding model. REQUIRED."""
+        return "my-embedding-model"
+
     def embed_query(self, text: str, **kwargs) -> list[float]:
         """Embed a single text. REQUIRED."""
         return my_model.encode(text).tolist()
 ```
+
+The `model_name` property is used by the graph config node to validate that the same embedding model is used for ingestion and retrieval.
 
 ### Optional Overrides
 

--- a/docs/retrieval.md
+++ b/docs/retrieval.md
@@ -288,7 +288,7 @@ strategy = MultiPathRetrieval(
     enable_cypher=True,
 )
 
-result = await rag.query("Your question", strategy=strategy)
+result = await rag.completion("Your question", strategy=strategy)
 ```
 
 ### Tuning Parameters
@@ -309,7 +309,7 @@ The pipeline has built-in reranking (step 8), but you can also apply an external
 from graphrag_sdk.retrieval.reranking_strategies.cosine import CosineReranker
 
 reranker = CosineReranker(embedder=embedder, top_k=10)
-result = await rag.query("Your question", reranker=reranker)
+result = await rag.completion("Your question", reranker=reranker)
 ```
 
 ---

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -512,7 +512,7 @@ reranker = CosineReranker(
     top_k=15,          # keep top N results (default: 15)
 )
 
-result = await rag.query("question", reranker=reranker)
+result = await rag.completion("question", reranker=reranker)
 ```
 
 **Note:** `MultiPathRetrieval` already includes cosine reranking internally. The standalone `CosineReranker` is useful when using `LocalRetrieval` or a custom strategy.

--- a/graphrag_sdk/README.md
+++ b/graphrag_sdk/README.md
@@ -100,7 +100,7 @@ print(result.retriever_result.items)  # See what was retrieved
 
 ### Multi-Turn Conversations
 
-`completion()` supports native multi-turn conversations. Messages are passed directly to the LLM's chat API — not string-stuffed into a single prompt.
+`completion()` supports multi-turn conversations. With the built-in providers (`LiteLLM`, `OpenRouterLLM`), messages are passed natively to the LLM's chat API. Custom providers that only implement `invoke()` get automatic fallback via message concatenation.
 
 ```python
 from graphrag_sdk import ChatMessage

--- a/graphrag_sdk/README.md
+++ b/graphrag_sdk/README.md
@@ -5,7 +5,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
 [![Version: 1.0.0](https://img.shields.io/badge/version-1.0.0-orange.svg)](pyproject.toml)
-[![Tests: 547 passing](https://img.shields.io/badge/tests-547%20passing-brightgreen.svg)](tests/)
+[![Tests: 556 passing](https://img.shields.io/badge/tests-556%20passing-brightgreen.svg)](tests/)
 
 GraphRAG SDK builds knowledge graphs from documents and answers questions over them using retrieval-augmented generation. Every algorithmic concern (chunking, extraction, resolution, retrieval, reranking) is a swappable strategy behind an abstract interface. The default pipeline scores **84.8% accuracy** on a 20-document novel benchmark using GPT-4.1.
 
@@ -86,14 +86,46 @@ await rag.ingest("report.pdf")
 # Ingest from raw text
 await rag.ingest("source_id", text="Alice works at Acme Corp in London.")
 
-# Query
-result = await rag.query("Where does Alice work?")
+# Retrieve context only (no LLM call)
+context = await rag.retrieve("Where does Alice work?")
+
+# Full RAG: retrieve + generate answer
+result = await rag.completion("Where does Alice work?")
 print(result.answer)  # "Alice works at Acme Corp in London."
 
-# Query with context inspection
-result = await rag.query("Where does Alice work?", return_context=True)
+# With context inspection
+result = await rag.completion("Where does Alice work?", return_context=True)
 print(result.retriever_result.items)  # See what was retrieved
 ```
+
+### Multi-Turn Conversations
+
+`completion()` supports native multi-turn conversations. Messages are passed directly to the LLM's chat API — not string-stuffed into a single prompt.
+
+```python
+from graphrag_sdk import ChatMessage
+
+# Using ChatMessage objects (validated)
+answer = await rag.completion(
+    "What happened next?",
+    history=[
+        ChatMessage(role="system", content="Answer concisely."),
+        ChatMessage(role="user", content="Who is Alice?"),
+        ChatMessage(role="assistant", content="Alice is an engineer at Acme Corp."),
+    ],
+)
+
+# Using plain dicts (also validated)
+answer = await rag.completion(
+    "Tell me more.",
+    history=[
+        {"role": "user", "content": "What is Acme Corp?"},
+        {"role": "assistant", "content": "A tech company in London."},
+    ],
+)
+```
+
+Supported roles: `"system"`, `"user"`, `"assistant"`. Invalid roles raise `ValueError`.
 
 ### Schema Definition
 

--- a/graphrag_sdk/README.md
+++ b/graphrag_sdk/README.md
@@ -1,11 +1,11 @@
-# GraphRAG SDK v2.0
+# GraphRAG SDK
 
 **A modular, async-first Graph RAG framework for FalkorDB.**
 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
-[![Version: 2.0.0a1](https://img.shields.io/badge/version-2.0.0a1-orange.svg)](pyproject.toml)
-[![Tests: 491 passing](https://img.shields.io/badge/tests-491%20passing-brightgreen.svg)](tests/)
+[![Version: 1.0.0](https://img.shields.io/badge/version-1.0.0-orange.svg)](pyproject.toml)
+[![Tests: 547 passing](https://img.shields.io/badge/tests-547%20passing-brightgreen.svg)](tests/)
 
 GraphRAG SDK builds knowledge graphs from documents and answers questions over them using retrieval-augmented generation. Every algorithmic concern (chunking, extraction, resolution, retrieval, reranking) is a swappable strategy behind an abstract interface. The default pipeline scores **84.8% accuracy** on a 20-document novel benchmark using GPT-4.1.
 
@@ -32,8 +32,11 @@ async def main():
     result = await rag.ingest("my_document.txt")
     print(f"Created {result.nodes_created} nodes, {result.relationships_created} edges")
 
-    # Query the knowledge graph
-    answer = await rag.query("What is the main theme?")
+    # Retrieve context only
+    context = await rag.retrieve("What is the main theme?")
+
+    # Full RAG: retrieve + generate answer
+    answer = await rag.completion("What is the main theme?")
     print(answer.answer)
 
 asyncio.run(main())

--- a/graphrag_sdk/examples/01_quickstart.py
+++ b/graphrag_sdk/examples/01_quickstart.py
@@ -70,6 +70,19 @@ async def main():
         print(f"\nQ: {question}")
         print(f"A: {answer.answer}")
 
+    # 6. Multi-turn conversation (native messages to LLM)
+    from graphrag_sdk import ChatMessage
+
+    followup = await rag.completion(
+        "What is her role there?",
+        history=[
+            ChatMessage(role="user", content="Where does Alice work?"),
+            ChatMessage(role="assistant", content="Alice works at Acme Corp in London."),
+        ],
+    )
+    print(f"\nQ: What is her role there?")
+    print(f"A: {followup.answer}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/graphrag_sdk/examples/01_quickstart.py
+++ b/graphrag_sdk/examples/01_quickstart.py
@@ -1,5 +1,5 @@
 """
-GraphRAG SDK v2 -- Quick Start
+GraphRAG SDK -- Quick Start
 ===============================
 Minimal example: ingest a short text and query it.
 No external files needed -- just an LLM API key and FalkorDB.
@@ -56,13 +56,17 @@ async def main():
     result = await rag.ingest("quickstart_doc", text=TEXT)
     print(f"Ingested: {result.nodes_created} nodes, {result.relationships_created} edges")
 
-    # 4. Query
+    # 4. Retrieve context only (no LLM answer generation)
+    context = await rag.retrieve("Where does Alice work?")
+    print(f"\nRetrieved {len(context.items)} context items")
+
+    # 5. Full RAG: retrieve + generate answer
     for question in [
         "Where does Alice work?",
         "Who is the CTO of Acme Corp?",
         "When was Acme Corp founded?",
     ]:
-        answer = await rag.query(question)
+        answer = await rag.completion(question)
         print(f"\nQ: {question}")
         print(f"A: {answer.answer}")
 

--- a/graphrag_sdk/examples/02_pdf_with_schema.py
+++ b/graphrag_sdk/examples/02_pdf_with_schema.py
@@ -98,7 +98,7 @@ async def main():
     question = "What are the main topics discussed in this document?"
     print(f"\nQ: {question}")
 
-    answer = await rag.query(question, return_context=True)
+    answer = await rag.completion(question, return_context=True)
     print(f"A: {answer.answer}")
 
     # Show what was retrieved

--- a/graphrag_sdk/examples/02_pdf_with_schema.py
+++ b/graphrag_sdk/examples/02_pdf_with_schema.py
@@ -1,5 +1,5 @@
 """
-GraphRAG SDK v2 -- PDF Ingestion with Schema
+GraphRAG SDK -- PDF Ingestion with Schema
 ==============================================
 Ingest a PDF file with a custom schema that constrains entity/relationship extraction.
 Shows how to inspect retrieved context alongside the answer.

--- a/graphrag_sdk/examples/03_custom_strategies.py
+++ b/graphrag_sdk/examples/03_custom_strategies.py
@@ -1,5 +1,5 @@
 """
-GraphRAG SDK v2 -- Custom Strategies (Benchmark-Winning Pipeline)
+GraphRAG SDK -- Custom Strategies (Benchmark-Winning Pipeline)
 ==================================================================
 Demonstrates the full pipeline configuration that achieved 84.8% accuracy
 on the 20-document novel benchmark. Uses:

--- a/graphrag_sdk/examples/03_custom_strategies.py
+++ b/graphrag_sdk/examples/03_custom_strategies.py
@@ -155,7 +155,7 @@ async def main():
     ]
 
     for q in questions:
-        result = await rag.query(q)
+        result = await rag.completion(q)
         print(f"\nQ: {q}")
         print(f"A: {result.answer}")
 

--- a/graphrag_sdk/examples/04_custom_provider.py
+++ b/graphrag_sdk/examples/04_custom_provider.py
@@ -64,6 +64,10 @@ class MyCustomEmbedder(Embedder):
         # Initialize your embedding model here, e.g.:
         # self.model = SentenceTransformer("all-MiniLM-L6-v2")
 
+    @property
+    def model_name(self) -> str:
+        return "my-custom-embedder"
+
     def embed_query(self, text: str, **kwargs: Any) -> list[float]:
         # Replace with your actual embedding call:
         # return self.model.encode(text).tolist()
@@ -98,7 +102,7 @@ async def main():
     print(f"Ingested: {result.nodes_created} nodes")
 
     # Query
-    answer = await rag.query("What did the fox do?")
+    answer = await rag.completion("What did the fox do?")
     print(f"Answer: {answer.answer}")
 
 

--- a/graphrag_sdk/examples/04_custom_provider.py
+++ b/graphrag_sdk/examples/04_custom_provider.py
@@ -1,5 +1,5 @@
 """
-GraphRAG SDK v2 -- Custom LLM & Embedder Providers
+GraphRAG SDK -- Custom LLM & Embedder Providers
 ====================================================
 Shows how to implement your own LLM and Embedder by subclassing the ABCs.
 Use this pattern to integrate local models, custom APIs, or any provider
@@ -45,6 +45,13 @@ class MyCustomLLM(LLMInterface):
     # Optional: override for native async support
     # async def ainvoke(self, prompt, *, max_retries=3, **kwargs) -> LLMResponse:
     #     response = await self.client.agenerate(prompt)
+    #     return LLMResponse(content=response.text)
+
+    # Optional: override for native multi-turn conversations
+    # async def ainvoke_messages(self, messages, *, max_retries=3, **kwargs) -> LLMResponse:
+    #     response = await self.client.chat(
+    #         messages=[m.to_dict() for m in messages],
+    #     )
     #     return LLMResponse(content=response.text)
 
 

--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphrag-sdk"
-version = "2.0.0a1"
-description = "GraphRAG SDK 2.0 — A modular, async-first Graph RAG framework for FalkorDB"
+version = "1.0.0"
+description = "GraphRAG SDK — A modular, async-first Graph RAG framework for FalkorDB"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [{ name = "FalkorDB", email = "support@falkordb.com" }]
 keywords = ["graphrag", "rag", "falkordb", "knowledge-graph", "llm"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -23,13 +23,13 @@ classifiers = [
 
 dependencies = [
     "pydantic>=2.0,<3.0",
-    "falkordb>=1.0",
-    "numpy>=1.24",
+    "falkordb>=1.0,<2",
+    "numpy>=1.24,<3",
     "python-dotenv>=1.0",
     "tiktoken>=0.5",
-    "gliner>=0.2",
+    "gliner>=0.2,<1",
     "hnswlib>=0.8",
-    "scipy>=1.11",
+    "scipy>=1.11,<2",
 ]
 
 [project.optional-dependencies]
@@ -37,7 +37,7 @@ openai = ["openai>=1.0"]
 anthropic = ["anthropic>=0.20"]
 cohere = ["cohere>=5.0"]
 sentence-transformers = ["sentence-transformers>=2.0"]
-pdf = ["pypdf>=5.0"]
+pdf = ["pypdf>=6.9.2"]
 litellm = ["litellm>=1.83.0"]
 openrouter = ["openai>=1.0"]
 fastcoref = ["fastcoref>=2.0"]
@@ -47,7 +47,7 @@ all = [
     "anthropic>=0.20",
     "cohere>=5.0",
     "sentence-transformers>=2.0",
-    "pypdf>=5.0",
+    "pypdf>=6.9.2",
     "litellm>=1.83.0",
 ]
 dev = [

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -21,6 +21,7 @@ from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.exceptions import GraphRAGError
 from graphrag_sdk.core.models import (
+    ChatMessage,
     DataModel,
     DocumentInfo,
     DocumentOutput,
@@ -85,6 +86,7 @@ __all__ = [
     # API
     "GraphRAG",
     # Core
+    "ChatMessage",
     "ConnectionConfig",
     "Context",
     "DataModel",

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0
+# GraphRAG SDK
 # A modular, async-first Graph RAG framework for FalkorDB.
 #
 # Core Principles:
@@ -11,7 +11,7 @@
 #   Adaptability — Optimization-ready core, strategies are swappable.
 #   Velocity — Production-grade throughput.
 
-__version__ = "2.0.0a1"
+__version__ = "1.0.0"
 
 # ── API Surface (Facade) ────────────────────────────────────────
 from graphrag_sdk.api.main import GraphRAG
@@ -42,10 +42,10 @@ from graphrag_sdk.core.models import (
 )
 from graphrag_sdk.core.providers import (
     Embedder,
-    LLMBatchItem,
-    LLMInterface,
     LiteLLM,
     LiteLLMEmbedder,
+    LLMBatchItem,
+    LLMInterface,
     OpenRouterEmbedder,
     OpenRouterLLM,
 )

--- a/graphrag_sdk/src/graphrag_sdk/api/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — API
+# GraphRAG SDK — API
 
 from graphrag_sdk.api.main import GraphRAG
 

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -428,8 +428,10 @@ class GraphRAG:
                 provider's multi-turn API.
             strategy: Override retrieval strategy (uses default if None).
             reranker: Optional reranking strategy to apply.
-            prompt_template: Custom prompt (must contain {context} and
-                {question}).  Only used when *history* is ``None`` (single-turn).
+            prompt_template: Custom prompt for single-turn mode (must
+                contain ``{context}`` and ``{question}``).  Ignored when
+                *history* is provided — multi-turn uses the built-in
+                system prompt with the question in the final user message.
             return_context: If True, include retriever results in output.
             ctx: Execution context.
 
@@ -454,11 +456,11 @@ class GraphRAG:
 
         # Step 4: Generate answer
         if history:
-            # Multi-turn: validate history and use native messages API
+            # Multi-turn: validate history and use native messages API.
+            # prompt_template is ignored — the question goes in the final
+            # user message, not the system prompt.
             validated = self._validate_history(history)
-            system_prompt = (prompt_template or _RAG_SYSTEM_PROMPT).format(
-                context=context_str,
-            )
+            system_prompt = _RAG_SYSTEM_PROMPT.format(context=context_str)
             messages: list[ChatMessage] = [
                 ChatMessage(role="system", content=system_prompt),
                 *validated,

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -243,8 +243,14 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         ctx: Context | None = None,
+        _skip_post: bool = False,
     ) -> IngestionResult:
-        """Ingest a single source document."""
+        """Ingest a single source document.
+
+        Args:
+            _skip_post: Internal flag — when True, skips ensure_indices
+                and config write (caller handles them after the batch).
+        """
         if ctx is None:
             ctx = Context()
 
@@ -267,14 +273,15 @@ class GraphRAG:
 
         result = await pipeline.run(source, ctx, text=text)
 
-        # Post-ingestion: create indices only.
-        # backfill_entity_embeddings() is intentionally NOT called here —
-        # it re-scans all entities and is very slow when ingesting multiple
-        # documents sequentially.  Call finalize() after all ingestion.
-        await self.vector_store.ensure_indices()
+        if not _skip_post:
+            # Post-ingestion: create indices only.
+            # backfill_entity_embeddings() is intentionally NOT called here —
+            # it re-scans all entities and is very slow when ingesting multiple
+            # documents sequentially.  Call finalize() after all ingestion.
+            await self.vector_store.ensure_indices()
 
-        # Write/update graph config node (idempotent)
-        await self._write_graph_config()
+            # Write/update graph config node (idempotent)
+            await self._write_graph_config()
 
         return result
 
@@ -290,6 +297,10 @@ class GraphRAG:
         ctx: Context | None = None,
     ) -> list[IngestionResult]:
         """Ingest multiple sources in parallel with bounded concurrency."""
+        if max_concurrent < 1:
+            raise ValueError("max_concurrent must be >= 1")
+
+        parent_ctx = ctx or Context()
         sem = asyncio.Semaphore(max_concurrent)
 
         async def _one(src: str) -> IngestionResult:
@@ -301,10 +312,17 @@ class GraphRAG:
                     chunker=chunker,
                     extractor=extractor,
                     resolver=resolver,
-                    ctx=ctx,
+                    ctx=parent_ctx.child(),
+                    _skip_post=True,
                 )
 
-        return list(await asyncio.gather(*[_one(s) for s in sources]))
+        results = list(await asyncio.gather(*[_one(s) for s in sources]))
+
+        # Post-batch: run ensure_indices and config write once
+        await self.vector_store.ensure_indices()
+        await self._write_graph_config()
+
+        return results
 
     def _default_extractor(self) -> ExtractionStrategy:
         """Return default GraphExtraction with schema entity types if available."""
@@ -566,7 +584,9 @@ class GraphRAG:
         except ConfigError:
             raise
         except Exception:
+            # Don't mark as validated on transient failures — retry next call.
             logger.debug("Failed to validate graph config", exc_info=True)
+            return
 
         self._config_validated = True
 

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -43,7 +43,7 @@ from graphrag_sdk.storage.vector_store import VectorStore
 logger = logging.getLogger(__name__)
 
 
-_RAG_PROMPT = (
+_RAG_SYSTEM_PROMPT = (
     "You are a helpful assistant. Answer the question using ONLY "
     "the provided context.\n\n"
     "RULES:\n"
@@ -60,12 +60,11 @@ _RAG_PROMPT = (
     "6. If the context lacks sufficient information, say so briefly "
     "rather than inventing details.\n"
     "7. Respect negation: if a passage states something did NOT happen "
-    "or is NOT true, preserve that meaning.\n"
-    "{history_section}\n"
-    "{context}\n\n"
-    "Question: {question}\n\n"
-    "Answer:"
+    "or is NOT true, preserve that meaning.\n\n"
+    "{context}"
 )
+
+_RAG_PROMPT = _RAG_SYSTEM_PROMPT + ("\n\n{history_section}Question: {question}\n\nAnswer:")
 
 
 class GraphRAG:
@@ -457,10 +456,8 @@ class GraphRAG:
         if history:
             # Multi-turn: validate history and use native messages API
             validated = self._validate_history(history)
-            system_prompt = (prompt_template or _RAG_PROMPT).format(
+            system_prompt = (prompt_template or _RAG_SYSTEM_PROMPT).format(
                 context=context_str,
-                question="",
-                history_section="",
             )
             messages: list[ChatMessage] = [
                 ChatMessage(role="system", content=system_prompt),

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -212,9 +212,7 @@ class GraphRAG:
         """
         if isinstance(source, list):
             if text is not None:
-                raise ValueError(
-                    "'text' parameter cannot be used with a list of sources"
-                )
+                raise ValueError("'text' parameter cannot be used with a list of sources")
             return await self._ingest_batch(
                 source,
                 loader=loader,
@@ -350,9 +348,7 @@ class GraphRAG:
         retriever_result = await retrieval.search(question, ctx)
 
         if reranker is not None:
-            retriever_result = await reranker.rerank(
-                question, retriever_result, ctx
-            )
+            retriever_result = await reranker.rerank(question, retriever_result, ctx)
 
         ctx.log(f"Retrieved {len(retriever_result.items)} context items")
         return retriever_result
@@ -393,13 +389,14 @@ class GraphRAG:
 
         # Step 1-2: Retrieve + rerank
         retriever_result = await self.retrieve(
-            question, strategy=strategy, reranker=reranker, ctx=ctx,
+            question,
+            strategy=strategy,
+            reranker=reranker,
+            ctx=ctx,
         )
 
         # Step 3: Build context string
-        context_str = "\n---\n".join(
-            item.content for item in retriever_result.items
-        )
+        context_str = "\n---\n".join(item.content for item in retriever_result.items)
 
         # Step 4: Build history section
         history_section = ""
@@ -408,9 +405,7 @@ class GraphRAG:
             for msg in history:
                 role = msg.get("role", "user").capitalize()
                 lines.append(f"{role}: {msg.get('content', '')}")
-            history_section = (
-                "\nConversation history:\n" + "\n".join(lines) + "\n"
-            )
+            history_section = "\nConversation history:\n" + "\n".join(lines) + "\n"
 
         # Step 5: Generate answer
         template = prompt_template or _RAG_PROMPT
@@ -427,9 +422,7 @@ class GraphRAG:
             metadata={
                 "model": self.llm.model_name,
                 "num_context_items": len(retriever_result.items),
-                "strategy": (
-                    strategy or self._retrieval_strategy
-                ).__class__.__name__,
+                "strategy": (strategy or self._retrieval_strategy).__class__.__name__,
                 "has_history": bool(history),
             },
         )
@@ -529,9 +522,7 @@ class GraphRAG:
         except ConfigError:
             raise
         except Exception:
-            logger.debug(
-                "Failed to validate graph config", exc_info=True
-            )
+            logger.debug("Failed to validate graph config", exc_info=True)
 
         self._config_validated = True
 

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -14,6 +14,7 @@ from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.exceptions import ConfigError
 from graphrag_sdk.core.models import (
+    ChatMessage,
     GraphSchema,
     IngestionResult,
     RagResult,
@@ -355,11 +356,44 @@ class GraphRAG:
 
     # ── Completion ──────────────────────────────────────────────
 
+    @staticmethod
+    def _validate_history(
+        history: list[ChatMessage | dict[str, str]],
+    ) -> list[ChatMessage]:
+        """Validate and normalise conversation history to ``ChatMessage`` objects.
+
+        Accepts either pre-built ``ChatMessage`` instances or plain dicts
+        with ``role`` and ``content`` keys.  Raises ``ValueError`` on
+        invalid entries.
+        """
+        validated: list[ChatMessage] = []
+        for i, msg in enumerate(history):
+            if isinstance(msg, ChatMessage):
+                validated.append(msg)
+            elif isinstance(msg, dict):
+                if "role" not in msg or "content" not in msg:
+                    raise ValueError(
+                        f"history[{i}]: each message must have 'role' and "
+                        f"'content' keys, got {sorted(msg.keys())}"
+                    )
+                try:
+                    validated.append(ChatMessage(role=msg["role"], content=msg["content"]))
+                except Exception:
+                    raise ValueError(
+                        f"history[{i}]: invalid role '{msg['role']}'. "
+                        f"Must be one of: 'system', 'user', 'assistant'"
+                    )
+            else:
+                raise TypeError(
+                    f"history[{i}]: expected ChatMessage or dict, got {type(msg).__name__}"
+                )
+        return validated
+
     async def completion(
         self,
         question: str,
         *,
-        history: list[dict[str, str]] | None = None,
+        history: list[ChatMessage | dict[str, str]] | None = None,
         strategy: RetrievalStrategy | None = None,
         reranker: RerankingStrategy | None = None,
         prompt_template: str | None = None,
@@ -370,12 +404,15 @@ class GraphRAG:
 
         Args:
             question: The user's question.
-            history: Optional conversation history as list of
-                ``{"role": "user"/"assistant", "content": "..."}`` dicts.
+            history: Optional conversation history as a list of
+                ``ChatMessage`` objects or ``{"role": ..., "content": ...}``
+                dicts.  Supported roles: ``"system"``, ``"user"``,
+                ``"assistant"``.  Messages are passed natively to the LLM
+                provider's multi-turn API.
             strategy: Override retrieval strategy (uses default if None).
             reranker: Optional reranking strategy to apply.
             prompt_template: Custom prompt (must contain {context} and
-                {question}; optionally {history_section}).
+                {question}).  Only used when *history* is ``None`` (single-turn).
             return_context: If True, include retriever results in output.
             ctx: Execution context.
 
@@ -398,23 +435,30 @@ class GraphRAG:
         # Step 3: Build context string
         context_str = "\n---\n".join(item.content for item in retriever_result.items)
 
-        # Step 4: Build history section
-        history_section = ""
+        # Step 4: Generate answer
         if history:
-            lines = []
-            for msg in history:
-                role = msg.get("role", "user").capitalize()
-                lines.append(f"{role}: {msg.get('content', '')}")
-            history_section = "\nConversation history:\n" + "\n".join(lines) + "\n"
-
-        # Step 5: Generate answer
-        template = prompt_template or _RAG_PROMPT
-        prompt = template.format(
-            context=context_str,
-            question=question,
-            history_section=history_section,
-        )
-        llm_response = await self.llm.ainvoke(prompt)
+            # Multi-turn: validate history and use native messages API
+            validated = self._validate_history(history)
+            system_prompt = (prompt_template or _RAG_PROMPT).format(
+                context=context_str,
+                question="",
+                history_section="",
+            )
+            messages: list[ChatMessage] = [
+                ChatMessage(role="system", content=system_prompt),
+                *validated,
+                ChatMessage(role="user", content=question),
+            ]
+            llm_response = await self.llm.ainvoke_messages(messages)
+        else:
+            # Single-turn: use the existing prompt template path
+            template = prompt_template or _RAG_PROMPT
+            prompt = template.format(
+                context=context_str,
+                question=question,
+                history_section="",
+            )
+            llm_response = await self.llm.ainvoke(prompt)
 
         result = RagResult(
             answer=self._clean_answer(llm_response.content),

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -1,19 +1,23 @@
-# GraphRAG SDK 2.0 — API: GraphRAG Facade
+# GraphRAG SDK — API: GraphRAG Facade
 # Pattern: Facade — single entry point that hides all internal wiring.
 # Principle: Simplicity — two-line usage: init + query/ingest.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
-from typing import Any
+from typing import Any, overload
 
+from graphrag_sdk import __version__
 from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
 from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.exceptions import ConfigError
 from graphrag_sdk.core.models import (
     GraphSchema,
     IngestionResult,
     RagResult,
+    RetrieverResult,
 )
 from graphrag_sdk.core.providers import Embedder, LLMInterface
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
@@ -55,7 +59,8 @@ _RAG_PROMPT = (
     "6. If the context lacks sufficient information, say so briefly "
     "rather than inventing details.\n"
     "7. Respect negation: if a passage states something did NOT happen "
-    "or is NOT true, preserve that meaning.\n\n"
+    "or is NOT true, preserve that meaning.\n"
+    "{history_section}\n"
     "{context}\n\n"
     "Question: {question}\n\n"
     "Answer:"
@@ -65,11 +70,12 @@ _RAG_PROMPT = (
 class GraphRAG:
     """The main user-facing class for GraphRAG operations.
 
-    Provides two primary operations:
+    Provides three primary operations:
     - ``ingest()`` — build a knowledge graph from sources
-    - ``query()`` — search the knowledge graph and generate answers
+    - ``retrieve()`` — search the knowledge graph (retrieval only)
+    - ``completion()`` — retrieve context and generate an answer
 
-    Both use sensible defaults but allow full strategy customisation.
+    All use sensible defaults but allow full strategy customisation.
 
     Args:
         connection: FalkorDB connection (or ConnectionConfig to create one).
@@ -90,8 +96,11 @@ class GraphRAG:
         # Ingest
         await rag.ingest("my_document.pdf")
 
-        # Query
-        result = await rag.query("What is the capital of France?")
+        # Retrieve context only
+        context = await rag.retrieve("What is the capital of France?")
+
+        # Full RAG: retrieve + generate answer
+        result = await rag.completion("What is the capital of France?")
         print(result.answer)
     """
 
@@ -113,6 +122,8 @@ class GraphRAG:
         self.llm = llm
         self.embedder = embedder
         self.schema = schema or GraphSchema()
+        self._embedding_dimension = embedding_dimension
+        self._config_validated = False
 
         # Storage layer
         self.graph_store = GraphStore(self._conn)
@@ -135,6 +146,7 @@ class GraphRAG:
 
     # ── Ingestion ────────────────────────────────────────────────
 
+    @overload
     async def ingest(
         self,
         source: str,
@@ -145,8 +157,38 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         ctx: Context | None = None,
-    ) -> IngestionResult:
-        """Build a knowledge graph from a source.
+    ) -> IngestionResult: ...
+
+    @overload
+    async def ingest(
+        self,
+        source: list[str],
+        *,
+        loader: LoaderStrategy | None = None,
+        chunker: ChunkingStrategy | None = None,
+        extractor: ExtractionStrategy | None = None,
+        resolver: ResolutionStrategy | None = None,
+        max_concurrent: int = 3,
+        ctx: Context | None = None,
+    ) -> list[IngestionResult]: ...
+
+    async def ingest(
+        self,
+        source: str | list[str],
+        *,
+        text: str | None = None,
+        loader: LoaderStrategy | None = None,
+        chunker: ChunkingStrategy | None = None,
+        extractor: ExtractionStrategy | None = None,
+        resolver: ResolutionStrategy | None = None,
+        max_concurrent: int = 3,
+        ctx: Context | None = None,
+    ) -> IngestionResult | list[IngestionResult]:
+        """Build a knowledge graph from one or more sources.
+
+        Accepts a single source path or a list of paths. When a list
+        is provided, documents are ingested in parallel with bounded
+        concurrency.
 
         Uses sensible defaults for any unspecified strategy:
         - Loader: auto-detected from file extension (PDF or text)
@@ -155,17 +197,55 @@ class GraphRAG:
         - Resolver: ExactMatchResolution
 
         Args:
-            source: File path, URL, or identifier for the data source.
-            text: Optional raw text (skips loader if provided).
+            source: File path (or list of paths) for ingestion.
+            text: Optional raw text (single source only).
             loader: Custom loader strategy.
             chunker: Custom chunking strategy.
             extractor: Custom extraction strategy.
             resolver: Custom resolution strategy.
+            max_concurrent: Max parallel ingestions (default 3).
             ctx: Execution context.
 
         Returns:
-            IngestionResult with pipeline statistics.
+            IngestionResult for a single source, or
+            list[IngestionResult] for multiple sources.
         """
+        if isinstance(source, list):
+            if text is not None:
+                raise ValueError(
+                    "'text' parameter cannot be used with a list of sources"
+                )
+            return await self._ingest_batch(
+                source,
+                loader=loader,
+                chunker=chunker,
+                extractor=extractor,
+                resolver=resolver,
+                max_concurrent=max_concurrent,
+                ctx=ctx,
+            )
+        return await self._ingest_single(
+            source,
+            text=text,
+            loader=loader,
+            chunker=chunker,
+            extractor=extractor,
+            resolver=resolver,
+            ctx=ctx,
+        )
+
+    async def _ingest_single(
+        self,
+        source: str,
+        *,
+        text: str | None = None,
+        loader: LoaderStrategy | None = None,
+        chunker: ChunkingStrategy | None = None,
+        extractor: ExtractionStrategy | None = None,
+        resolver: ResolutionStrategy | None = None,
+        ctx: Context | None = None,
+    ) -> IngestionResult:
+        """Ingest a single source document."""
         if ctx is None:
             ctx = Context()
 
@@ -191,11 +271,41 @@ class GraphRAG:
         # Post-ingestion: create indices only.
         # backfill_entity_embeddings() is intentionally NOT called here —
         # it re-scans all entities and is very slow when ingesting multiple
-        # documents sequentially.  Call it explicitly after all ingestion
-        # is complete (e.g. ``await rag.vector_store.backfill_entity_embeddings()``).
+        # documents sequentially.  Call finalize() after all ingestion.
         await self.vector_store.ensure_indices()
 
+        # Write/update graph config node (idempotent)
+        await self._write_graph_config()
+
         return result
+
+    async def _ingest_batch(
+        self,
+        sources: list[str],
+        *,
+        loader: LoaderStrategy | None = None,
+        chunker: ChunkingStrategy | None = None,
+        extractor: ExtractionStrategy | None = None,
+        resolver: ResolutionStrategy | None = None,
+        max_concurrent: int = 3,
+        ctx: Context | None = None,
+    ) -> list[IngestionResult]:
+        """Ingest multiple sources in parallel with bounded concurrency."""
+        sem = asyncio.Semaphore(max_concurrent)
+
+        async def _one(src: str) -> IngestionResult:
+            async with sem:
+                return await self._ingest_single(
+                    src,
+                    text=None,
+                    loader=loader,
+                    chunker=chunker,
+                    extractor=extractor,
+                    resolver=resolver,
+                    ctx=ctx,
+                )
+
+        return list(await asyncio.gather(*[_one(s) for s in sources]))
 
     def _default_extractor(self) -> ExtractionStrategy:
         """Return default GraphExtraction with schema entity types if available."""
@@ -205,7 +315,129 @@ class GraphRAG:
             entity_types=entity_types,
         )
 
-    # ── Query ────────────────────────────────────────────────────
+    # ── Retrieval ────────────────────────────────────────────────
+
+    async def retrieve(
+        self,
+        question: str,
+        *,
+        strategy: RetrievalStrategy | None = None,
+        reranker: RerankingStrategy | None = None,
+        ctx: Context | None = None,
+    ) -> RetrieverResult:
+        """Retrieve context from the knowledge graph without generating an answer.
+
+        Use this to inspect retrieved context or pass it to your own LLM.
+        Use ``completion()`` for the full RAG pipeline.
+
+        Args:
+            question: The user's question.
+            strategy: Override retrieval strategy (uses default if None).
+            reranker: Optional reranking strategy to apply.
+            ctx: Execution context.
+
+        Returns:
+            RetrieverResult with context items and metadata.
+        """
+        if ctx is None:
+            ctx = Context()
+
+        ctx.log(f"Retrieve: {question[:80]}...")
+
+        await self._validate_graph_config()
+
+        retrieval = strategy or self._retrieval_strategy
+        retriever_result = await retrieval.search(question, ctx)
+
+        if reranker is not None:
+            retriever_result = await reranker.rerank(
+                question, retriever_result, ctx
+            )
+
+        ctx.log(f"Retrieved {len(retriever_result.items)} context items")
+        return retriever_result
+
+    # ── Completion ──────────────────────────────────────────────
+
+    async def completion(
+        self,
+        question: str,
+        *,
+        history: list[dict[str, str]] | None = None,
+        strategy: RetrievalStrategy | None = None,
+        reranker: RerankingStrategy | None = None,
+        prompt_template: str | None = None,
+        return_context: bool = False,
+        ctx: Context | None = None,
+    ) -> RagResult:
+        """Full RAG pipeline: retrieve context and generate an answer.
+
+        Args:
+            question: The user's question.
+            history: Optional conversation history as list of
+                ``{"role": "user"/"assistant", "content": "..."}`` dicts.
+            strategy: Override retrieval strategy (uses default if None).
+            reranker: Optional reranking strategy to apply.
+            prompt_template: Custom prompt (must contain {context} and
+                {question}; optionally {history_section}).
+            return_context: If True, include retriever results in output.
+            ctx: Execution context.
+
+        Returns:
+            RagResult with the generated answer.
+        """
+        if ctx is None:
+            ctx = Context()
+
+        ctx.log(f"Completion: {question[:80]}...")
+
+        # Step 1-2: Retrieve + rerank
+        retriever_result = await self.retrieve(
+            question, strategy=strategy, reranker=reranker, ctx=ctx,
+        )
+
+        # Step 3: Build context string
+        context_str = "\n---\n".join(
+            item.content for item in retriever_result.items
+        )
+
+        # Step 4: Build history section
+        history_section = ""
+        if history:
+            lines = []
+            for msg in history:
+                role = msg.get("role", "user").capitalize()
+                lines.append(f"{role}: {msg.get('content', '')}")
+            history_section = (
+                "\nConversation history:\n" + "\n".join(lines) + "\n"
+            )
+
+        # Step 5: Generate answer
+        template = prompt_template or _RAG_PROMPT
+        prompt = template.format(
+            context=context_str,
+            question=question,
+            history_section=history_section,
+        )
+        llm_response = await self.llm.ainvoke(prompt)
+
+        result = RagResult(
+            answer=self._clean_answer(llm_response.content),
+            retriever_result=retriever_result if return_context else None,
+            metadata={
+                "model": self.llm.model_name,
+                "num_context_items": len(retriever_result.items),
+                "strategy": (
+                    strategy or self._retrieval_strategy
+                ).__class__.__name__,
+                "has_history": bool(history),
+            },
+        )
+
+        ctx.log(f"Generated answer ({len(result.answer)} chars)")
+        return result
+
+    # ── Deprecated query() alias ────────────────────────────────
 
     async def query(
         self,
@@ -217,54 +449,91 @@ class GraphRAG:
         return_context: bool = False,
         ctx: Context | None = None,
     ) -> RagResult:
-        """Query the knowledge graph and generate an answer.
+        """Deprecated: use ``completion()`` instead.
 
-        Flow: Retrieve context → (optional) Rerank → Generate answer.
-
-        Args:
-            question: The user's question.
-            strategy: Override retrieval strategy (uses default if None).
-            reranker: Optional reranking strategy to apply.
-            prompt_template: Custom prompt template (must contain {context} and {question}).
-            return_context: If True, include retriever results in output.
-            ctx: Execution context.
-
-        Returns:
-            RagResult with the generated answer.
+        This is a backward-compatibility alias. It will be removed in
+        a future version.
         """
-        if ctx is None:
-            ctx = Context()
+        import warnings
 
-        ctx.log(f"Query: {question[:80]}...")
-
-        # Step 1: Retrieve
-        retrieval = strategy or self._retrieval_strategy
-        retriever_result = await retrieval.search(question, ctx)
-
-        # Step 2: Rerank (optional)
-        if reranker is not None:
-            retriever_result = await reranker.rerank(question, retriever_result, ctx)
-
-        # Step 3: Build context
-        context_str = "\n---\n".join(item.content for item in retriever_result.items)
-
-        # Step 4: Generate answer
-        template = prompt_template or _RAG_PROMPT
-        prompt = template.format(context=context_str, question=question)
-        llm_response = await self.llm.ainvoke(prompt)
-
-        result = RagResult(
-            answer=self._clean_answer(llm_response.content),
-            retriever_result=retriever_result if return_context else None,
-            metadata={
-                "model": self.llm.model_name,
-                "num_context_items": len(retriever_result.items),
-                "strategy": retrieval.__class__.__name__,
-            },
+        warnings.warn(
+            "GraphRAG.query() is deprecated. Use completion() for the full "
+            "RAG pipeline, or retrieve() for retrieval-only.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await self.completion(
+            question,
+            strategy=strategy,
+            reranker=reranker,
+            prompt_template=prompt_template,
+            return_context=return_context,
+            ctx=ctx,
         )
 
-        ctx.log(f"Generated answer ({len(result.answer)} chars)")
-        return result
+    # ── Graph Config ────────────────────────────────────────────
+
+    async def _write_graph_config(self) -> None:
+        """Write or update the ``__GraphRAGConfig__`` singleton node."""
+        from datetime import datetime, timezone
+
+        try:
+            await self.graph_store.query_raw(
+                "MERGE (c:__GraphRAGConfig__ {id: 'default'}) "
+                "SET c.embedding_model = $model, "
+                "c.embedding_dimension = $dim, "
+                "c.sdk_version = $version, "
+                "c.updated_at = $ts",
+                params={
+                    "model": self.embedder.model_name,
+                    "dim": self._embedding_dimension,
+                    "version": __version__,
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+        except Exception:
+            logger.debug("Failed to write graph config node", exc_info=True)
+
+    async def _validate_graph_config(self) -> None:
+        """Check that the current embedder matches the graph's stored config."""
+        if self._config_validated:
+            return
+
+        try:
+            result = await self.graph_store.query_raw(
+                "MATCH (c:__GraphRAGConfig__ {id: 'default'}) "
+                "RETURN c.embedding_model, c.embedding_dimension"
+            )
+            if not result.result_set:
+                # No config node — graph is empty or pre-config
+                self._config_validated = True
+                return
+
+            stored_model = result.result_set[0][0]
+            stored_dim = result.result_set[0][1]
+            current_model = self.embedder.model_name
+
+            if stored_model and stored_model != current_model:
+                raise ConfigError(
+                    f"Embedding model mismatch: graph was built with "
+                    f"'{stored_model}' but current embedder is "
+                    f"'{current_model}'. Use the same embedding model "
+                    f"to query this graph."
+                )
+            if stored_dim and stored_dim != self._embedding_dimension:
+                raise ConfigError(
+                    f"Embedding dimension mismatch: graph was built with "
+                    f"dimension {stored_dim} but current config is "
+                    f"{self._embedding_dimension}."
+                )
+        except ConfigError:
+            raise
+        except Exception:
+            logger.debug(
+                "Failed to validate graph config", exc_info=True
+            )
+
+        self._config_validated = True
 
     # ── Answer Post-processing ─────────────────────────────────
 
@@ -374,24 +643,31 @@ class GraphRAG:
 
     # ── Sync Convenience ─────────────────────────────────────────
 
+    def retrieve_sync(self, question: str, **kwargs: Any) -> RetrieverResult:
+        """Synchronous retrieve convenience method."""
+        return asyncio.run(self.retrieve(question, **kwargs))
+
+    def completion_sync(self, question: str, **kwargs: Any) -> RagResult:
+        """Synchronous completion convenience method."""
+        return asyncio.run(self.completion(question, **kwargs))
+
     def query_sync(self, question: str, **kwargs: Any) -> RagResult:
-        """Synchronous query convenience method.
+        """Deprecated: use ``completion_sync()`` instead."""
+        import warnings
 
-        Runs the async query in a new event loop. Prefer ``query()``
-        for production use.
-        """
-        import asyncio
+        warnings.warn(
+            "GraphRAG.query_sync() is deprecated. Use completion_sync().",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.completion_sync(question, **kwargs)
 
-        return asyncio.run(self.query(question, **kwargs))
-
-    def ingest_sync(self, source: str, **kwargs: Any) -> IngestionResult:
+    def ingest_sync(
+        self, source: str | list[str], **kwargs: Any
+    ) -> IngestionResult | list[IngestionResult]:
         """Synchronous ingest convenience method."""
-        import asyncio
-
         return asyncio.run(self.ingest(source, **kwargs))
 
     def finalize_sync(self) -> dict[str, Any]:
         """Synchronous finalize convenience method."""
-        import asyncio
-
         return asyncio.run(self.finalize())

--- a/graphrag_sdk/src/graphrag_sdk/core/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Core Foundation
+# GraphRAG SDK — Core Foundation
 # Stable contracts: models, providers, connection, context, exceptions.
 
 from graphrag_sdk.core.context import Context
@@ -16,9 +16,9 @@ from graphrag_sdk.core.models import (
 )
 from graphrag_sdk.core.providers import (
     Embedder,
-    LLMInterface,
     LiteLLM,
     LiteLLMEmbedder,
+    LLMInterface,
     OpenRouterEmbedder,
     OpenRouterLLM,
 )

--- a/graphrag_sdk/src/graphrag_sdk/core/circuit_breaker.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/circuit_breaker.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Core: Circuit Breaker
+# GraphRAG SDK — Core: Circuit Breaker
 # Async-safe circuit breaker for database connections.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/core/connection.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/connection.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Core: FalkorDB Connection
+# GraphRAG SDK — Core: FalkorDB Connection
 # Async-only FalkorDB client using native ``falkordb.asyncio``.
 # Origin: User design — production resilience.
 
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlparse
 
@@ -21,7 +21,7 @@ class ConnectionConfig:
     host: str = "localhost"
     port: int = 6379
     username: str | None = None
-    password: str | None = None
+    password: str | None = field(default=None, repr=False)
     graph_name: str = "knowledge_graph"
     max_connections: int = 16
     retry_count: int = 3

--- a/graphrag_sdk/src/graphrag_sdk/core/context.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/context.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Core: Context Object
+# GraphRAG SDK — Core: Context Object
 # Threaded through every strategy call for tracing, tenancy, and budgeting.
 # Origin: User design (TenantID, TraceID, Latency Budget) + Neo4j RunContext (simplified).
 

--- a/graphrag_sdk/src/graphrag_sdk/core/exceptions.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/exceptions.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Core: Exception Hierarchy
+# GraphRAG SDK — Core: Exception Hierarchy
 # Centralized exceptions for the entire SDK.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -254,11 +254,28 @@ class RawSearchResult(DataModel):
 # ── LLM Types ────────────────────────────────────────────────────
 
 
-class LLMMessage(DataModel):
-    """A message for the LLM conversation."""
+class ChatMessage(DataModel):
+    """A validated message for multi-turn LLM conversations.
 
-    role: str  # "system" | "user" | "assistant"
+    Used by ``completion(history=...)`` and ``LLMInterface.ainvoke_messages()``.
+
+    Example::
+
+        ChatMessage(role="system", content="You are a helpful assistant.")
+        ChatMessage(role="user", content="What is GraphRAG?")
+        ChatMessage(role="assistant", content="GraphRAG is...")
+    """
+
+    role: Literal["system", "user", "assistant"]
     content: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Convert to the ``{"role": ..., "content": ...}`` dict format used by LLM APIs."""
+        return {"role": self.role, "content": self.content}
+
+
+# Backward-compatible alias
+LLMMessage = ChatMessage
 
 
 class LLMResponse(DataModel):

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Core: Data Models
+# GraphRAG SDK — Core: Data Models
 # Pydantic v2 schemas used across the entire SDK.
 # Origin: Shared types + Neo4j DataModel pattern + schema types.
 
@@ -9,7 +9,6 @@ from typing import Any
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
-
 
 # ── Base ─────────────────────────────────────────────────────────
 

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Provider package
+# GraphRAG SDK — Provider package
 # Re-exports all provider ABCs and built-in implementations.
 
 from graphrag_sdk.core.providers.base import (

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/_retry.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/_retry.py
@@ -1,11 +1,11 @@
-# GraphRAG SDK 2.0 — Embedding retry utilities
+# GraphRAG SDK — Embedding retry utilities
 # Binary-split recovery for transient batch embedding failures.
 
 from __future__ import annotations
 
 import logging
-from typing import Any
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/base.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from graphrag_sdk.core.models import LLMResponse
+from graphrag_sdk.core.models import ChatMessage, LLMResponse
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +124,36 @@ class LLMInterface(ABC):
                     )
                     await asyncio.sleep(delay)
         raise last_exc  # type: ignore[misc]
+
+    async def ainvoke_messages(
+        self,
+        messages: list[ChatMessage],
+        *,
+        max_retries: int = 3,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Invoke the LLM with a list of structured chat messages.
+
+        Override this in provider subclasses to pass messages natively
+        to the LLM API (OpenAI, Anthropic, etc.).  The default
+        implementation concatenates messages into a single prompt
+        string and delegates to ``ainvoke()``, so custom providers
+        that only implement ``invoke()`` still work.
+
+        Args:
+            messages: Ordered list of ``ChatMessage`` objects.
+            max_retries: Retry count forwarded to ``ainvoke``.
+            **kwargs: Extra arguments forwarded to the underlying call.
+
+        Returns:
+            LLMResponse with the model's reply.
+        """
+        # Default fallback: flatten messages into a single prompt string.
+        parts: list[str] = []
+        for msg in messages:
+            parts.append(f"{msg.role.capitalize()}: {msg.content}")
+        prompt = "\n\n".join(parts)
+        return await self.ainvoke(prompt, max_retries=max_retries, **kwargs)
 
     async def astream(self, prompt: str, **kwargs: Any) -> AsyncIterator[str]:
         """Async streaming — default yields the full response as one chunk."""

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/base.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Core: Provider ABCs
+# GraphRAG SDK — Core: Provider ABCs
 # Thin abstract interfaces for Embedders and LLMs.
 
 from __future__ import annotations
@@ -7,9 +7,9 @@ import asyncio
 import logging
 import random
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
-from collections.abc import AsyncIterator
 
 from pydantic import BaseModel
 
@@ -34,16 +34,23 @@ class LLMBatchItem:
 class Embedder(ABC):
     """Abstract base class for all embedding providers.
 
-    Subclasses must implement ``embed_query``.  The async variant
-    defaults to running the sync method in a thread pool — override
-    ``aembed_query`` for true async providers.
+    Subclasses must implement ``embed_query`` and expose a
+    ``model_name`` property identifying the model (used for
+    graph config validation).
 
     Example::
 
         class OpenAIEmbedder(Embedder):
+            model_name = "text-embedding-ada-002"
             def embed_query(self, text: str, **kw) -> list[float]:
                 return openai.embed(text)
     """
+
+    @property
+    @abstractmethod
+    def model_name(self) -> str:
+        """Identifier of the embedding model (e.g. ``"text-embedding-ada-002"``)."""
+        ...
 
     @abstractmethod
     def embed_query(self, text: str, **kwargs: Any) -> list[float]:

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/base.py
@@ -41,7 +41,9 @@ class Embedder(ABC):
     Example::
 
         class OpenAIEmbedder(Embedder):
-            model_name = "text-embedding-ada-002"
+            @property
+            def model_name(self) -> str:
+                return "text-embedding-ada-002"
             def embed_query(self, text: str, **kw) -> list[float]:
                 return openai.embed(text)
     """

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/litellm.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/litellm.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — LiteLLM Provider
+# GraphRAG SDK — LiteLLM Provider
 # LLM and Embedder backed by LiteLLM (100+ providers via unified interface).
 # Requires: pip install graphrag-sdk[litellm]
 
@@ -9,11 +9,11 @@ import logging
 from typing import Any
 
 from graphrag_sdk.core.models import LLMResponse
-from graphrag_sdk.core.providers.base import Embedder, LLMInterface
 from graphrag_sdk.core.providers._retry import (
     binary_split_retry_async,
     binary_split_retry_sync,
 )
+from graphrag_sdk.core.providers.base import Embedder, LLMInterface
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +139,11 @@ class LiteLLMEmbedder(Embedder):
         self._api_version = api_version
         self.batch_size = batch_size
         self._extra = kwargs
+
+    @property
+    def model_name(self) -> str:
+        """Identifier of the embedding model."""
+        return self.model
 
     def _embedding_kwargs(self, input_: str | list[str], **kwargs: Any) -> dict[str, Any]:
         kw: dict[str, Any] = {

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/litellm.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/litellm.py
@@ -138,6 +138,8 @@ class LiteLLM(LLMInterface):
         **kwargs: Any,
     ) -> LLMResponse:
         """Native multi-turn completion via LiteLLM."""
+        if max_retries < 1:
+            raise ValueError("max_retries must be >= 1")
         try:
             import litellm
         except ImportError:

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/litellm.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/litellm.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from typing import Any
 
-from graphrag_sdk.core.models import LLMResponse
+from graphrag_sdk.core.models import ChatMessage, LLMResponse
 from graphrag_sdk.core.providers._retry import (
     binary_split_retry_async,
     binary_split_retry_sync,
@@ -97,6 +97,60 @@ class LiteLLM(LLMInterface):
         for attempt in range(max_retries):
             try:
                 response = await litellm.acompletion(**self._completion_kwargs(prompt, **kwargs))
+                content = response.choices[0].message.content or ""
+                return LLMResponse(content=content)
+            except Exception as exc:
+                last_exc = exc
+                if attempt < max_retries - 1:
+                    delay = 2**attempt
+                    logger.warning(
+                        f"LiteLLM call failed (attempt {attempt + 1}/{max_retries}), "
+                        f"retrying in {delay}s: {exc}"
+                    )
+                    await asyncio.sleep(delay)
+        raise last_exc  # type: ignore[misc]
+
+    def _messages_completion_kwargs(
+        self, messages: list[ChatMessage], **kwargs: Any
+    ) -> dict[str, Any]:
+        kw: dict[str, Any] = {
+            "model": self.model_name,
+            "messages": [m.to_dict() for m in messages],
+            "temperature": self._temperature,
+            **self._extra,
+            **kwargs,
+        }
+        if self._api_key is not None:
+            kw["api_key"] = self._api_key
+        if self._api_base is not None:
+            kw["api_base"] = self._api_base
+        if self._api_version is not None:
+            kw["api_version"] = self._api_version
+        if self._max_tokens is not None:
+            kw["max_tokens"] = self._max_tokens
+        return kw
+
+    async def ainvoke_messages(
+        self,
+        messages: list[ChatMessage],
+        *,
+        max_retries: int = 3,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Native multi-turn completion via LiteLLM."""
+        try:
+            import litellm
+        except ImportError:
+            raise ImportError(
+                "LiteLLM is required for the LiteLLM provider. "
+                "Install with: pip install graphrag-sdk[litellm]"
+            )
+        last_exc: Exception | None = None
+        for attempt in range(max_retries):
+            try:
+                response = await litellm.acompletion(
+                    **self._messages_completion_kwargs(messages, **kwargs)
+                )
                 content = response.choices[0].message.content or ""
                 return LLMResponse(content=content)
             except Exception as exc:

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/openrouter.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/openrouter.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — OpenRouter Provider
+# GraphRAG SDK — OpenRouter Provider
 # LLM and Embedder backed by OpenRouter (uses the OpenAI SDK).
 # Requires: pip install graphrag-sdk[openrouter]
 
@@ -10,11 +10,11 @@ import os
 from typing import Any
 
 from graphrag_sdk.core.models import LLMResponse
-from graphrag_sdk.core.providers.base import Embedder, LLMInterface
 from graphrag_sdk.core.providers._retry import (
     binary_split_retry_async,
     binary_split_retry_sync,
 )
+from graphrag_sdk.core.providers.base import Embedder, LLMInterface
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +151,11 @@ class OpenRouterEmbedder(Embedder):
         self._extra_headers = extra_headers or {}
         self._client = None
         self._async_client = None
+
+    @property
+    def model_name(self) -> str:
+        """Identifier of the embedding model."""
+        return self.model
 
     def _get_client(self):
         if self._client is None:

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/openrouter.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/openrouter.py
@@ -134,6 +134,8 @@ class OpenRouterLLM(LLMInterface):
         **kwargs: Any,
     ) -> LLMResponse:
         """Native multi-turn completion via OpenRouter."""
+        if max_retries < 1:
+            raise ValueError("max_retries must be >= 1")
         client = self._get_async_client()
         create_kwargs: dict[str, Any] = {
             "model": self.model_name,

--- a/graphrag_sdk/src/graphrag_sdk/core/providers/openrouter.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/providers/openrouter.py
@@ -9,7 +9,7 @@ import logging
 import os
 from typing import Any
 
-from graphrag_sdk.core.models import LLMResponse
+from graphrag_sdk.core.models import ChatMessage, LLMResponse
 from graphrag_sdk.core.providers._retry import (
     binary_split_retry_async,
     binary_split_retry_sync,
@@ -104,6 +104,40 @@ class OpenRouterLLM(LLMInterface):
         create_kwargs: dict[str, Any] = {
             "model": self.model_name,
             "messages": [{"role": "user", "content": prompt}],
+            "temperature": self._temperature,
+            **kwargs,
+        }
+        if self._max_tokens is not None:
+            create_kwargs.setdefault("max_tokens", self._max_tokens)
+        last_exc: Exception | None = None
+        for attempt in range(max_retries):
+            try:
+                response = await client.chat.completions.create(**create_kwargs)
+                content = response.choices[0].message.content or ""
+                return LLMResponse(content=content)
+            except Exception as exc:
+                last_exc = exc
+                if attempt < max_retries - 1:
+                    delay = 2**attempt
+                    logger.warning(
+                        f"OpenRouter call failed (attempt {attempt + 1}/{max_retries}), "
+                        f"retrying in {delay}s: {exc}"
+                    )
+                    await asyncio.sleep(delay)
+        raise last_exc  # type: ignore[misc]
+
+    async def ainvoke_messages(
+        self,
+        messages: list[ChatMessage],
+        *,
+        max_retries: int = 3,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Native multi-turn completion via OpenRouter."""
+        client = self._get_async_client()
+        create_kwargs: dict[str, Any] = {
+            "model": self.model_name,
+            "messages": [m.to_dict() for m in messages],
             "temperature": self._temperature,
             **kwargs,
         }

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion
+# GraphRAG SDK — Ingestion
 # Knowledge graph construction: loaders, chunkers, extractors, resolvers, pipeline.
 
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Chunking Strategies
+# GraphRAG SDK — Ingestion: Chunking Strategies
 
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
 from graphrag_sdk.ingestion.chunking_strategies.callable_chunking import CallableChunking

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/base.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Chunking Strategy ABC
+# GraphRAG SDK — Ingestion: Chunking Strategy ABC
 # Pattern: Strategy — every text splitting approach implements this interface.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/callable_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/callable_chunking.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Callable Chunking Adapter
+# GraphRAG SDK — Ingestion: Callable Chunking Adapter
 #
 # Adapts any user-supplied function into the SDK's ChunkingStrategy interface.
 # This lets users plug in any chunking framework (LlamaIndex, LangChain,

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Contextual Chunking
+# GraphRAG SDK — Ingestion: Contextual Chunking
 #
 # Anthropic's approach: for each chunk, ask the LLM to generate a
 # short context summary ("This chunk is from Chapter 3, describing

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/fixed_size.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/fixed_size.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Fixed-Size Chunking
+# GraphRAG SDK — Ingestion: Fixed-Size Chunking
 
 from __future__ import annotations
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/sentence_token_cap.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/sentence_token_cap.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Sentence + Token Cap Chunking
+# GraphRAG SDK — Ingestion: Sentence + Token Cap Chunking
 #
 # Best of both worlds: never splits mid-sentence (sentence boundaries via
 # regex) AND enforces a token cap per chunk (via tiktoken).

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Extraction Strategies
+# GraphRAG SDK — Ingestion: Extraction Strategies
 
 from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
 from graphrag_sdk.ingestion.extraction_strategies.coref_resolvers import (

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/base.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Extraction Strategy ABC
+# GraphRAG SDK — Ingestion: Extraction Strategy ABC
 # Pattern: Strategy — different extraction approaches implement this interface.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/coref_resolvers.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/coref_resolvers.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Extraction: Pluggable Coreference Resolvers
+# GraphRAG SDK — Extraction: Pluggable Coreference Resolvers
 # ABC + concrete implementations for coreference resolution
 # as an optional pre-processing step in GraphExtraction.
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Extraction: Entity Extractors
+# GraphRAG SDK — Extraction: Entity Extractors
 # ABC + built-in implementations for step 1 entity NER.
 #
 # Also exports shared entity utilities (constants, ID computation,

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Two-Step Extraction Strategy
+# GraphRAG SDK — Ingestion: Two-Step Extraction Strategy
 # Composable 2-step extraction: pluggable entity NER (step 1) +
 # LLM verify/enrich/relationship extraction (step 2).
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Loaders
+# GraphRAG SDK — Ingestion: Loaders
 
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/base.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Loader Strategy ABC
+# GraphRAG SDK — Ingestion: Loader Strategy ABC
 # Pattern: Strategy — every data source adapter implements this interface.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/pdf_loader.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/pdf_loader.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: PDF Loader
+# GraphRAG SDK — Ingestion: PDF Loader
 
 from __future__ import annotations
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/text_loader.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/text_loader.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Text File Loader
+# GraphRAG SDK — Ingestion: Text File Loader
 
 from __future__ import annotations
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/pipeline.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/pipeline.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Pipeline Orchestrator
+# GraphRAG SDK — Ingestion: Pipeline Orchestrator
 # Pattern: Sequential Pipeline — domain-specific linear orchestrator.
 # Flow: Load → Chunk → Lexical Graph (MANDATORY) → Extract → Prune → Resolve → Write + Index
 #

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Resolution Strategies
+# GraphRAG SDK — Ingestion: Resolution Strategies
 
 from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
 from graphrag_sdk.ingestion.resolution_strategies.description_merge import (

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Resolution Strategy ABC
+# GraphRAG SDK — Ingestion: Resolution Strategy ABC
 # Pattern: Strategy — different deduplication approaches implement this interface.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/description_merge.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/description_merge.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Description Merge Resolution
+# GraphRAG SDK — Ingestion: Description Merge Resolution
 # Deduplicates entities by normalized name and merges their descriptions.
 # Uses LLM summarisation when the number of descriptions exceeds a threshold.
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/exact_match.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/exact_match.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Exact Match Resolution
+# GraphRAG SDK — Ingestion: Exact Match Resolution
 # Origin: Neo4j SinglePropertyExactMatchResolver — simplified.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/llm_verified_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/llm_verified_resolution.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: LLM-Verified Resolution
+# GraphRAG SDK — Ingestion: LLM-Verified Resolution
 # Three-tier deduplication:
 #   Phase 1: normalized name exact-match merge (free)
 #   Phase 2: embedding cosine similarity
@@ -288,6 +288,11 @@ class LLMVerifiedResolution(ResolutionStrategy):
             # ANN via hnswlib HNSW (O(N log N)) — no OpenMP, no macOS deadlock.
             top_k = min(self.ann_top_k, n_nodes - 1)
             dim = mat_normed.shape[1]
+            if _hnswlib is None:
+                raise ImportError(
+                    "hnswlib is required for LLMVerifiedResolution embedding merge. "
+                    "Install with: pip install hnswlib"
+                )
             hnsw_index = _hnswlib.Index(space="ip", dim=dim)
             hnsw_index.init_index(max_elements=n_nodes, ef_construction=200, M=32)
             hnsw_index.set_ef(max(top_k + 1, 64))

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/semantic_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/semantic_resolution.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Ingestion: Semantic Resolution
+# GraphRAG SDK — Ingestion: Semantic Resolution
 # Groups entities by (normalized_name, label) to prevent cross-type merges,
 # then uses embeddings for near-duplicate detection within same-label groups.
 
@@ -211,6 +211,11 @@ class SemanticResolution(ResolutionStrategy):
                 top_k,
             )
             dim = mat_normed.shape[1]
+            if _hnswlib is None:
+                raise ImportError(
+                    "hnswlib is required for SemanticResolution fuzzy merge. "
+                    "Install with: pip install hnswlib"
+                )
             hnsw_index = _hnswlib.Index(space="ip", dim=dim)
             hnsw_index.init_index(max_elements=n, ef_construction=200, M=32)
             hnsw_index.set_ef(max(top_k + 1, 64))

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval
+# GraphRAG SDK — Retrieval
 # Intelligent search: strategies, routing, reranking.
 
 from graphrag_sdk.retrieval.reranking_strategies.base import RerankingStrategy

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/reranking_strategies/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/reranking_strategies/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Reranking Strategies
+# GraphRAG SDK — Retrieval: Reranking Strategies
 
 from graphrag_sdk.retrieval.reranking_strategies.base import RerankingStrategy
 from graphrag_sdk.retrieval.reranking_strategies.cosine import CosineReranker

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/reranking_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/reranking_strategies/base.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Reranking Strategy ABC
+# GraphRAG SDK — Retrieval: Reranking Strategy ABC
 # Pattern: Strategy — composable result quality layer.
 # Origin: User design — absent in Neo4j.
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/reranking_strategies/cosine.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/reranking_strategies/cosine.py
@@ -1,9 +1,10 @@
-# GraphRAG SDK 2.0 — Retrieval: Cosine Reranker
+# GraphRAG SDK — Retrieval: Cosine Reranker
 # Embedding-based reranking using cosine similarity.
 
 from __future__ import annotations
 
 import logging
+
 import numpy as np
 
 from graphrag_sdk.core.context import Context

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/router.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/router.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Semantic Router
+# GraphRAG SDK — Retrieval: Semantic Router
 # Classifies query intent and selects the appropriate retrieval strategy.
 # Origin: User design — absent in Neo4j (which forces a single retriever at init).
 #

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Strategies
+# GraphRAG SDK — Retrieval: Strategies
 
 from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
 from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/base.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Strategy ABC (Template Method)
+# GraphRAG SDK — Retrieval: Strategy ABC (Template Method)
 # Pattern: Template Method — base handles telemetry/validation/formatting,
 #          subclasses implement only ``_execute()``.
 # Origin: Neo4j Retriever.search() → get_search_results() pattern, upgraded

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/chunk_retrieval.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/chunk_retrieval.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Chunk Retrieval
+# GraphRAG SDK — Retrieval: Chunk Retrieval
 # 4-path chunk retrieval: fulltext + vector + MENTIONED_IN + 2-hop.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/cypher_generation.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/cypher_generation.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Text-to-Cypher Generation
+# GraphRAG SDK — Retrieval: Text-to-Cypher Generation
 # Adapted from FalkorDB/GraphRAG-SDK upstream for the unified RELATES schema.
 # Generates read-only Cypher queries from natural language questions.
 #
@@ -63,8 +63,11 @@ Person, Organization, Technology, Product, Location, Date, Event, Concept, Law, 
 - NEXT_CHUNK: connects Chunk to next sequential Chunk
 
 ## FalkorDB-specific rules (CRITICAL — violating these causes execution errors):
-1. Do NOT use shortestPath() or allShortestPaths() — FalkorDB returns Path objects that cause "Type mismatch: expected List or Null but was Path".
-2. Every column in RETURN must have a UNIQUE name. Use aliases: `RETURN a.name AS a_name, b.name AS b_name` — NEVER `RETURN a.name, b.name` without aliases when both are `.name`.
+1. Do NOT use shortestPath() or allShortestPaths() — FalkorDB returns
+   Path objects that cause "Type mismatch: expected List or Null but was Path".
+2. Every column in RETURN must have a UNIQUE name. Use aliases:
+   `RETURN a.name AS a_name, b.name AS b_name` — NEVER return
+   columns without aliases when both are `.name`.
 3. Do NOT use the `path =` variable syntax. Instead use explicit node/edge variables.
 4. Keep queries simple: 1-2 MATCH clauses maximum. Add LIMIT 25 to prevent huge result sets.
 5. Use CONTAINS for fuzzy name matching: `WHERE e.name CONTAINS 'keyword'`
@@ -100,7 +103,8 @@ Question: "How are Alice and the castle connected?"
 ```cypher
 MATCH (a:__Entity__)-[r1:RELATES]-(mid:__Entity__)-[r2:RELATES]-(b:__Entity__)
 WHERE a.name CONTAINS 'Alice' AND b.name CONTAINS 'castle'
-RETURN a.name AS from_entity, r1.rel_type AS rel1, mid.name AS via_entity, r2.rel_type AS rel2, b.name AS to_entity
+RETURN a.name AS from_entity, r1.rel_type AS rel1,
+  mid.name AS via_entity, r2.rel_type AS rel2, b.name AS to_entity
 LIMIT 15
 ```
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Entity Discovery
+# GraphRAG SDK — Retrieval: Entity Discovery
 # 2-path entity discovery: Cypher CONTAINS + fulltext search,
 # with optional sibling expansion for enumeration queries.
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/local.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/local.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Local Strategy
+# GraphRAG SDK — Retrieval: Local Strategy
 # Vector similarity search + 1-hop graph traversal.
 # The default retrieval strategy for v1.
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Multi-Path Strategy (Lean)
+# GraphRAG SDK — Retrieval: Multi-Path Strategy (Lean)
 # Thin orchestrator combining RELATES edge vector search for facts +
 # entity entry points, 2-path entity discovery, 4-path chunk retrieval,
 # and cosine reranking.  Phase logic lives in sub-modules.
@@ -22,6 +22,9 @@ from graphrag_sdk.retrieval.strategies.chunk_retrieval import (
     fetch_chunk_documents,
     retrieve_chunks,
 )
+from graphrag_sdk.retrieval.strategies.cypher_generation import (
+    execute_cypher_retrieval,
+)
 from graphrag_sdk.retrieval.strategies.entity_discovery import (
     discover_entities,
     expand_sibling_entities,
@@ -30,9 +33,6 @@ from graphrag_sdk.retrieval.strategies.entity_discovery import (
 )
 from graphrag_sdk.retrieval.strategies.relationship_expansion import (
     expand_relationships,
-)
-from graphrag_sdk.retrieval.strategies.cypher_generation import (
-    execute_cypher_retrieval,
 )
 from graphrag_sdk.retrieval.strategies.result_assembly import (
     assemble_raw_result,

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/relationship_expansion.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/relationship_expansion.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Relationship Expansion
+# GraphRAG SDK — Retrieval: Relationship Expansion
 # 1-hop + 2-hop relationship traversal from top entities.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/result_assembly.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/result_assembly.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Retrieval: Result Assembly
+# GraphRAG SDK — Retrieval: Result Assembly
 # Cosine reranking, question-type detection, and structured result assembly.
 
 from __future__ import annotations

--- a/graphrag_sdk/src/graphrag_sdk/storage/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Storage
+# GraphRAG SDK — Storage
 # Data access layer: graph store and vector store.
 
 from graphrag_sdk.storage.deduplicator import EntityDeduplicator

--- a/graphrag_sdk/src/graphrag_sdk/storage/deduplicator.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/deduplicator.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Storage: Entity Deduplicator
+# GraphRAG SDK — Storage: Entity Deduplicator
 # Two-phase entity deduplication: exact name match + optional fuzzy embedding.
 # Preserves label-aware grouping to prevent cross-type merging.
 

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Storage: Graph Store
+# GraphRAG SDK — Storage: Graph Store
 # Pattern: Repository — all Cypher operations behind clean methods.
 # Origin: Neo4j batched upserts + User design for storage separation.
 #

--- a/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Storage: Vector Store
+# GraphRAG SDK — Storage: Vector Store
 # Native vector index management + search for FalkorDB.
 # Pattern: Repository — abstracts all vector operations.
 
@@ -423,7 +423,8 @@ class VectorStore:
         """
         # Try edge vector index query first (FalkorDB >= 4.2)
         query = (
-            "CALL db.idx.vector.queryRelationships('RELATES', 'embedding', $top_k, vecf32($vector)) "
+            "CALL db.idx.vector.queryRelationships("
+            "'RELATES', 'embedding', $top_k, vecf32($vector)) "
             "YIELD relationship AS r, score "
             "RETURN r.src_name AS src, r.rel_type AS type, "
             "r.tgt_name AS tgt, r.fact AS fact, score "

--- a/graphrag_sdk/src/graphrag_sdk/telemetry/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/telemetry/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Telemetry
+# GraphRAG SDK — Telemetry
 
 from graphrag_sdk.telemetry.tracer import Tracer
 

--- a/graphrag_sdk/src/graphrag_sdk/telemetry/tracer.py
+++ b/graphrag_sdk/src/graphrag_sdk/telemetry/tracer.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Telemetry: Tracer
+# GraphRAG SDK — Telemetry: Tracer
 # OpenTelemetry-compatible span tracking for enterprise observability.
 # Origin: User design — first-class telemetry module (replaces Neo4j's custom EventNotifier).
 
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
-from collections.abc import Generator
 
 logger = logging.getLogger(__name__)
 

--- a/graphrag_sdk/src/graphrag_sdk/utils/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/utils/__init__.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Utils
+# GraphRAG SDK — Utils
 
 from graphrag_sdk.utils.cypher import sanitize_cypher_label
 from graphrag_sdk.utils.graph_viz import GraphVisualizer

--- a/graphrag_sdk/src/graphrag_sdk/utils/cypher.py
+++ b/graphrag_sdk/src/graphrag_sdk/utils/cypher.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Utils: Cypher Sanitization
+# GraphRAG SDK — Utils: Cypher Sanitization
 # Prevents Cypher injection via label/type interpolation.
 
 

--- a/graphrag_sdk/src/graphrag_sdk/utils/graph_viz.py
+++ b/graphrag_sdk/src/graphrag_sdk/utils/graph_viz.py
@@ -1,4 +1,4 @@
-# GraphRAG SDK 2.0 — Utils: Graph Visualization
+# GraphRAG SDK — Utils: Graph Visualization
 # Debugging and visualization utilities for the knowledge graph.
 
 from __future__ import annotations

--- a/graphrag_sdk/tests/conftest.py
+++ b/graphrag_sdk/tests/conftest.py
@@ -53,11 +53,18 @@ class MockLLM(LLMInterface):
         super().__init__(model_name=model_name)
         self._responses = responses or ['{"nodes": [], "relationships": []}']
         self._call_index = 0
+        self.last_messages: list | None = None  # track ainvoke_messages calls
 
     def invoke(self, prompt: str, **kwargs: Any) -> LLMResponse:
         response = self._responses[min(self._call_index, len(self._responses) - 1)]
         self._call_index += 1
         return LLMResponse(content=response)
+
+    async def ainvoke_messages(self, messages, *, max_retries=3, **kwargs):
+        from graphrag_sdk.core.models import ChatMessage
+
+        self.last_messages = messages
+        return self.invoke("")
 
 
 class MockLLMWithGraphExtraction(MockLLM):

--- a/graphrag_sdk/tests/conftest.py
+++ b/graphrag_sdk/tests/conftest.py
@@ -32,6 +32,10 @@ class MockEmbedder(Embedder):
         self.dimension = dimension
         self.call_count = 0
 
+    @property
+    def model_name(self) -> str:
+        return "mock-embedder"
+
     def embed_query(self, text: str, **kwargs: Any) -> list[float]:
         self.call_count += 1
         h = hash(text) % (10**9)

--- a/graphrag_sdk/tests/conftest.py
+++ b/graphrag_sdk/tests/conftest.py
@@ -61,8 +61,6 @@ class MockLLM(LLMInterface):
         return LLMResponse(content=response)
 
     async def ainvoke_messages(self, messages, *, max_retries=3, **kwargs):
-        from graphrag_sdk.core.models import ChatMessage
-
         self.last_messages = messages
         return self.invoke("")
 

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -12,6 +12,7 @@ from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.exceptions import ConfigError
 from graphrag_sdk.core.models import (
+    ChatMessage,
     GraphSchema,
     IngestionResult,
     LLMResponse,
@@ -395,7 +396,8 @@ class TestGraphRAGCompletion:
         assert result.metadata["num_context_items"] == 1
         assert result.metadata["has_history"] is False
 
-    async def test_completion_with_history(self, mock_conn, embedder):
+    async def test_completion_with_history_dicts(self, mock_conn, embedder):
+        """History as dicts should use ainvoke_messages natively."""
         llm = MockLLM(responses=["Continued answer."])
         g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
         mock_strategy = MagicMock(spec=RetrievalStrategy)
@@ -415,6 +417,99 @@ class TestGraphRAGCompletion:
         )
         assert result.answer == "Continued answer."
         assert result.metadata["has_history"] is True
+        # Should have used ainvoke_messages, not ainvoke
+        assert llm.last_messages is not None
+        assert len(llm.last_messages) == 4  # system + 2 history + user question
+        assert llm.last_messages[0].role == "system"
+        assert llm.last_messages[1].role == "user"
+        assert llm.last_messages[1].content == "First question"
+        assert llm.last_messages[2].role == "assistant"
+        assert llm.last_messages[3].role == "user"
+        assert llm.last_messages[3].content == "Follow up question"
+
+    async def test_completion_with_history_chatmessage_objects(self, mock_conn, embedder):
+        """History as ChatMessage objects should work."""
+        llm = MockLLM(responses=["ChatMessage answer."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(
+                items=[RetrieverResultItem(content="c")]
+            )
+        )
+        g._retrieval_strategy = mock_strategy
+
+        result = await g.completion(
+            "Follow up",
+            history=[
+                ChatMessage(role="system", content="You are helpful."),
+                ChatMessage(role="user", content="Hi"),
+                ChatMessage(role="assistant", content="Hello!"),
+            ],
+        )
+        assert result.answer == "ChatMessage answer."
+        assert llm.last_messages is not None
+        # system (RAG prompt) + system (from history) + user + assistant + user question
+        assert len(llm.last_messages) == 5
+
+    async def test_completion_history_invalid_role_raises(self, mock_conn, embedder):
+        """Invalid role in history should raise ValueError."""
+        llm = MockLLM(responses=["unused"])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(items=[RetrieverResultItem(content="c")])
+        )
+        g._retrieval_strategy = mock_strategy
+
+        with pytest.raises(ValueError, match="invalid role 'robot'"):
+            await g.completion(
+                "test?",
+                history=[{"role": "robot", "content": "beep boop"}],
+            )
+
+    async def test_completion_history_missing_keys_raises(self, mock_conn, embedder):
+        """History dict missing 'content' should raise ValueError."""
+        llm = MockLLM(responses=["unused"])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(items=[RetrieverResultItem(content="c")])
+        )
+        g._retrieval_strategy = mock_strategy
+
+        with pytest.raises(ValueError, match="must have 'role' and 'content'"):
+            await g.completion(
+                "test?",
+                history=[{"role": "user"}],
+            )
+
+    async def test_completion_history_wrong_type_raises(self, mock_conn, embedder):
+        """Non-dict, non-ChatMessage in history should raise TypeError."""
+        llm = MockLLM(responses=["unused"])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(items=[RetrieverResultItem(content="c")])
+        )
+        g._retrieval_strategy = mock_strategy
+
+        with pytest.raises(TypeError, match="expected ChatMessage or dict"):
+            await g.completion("test?", history=["not a dict"])
+
+    async def test_completion_no_history_uses_ainvoke(self, mock_conn, embedder):
+        """Without history, completion should use ainvoke (not ainvoke_messages)."""
+        llm = MockLLM(responses=["Single-turn answer."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(items=[RetrieverResultItem(content="c")])
+        )
+        g._retrieval_strategy = mock_strategy
+
+        result = await g.completion("test?")
+        assert result.answer == "Single-turn answer."
+        assert llm.last_messages is None  # ainvoke_messages was NOT called
 
     async def test_completion_return_context(self, mock_conn, embedder):
         llm = MockLLM(responses=["Answer."])

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -10,15 +10,17 @@ import pytest
 from graphrag_sdk.api.main import GraphRAG
 from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
 from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.exceptions import ConfigError
 from graphrag_sdk.core.models import (
     GraphSchema,
+    IngestionResult,
     LLMResponse,
     RagResult,
+    RawSearchResult,
     RetrieverResult,
     RetrieverResultItem,
 )
 from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
-from graphrag_sdk.core.models import RawSearchResult
 
 from .conftest import MockEmbedder, MockLLM
 
@@ -308,3 +310,240 @@ class TestGraphRAGSyncWrappers:
         f.write_text("Sync ingest content.")
         result = g.ingest_sync(str(f))
         assert result is not None
+
+    def test_retrieve_sync(self, mock_conn, embedder):
+        llm = MockLLM(responses=["unused"])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(items=[RetrieverResultItem(content="c")])
+        )
+        g._retrieval_strategy = mock_strategy
+        result = g.retrieve_sync("test?")
+        assert isinstance(result, RetrieverResult)
+        assert len(result.items) == 1
+
+    def test_completion_sync(self, mock_conn, embedder):
+        llm = MockLLM(responses=["Sync completion."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(items=[RetrieverResultItem(content="c")])
+        )
+        g._retrieval_strategy = mock_strategy
+        result = g.completion_sync("test?")
+        assert result.answer == "Sync completion."
+
+
+class TestGraphRAGRetrieve:
+    async def test_retrieve_returns_retriever_result(self, mock_conn, embedder):
+        llm = MockLLM(responses=["should not be called"])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(
+                items=[RetrieverResultItem(content="context", score=0.9)]
+            )
+        )
+        g._retrieval_strategy = mock_strategy
+
+        result = await g.retrieve("question?")
+        assert isinstance(result, RetrieverResult)
+        assert len(result.items) == 1
+        assert result.items[0].content == "context"
+        # LLM should NOT have been called
+        assert llm._call_index == 0
+
+    async def test_retrieve_with_reranker(self, mock_conn, embedder):
+        from graphrag_sdk.retrieval.reranking_strategies.base import RerankingStrategy
+
+        llm = MockLLM(responses=["should not be called"])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(items=[
+                RetrieverResultItem(content="A", score=0.5),
+                RetrieverResultItem(content="B", score=0.9),
+            ])
+        )
+        g._retrieval_strategy = mock_strategy
+
+        class FlipReranker(RerankingStrategy):
+            async def rerank(self, query, result, ctx):
+                return RetrieverResult(items=list(reversed(result.items)))
+
+        result = await g.retrieve("test", reranker=FlipReranker())
+        assert result.items[0].content == "B"
+        assert llm._call_index == 0
+
+
+class TestGraphRAGCompletion:
+    async def test_completion_basic(self, mock_conn, embedder):
+        llm = MockLLM(responses=["The answer is 42."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(
+                items=[RetrieverResultItem(content="Context chunk", score=0.9)]
+            )
+        )
+        g._retrieval_strategy = mock_strategy
+
+        result = await g.completion("What is the answer?")
+        assert isinstance(result, RagResult)
+        assert result.answer == "The answer is 42."
+        assert result.metadata["num_context_items"] == 1
+        assert result.metadata["has_history"] is False
+
+    async def test_completion_with_history(self, mock_conn, embedder):
+        llm = MockLLM(responses=["Continued answer."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(
+                items=[RetrieverResultItem(content="c")]
+            )
+        )
+        g._retrieval_strategy = mock_strategy
+
+        result = await g.completion(
+            "Follow up question",
+            history=[
+                {"role": "user", "content": "First question"},
+                {"role": "assistant", "content": "First answer"},
+            ],
+        )
+        assert result.answer == "Continued answer."
+        assert result.metadata["has_history"] is True
+
+    async def test_completion_return_context(self, mock_conn, embedder):
+        llm = MockLLM(responses=["Answer."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(
+                items=[RetrieverResultItem(content="chunk")]
+            )
+        )
+        g._retrieval_strategy = mock_strategy
+
+        result = await g.completion("q?", return_context=True)
+        assert result.retriever_result is not None
+
+    async def test_completion_custom_prompt(self, mock_conn, embedder):
+        llm = MockLLM(responses=["Custom answer."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(
+                items=[RetrieverResultItem(content="c")]
+            )
+        )
+        g._retrieval_strategy = mock_strategy
+
+        template = "Context: {context}\nQ: {question}\nA:"
+        result = await g.completion("test?", prompt_template=template)
+        assert llm._call_index == 1
+
+
+class TestGraphRAGBatchIngest:
+    async def test_ingest_list(self, graphrag, tmp_path):
+        f1 = tmp_path / "a.txt"
+        f2 = tmp_path / "b.txt"
+        f1.write_text("Document A content.")
+        f2.write_text("Document B content.")
+        results = await graphrag.ingest([str(f1), str(f2)])
+        assert isinstance(results, list)
+        assert len(results) == 2
+        for r in results:
+            assert isinstance(r, IngestionResult)
+
+    async def test_ingest_list_with_text_raises(self, graphrag):
+        with pytest.raises(ValueError, match="text.*cannot be used with a list"):
+            await graphrag.ingest(["a", "b"], text="should fail")
+
+    async def test_ingest_single_still_works(self, graphrag, tmp_path):
+        f = tmp_path / "single.txt"
+        f.write_text("Single document.")
+        result = await graphrag.ingest(str(f))
+        assert isinstance(result, IngestionResult)
+
+
+class TestGraphRAGQueryDeprecation:
+    async def test_query_emits_deprecation(self, mock_conn, embedder):
+        llm = MockLLM(responses=["Answer."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(
+                items=[RetrieverResultItem(content="c")]
+            )
+        )
+        g._retrieval_strategy = mock_strategy
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            await g.query("test?")
+
+    def test_query_sync_emits_deprecation(self, mock_conn, embedder):
+        llm = MockLLM(responses=["Answer."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(
+                items=[RetrieverResultItem(content="c")]
+            )
+        )
+        g._retrieval_strategy = mock_strategy
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            g.query_sync("test?")
+
+
+class TestGraphRAGConfigNode:
+    async def test_config_mismatch_raises(self, mock_conn, embedder):
+        """Mismatched embedding model should raise ConfigError."""
+        llm = MockLLM(responses=["unused"])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+
+        # Simulate stored config with a different model
+        config_result = MagicMock()
+        config_result.result_set = [["different-model", 1536]]
+        g.graph_store.query_raw = AsyncMock(return_value=config_result)
+
+        with pytest.raises(ConfigError, match="Embedding model mismatch"):
+            await g.retrieve("test?")
+
+    async def test_config_match_passes(self, mock_conn, embedder):
+        """Matching embedding model should pass validation."""
+        llm = MockLLM(responses=["unused"])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+
+        # Simulate stored config matching the mock embedder
+        config_result = MagicMock()
+        config_result.result_set = [["mock-embedder", 1536]]
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(items=[])
+        )
+        g._retrieval_strategy = mock_strategy
+        g.graph_store.query_raw = AsyncMock(return_value=config_result)
+
+        result = await g.retrieve("test?")
+        assert isinstance(result, RetrieverResult)
+
+    async def test_no_config_node_passes(self, mock_conn, embedder):
+        """Empty graph (no config node) should pass validation."""
+        llm = MockLLM(responses=["unused"])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+
+        empty_result = MagicMock()
+        empty_result.result_set = []
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(items=[])
+        )
+        g._retrieval_strategy = mock_strategy
+        g.graph_store.query_raw = AsyncMock(return_value=empty_result)
+
+        result = await g.retrieve("test?")
+        assert isinstance(result, RetrieverResult)

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -540,6 +540,36 @@ class TestGraphRAGCompletion:
         result = await g.completion("test?", prompt_template=template)
         assert llm._call_index == 1
 
+    async def test_completion_prompt_template_ignored_with_history(self, mock_conn, embedder):
+        """prompt_template should be ignored in multi-turn mode (no KeyError)."""
+        llm = MockLLM(responses=["Multi-turn answer."])
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        mock_strategy = MagicMock(spec=RetrievalStrategy)
+        mock_strategy.search = AsyncMock(
+            return_value=RetrieverResult(
+                items=[RetrieverResultItem(content="c")]
+            )
+        )
+        g._retrieval_strategy = mock_strategy
+
+        # This template has {question} — would KeyError if used in multi-turn
+        template = "Context: {context}\nQ: {question}\nA:"
+        result = await g.completion(
+            "follow up?",
+            history=[{"role": "user", "content": "hi"}],
+            prompt_template=template,
+        )
+        assert result.answer == "Multi-turn answer."
+        # Should have used ainvoke_messages, not ainvoke
+        assert llm.last_messages is not None
+
+
+class TestGraphRAGBatchIngestValidation:
+    async def test_ingest_batch_max_concurrent_zero_raises(self, mock_conn, embedder, llm):
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder)
+        with pytest.raises(ValueError, match="max_concurrent must be >= 1"):
+            await g.ingest(["a.txt", "b.txt"], max_concurrent=0)
+
 
 class TestGraphRAGBatchIngest:
     async def test_ingest_list(self, graphrag, tmp_path):

--- a/graphrag_sdk/tests/test_integration.py
+++ b/graphrag_sdk/tests/test_integration.py
@@ -9,7 +9,7 @@ class TestTopLevelImports:
 
     def test_version(self):
         from graphrag_sdk import __version__
-        assert __version__ == "2.0.0a1"
+        assert __version__ == "1.0.0"
 
     def test_facade(self):
         from graphrag_sdk import GraphRAG

--- a/graphrag_sdk/tests/test_llm_verified_resolution.py
+++ b/graphrag_sdk/tests/test_llm_verified_resolution.py
@@ -22,6 +22,10 @@ class ControlledEmbedder(Embedder):
         self._vectors = vectors
         self._default_dim = default_dim
 
+    @property
+    def model_name(self) -> str:
+        return "controlled-test-embedder"
+
     def embed_query(self, text: str, **kwargs) -> list[float]:
         return self._vectors.get(text, [1.0] + [0.0] * (self._default_dim - 1))
 

--- a/graphrag_sdk/tests/test_models.py
+++ b/graphrag_sdk/tests/test_models.py
@@ -14,6 +14,7 @@ from graphrag_sdk.core.models import (
     GraphRelationship,
     GraphSchema,
     IngestionResult,
+    ChatMessage,
     LLMMessage,
     LLMResponse,
     PropertyType,
@@ -208,6 +209,28 @@ class TestRetrieverModels:
     def test_raw_search_result(self):
         raw = RawSearchResult(records=[{"text": "hello"}], metadata={"strategy": "local"})
         assert len(raw.records) == 1
+
+
+class TestChatMessage:
+    def test_valid_roles(self):
+        for role in ("system", "user", "assistant"):
+            msg = ChatMessage(role=role, content="Hello")
+            assert msg.role == role
+
+    def test_invalid_role_raises(self):
+        with pytest.raises(Exception):
+            ChatMessage(role="robot", content="beep")
+
+    def test_to_dict(self):
+        msg = ChatMessage(role="user", content="Hello")
+        d = msg.to_dict()
+        assert d == {"role": "user", "content": "Hello"}
+
+    def test_llm_message_alias(self):
+        """LLMMessage is a backward-compatible alias for ChatMessage."""
+        msg = LLMMessage(role="user", content="Hello")
+        assert isinstance(msg, ChatMessage)
+        assert msg.role == "user"
 
 
 class TestLLMModels:

--- a/graphrag_sdk/tests/test_models.py
+++ b/graphrag_sdk/tests/test_models.py
@@ -218,7 +218,7 @@ class TestChatMessage:
             assert msg.role == role
 
     def test_invalid_role_raises(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             ChatMessage(role="robot", content="beep")
 
     def test_to_dict(self):

--- a/graphrag_sdk/tests/test_providers.py
+++ b/graphrag_sdk/tests/test_providers.py
@@ -25,6 +25,10 @@ from graphrag_sdk.core.providers import (
 
 
 class SimpleEmbedder(Embedder):
+    @property
+    def model_name(self) -> str:
+        return "simple-test-embedder"
+
     def embed_query(self, text: str, **kwargs: Any) -> list[float]:
         return [float(len(text)), 0.5, 0.1]
 


### PR DESCRIPTION
Release readiness:
- Version 2.0.0a1 → 1.0.0, classifier → Production/Stable
- Fixed 14 ruff lint errors, removed CI ignore flags
- Added hnswlib import guard (clear ImportError vs AttributeError)
- Dependency hardening: upper bounds, pypdf CVE bump
- ConnectionConfig.password hidden from repr, py.typed marker
- Updated SECURITY.md, CHANGELOG.md

API changes:
- ingest() accepts str | list[str] with max_concurrent for parallel ingestion
- New retrieve() — retrieval-only, returns RetrieverResult (no LLM call)
- New completion() — full RAG pipeline with optional conversation history
- query()/query_sync() deprecated with DeprecationWarning
- New sync wrappers: retrieve_sync(), completion_sync()

Graph config node:
- Embedder ABC gains abstract model_name property
- __GraphRAGConfig__ singleton node written on ingest (model, dimension, version)
- Validated on retrieve/completion — raises ConfigError on embedder mismatch

Tests: 547 passed (up from 533), 14 new tests for all new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Multi-turn conversation support via message history in `completion()` API
  * Separate retrieval-only (`retrieve()`) and full generation (`completion()`) methods
  * Bounded parallel ingestion for multiple document sources

* **Changes**
  * Version 1.0.0 released (Production/Stable status)
  * `query()` method deprecated; use `completion()` instead
  * Tightened dependency version constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->