### PR TITLE
fix: store relationship description and entity type as graph properties

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -528,6 +528,7 @@ class GraphExtraction(ExtractionStrategy):
                 continue
             props: dict[str, Any] = {
                 "name": ent.name,
+                "type": ent.type,
                 "description": ent.description,
                 "source_chunk_ids": ent.source_chunk_ids,
             }
@@ -562,6 +563,7 @@ class GraphExtraction(ExtractionStrategy):
             props: dict[str, Any] = {
                 "rel_type": rel.type,
                 "fact": fact,
+                "description": rel.description or "",
                 "source_chunk_ids": rel.source_chunk_ids,
                 "src_name": rel.source,
                 "tgt_name": rel.target,


### PR DESCRIPTION
Relationship descriptions were extracted by the LLM but silently dropped during conversion to GraphRelationship — all RELATES edges had r.description = NULL. Entity type was only stored as a graph label, not as a queryable property. Both are now stored in the properties dict.