### PR TITLE
fix: cross-label entity dedup, type descriptions in prompts, noise fi…

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -92,9 +92,7 @@ def _optional_extras(obj: Any) -> dict[str, Any]:
     return extra
 
 
-def _format_entity_types(
-    types: list[str], descs: dict[str, str] | None = None
-) -> str:
+def _format_entity_types(types: list[str], descs: dict[str, str] | None = None) -> str:
     """Format entity types for prompt injection, including descriptions if available."""
     if not descs:
         return ", ".join(types)

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -52,6 +52,12 @@ VERIFY_EXTRACT_RELS_PROMPT = (
     "{text}\n\n"
     "## Instructions\n\n"
     "### Entities\n"
+    "- REMOVE any entity that is:\n"
+    "  - A purely symbolic or operator token (e.g. +=, ->, ++, ==, !=)\n"
+    "  - A common non-domain-specific shell/system abbreviation "
+    "(e.g. sh, cd, dt, ls, rm, cp, mv)\n"
+    "  - A generic short token (1-2 characters) that is not a widely-recognised "
+    "named entity or acronym (AI, US, UK, Go are fine; dt, bg, fn are not)\n"
     "- For each verified entity provide a concise 1-2 sentence description "
     "capturing key attributes and roles from the text. This description is "
     "embedded for semantic search.\n\n"
@@ -84,6 +90,19 @@ def _optional_extras(obj: Any) -> dict[str, Any]:
     if conf is not None:
         extra["confidence"] = conf
     return extra
+
+
+def _format_entity_types(
+    types: list[str], descs: dict[str, str] | None = None
+) -> str:
+    """Format entity types for prompt injection, including descriptions if available."""
+    if not descs:
+        return ", ".join(types)
+    parts = []
+    for t in types:
+        d = descs.get(t)
+        parts.append(f"{t} -- {d}" if d else t)
+    return "\n".join(parts)
 
 
 class GraphExtraction(ExtractionStrategy):
@@ -132,9 +151,14 @@ class GraphExtraction(ExtractionStrategy):
         ctx: Context,
     ) -> GraphData:
         # Resolve entity types: schema overrides instance default
-        entity_types = (
-            [e.label for e in schema.entities] if schema.entities else list(self.entity_types)
-        )
+        if schema.entities:
+            entity_types = [e.label for e in schema.entities]
+            entity_type_descs: dict[str, str] = {
+                e.label: e.description for e in schema.entities if e.description
+            }
+        else:
+            entity_types = list(self.entity_types)
+            entity_type_descs = {}
 
         ctx.log(
             f"Extracting from {len(chunks.chunks)} chunks (hybrid, "
@@ -173,7 +197,7 @@ class GraphExtraction(ExtractionStrategy):
             # LLM mode: batch all NER prompts via abatch_invoke
             ner_prompts = [
                 NER_PROMPT.format(
-                    entity_types=", ".join(entity_types),
+                    entity_types=_format_entity_types(entity_types, entity_type_descs),
                     text=text,
                 )
                 for text in chunk_texts
@@ -236,7 +260,7 @@ class GraphExtraction(ExtractionStrategy):
                 [{"name": e.name, "type": e.type, "description": e.description} for e in ents]
             )
             prompt = VERIFY_EXTRACT_RELS_PROMPT.format(
-                entity_types=", ".join(entity_types),
+                entity_types=_format_entity_types(entity_types, entity_type_descs),
                 entities_json=entities_json,
                 text=text,
             )

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -93,13 +93,21 @@ def _optional_extras(obj: Any) -> dict[str, Any]:
 
 
 def _format_entity_types(types: list[str], descs: dict[str, str] | None = None) -> str:
-    """Format entity types for prompt injection, including descriptions if available."""
+    """Format entity types for prompt injection.
+
+    When descriptions are available, each type is rendered on its own line
+    with a separate ``Description:`` sub-line so the LLM doesn't confuse
+    the description text with the canonical label.
+    """
     if not descs:
         return ", ".join(types)
     parts = []
     for t in types:
         d = descs.get(t)
-        parts.append(f"{t} -- {d}" if d else t)
+        if d:
+            parts.append(f"{t}\n  Description: {d}")
+        else:
+            parts.append(t)
     return "\n".join(parts)
 
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
@@ -136,9 +136,7 @@ async def exact_match_merge(
                     d = n.properties.get("description", "")
                     if d:
                         all_descs.append(str(d))
-            entity_name = str(
-                sl_entries[indices[0]]["nodes"][0].properties.get("name", "")
-            )
+            entity_name = str(sl_entries[indices[0]]["nodes"][0].properties.get("name", ""))
             cl_candidates.append(
                 {
                     "sl_indices": indices,

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
@@ -22,14 +22,19 @@ _SUMMARY_PROMPT = (
 )
 
 _SUMMARY_WITH_TYPE_PROMPT = (
-    "Summarise the following descriptions of the entity '{entity_name}' "
-    "into a single concise description (max {max_tokens} tokens).\n\n"
-    "The descriptions come from entities classified under different types: "
-    "{types}. Pick the single most accurate type.\n\n"
+    "Entities named '{entity_name}' appear under different types: {types}.\n\n"
     "Descriptions:\n{descriptions}\n\n"
-    "Answer on the first line with ONLY the chosen type, then on the next "
-    "line provide the summary.\n\n"
-    "Type:\n"
+    "Do ALL of these descriptions refer to the SAME real-world entity?\n\n"
+    "If YES, respond with:\n"
+    "  Line 1: 'YES <canonical_type>' (pick the most accurate type from {types})\n"
+    "  Line 2+: a single concise summary (max {max_tokens} tokens)\n\n"
+    "If NO (these are distinct real-world entities that happen to share a name), "
+    "respond with:\n"
+    "  Line 1: 'NO'\n"
+    "  Line 2: brief reason (max 20 words)\n\n"
+    "Do not attempt partial merges. Answer YES only if all entries describe "
+    "the same real-world entity.\n\n"
+    "Answer:"
 )
 
 
@@ -62,38 +67,31 @@ async def exact_match_merge(
     When *cross_label_merge* is False (default), groups by
     ``(normalized_name, label)`` — only same-type duplicates merge.
 
-    When *cross_label_merge* is True, groups by ``(normalized_name,)`` so
-    that same-name entities under different labels also merge. For groups
-    with mixed labels and enough descriptions, the summary prompt is
-    enhanced to also select the canonical type. For smaller groups, a
-    heuristic picks the most frequent non-Unknown label.
+    When *cross_label_merge* is True, this runs a two-stage resolution:
+    first the same-label pass (safe, unconditional), then a cross-label
+    pass that asks the LLM to verify whether same-name entries under
+    different labels refer to the same real-world entity. On YES the LLM
+    also picks the canonical type. On NO — or if evidence is too sparse,
+    or LLM is unavailable, or the call errors — homograph nodes are
+    preserved under their original labels. Both stages share a single LLM
+    batch invocation; no extra calls beyond what the same-label summary
+    path already performs.
 
     Returns:
         (deduplicated_nodes, id_remap, merged_count)
     """
-    groups: dict[tuple, list[GraphNode]] = defaultdict(list)
+    # ── Stage 1: always group by (name, label) for the safe same-label pass ──
+    sl_groups: dict[tuple[str, str], list[GraphNode]] = defaultdict(list)
     for node in nodes:
         name = node.properties.get("name", node.id)
         norm = str(name).strip().lower()
-        key = (norm,) if cross_label_merge else (norm, node.label)
-        groups[key].append(node)
+        sl_groups[(norm, node.label)].append(node)
 
-    id_remap: dict[str, str] = {}
-    deduplicated_nodes: list[GraphNode] = []
-    merged_count = 0
-
-    summary_requests: list[tuple[int, str, list[str]]] = []
-    group_data: list[tuple[GraphNode, list[GraphNode], list[str], list[str]]] = []
-    # Track which group_data indices are mixed-label (need type selection)
-    mixed_label_groups: dict[int, list[GraphNode]] = {}
-
-    for _key, group_nodes in groups.items():
-        if len(group_nodes) == 1:
-            survivor = group_nodes[0]
-            deduplicated_nodes.append(survivor)
-            group_data.append((survivor, group_nodes, [], []))
-            continue
-
+    # Collect per-group evidence. Each entry tracks nodes, descriptions,
+    # source ids, and original-description count (used by cross-label
+    # threshold check after same-label merging collapses the descriptions).
+    sl_entries: list[dict] = []
+    for _key, group_nodes in sl_groups.items():
         descriptions: list[str] = []
         all_source_ids: list[str] = []
         for n in group_nodes:
@@ -105,125 +103,199 @@ async def exact_match_merge(
                 for sid in src_ids:
                     if sid not in all_source_ids:
                         all_source_ids.append(sid)
+        sl_entries.append(
+            {
+                "nodes": group_nodes,
+                "descriptions": descriptions,
+                "all_source_ids": all_source_ids,
+                "orig_desc_count": len(descriptions),
+                "is_merge": len(group_nodes) >= 2,
+            }
+        )
 
-        # Check if this group has mixed labels
-        is_mixed = len({n.label for n in group_nodes}) >= 2
-
-        if is_mixed:
-            # Pick survivor whose label matches the canonical label so that
-            # survivor.id (derived from name+type) stays consistent.
-            canonical = _pick_canonical_label(group_nodes)
-            survivor = next(
-                (n for n in group_nodes if n.label == canonical),
-                group_nodes[0],
+    # ── Stage 2: detect cross-label candidates on top of same-label groups ──
+    cl_candidates: list[dict] = []
+    if cross_label_merge and llm is not None:
+        by_name: dict[str, list[int]] = defaultdict(list)
+        for i, entry in enumerate(sl_entries):
+            norm = str(entry["nodes"][0].properties.get("name", "")).strip().lower()
+            by_name[norm].append(i)
+        for _name_key, indices in by_name.items():
+            if len(indices) < 2:
+                continue
+            labels = {sl_entries[i]["nodes"][0].label for i in indices}
+            if len(labels) < 2:
+                continue
+            total_orig_descs = sum(sl_entries[i]["orig_desc_count"] for i in indices)
+            if total_orig_descs < force_summary_threshold:
+                # Fail-safe: insufficient evidence to ask the LLM; preserve.
+                continue
+            all_descs: list[str] = []
+            for i in indices:
+                for n in sl_entries[i]["nodes"]:
+                    d = n.properties.get("description", "")
+                    if d:
+                        all_descs.append(str(d))
+            entity_name = str(
+                sl_entries[indices[0]]["nodes"][0].properties.get("name", "")
             )
-        else:
-            survivor = group_nodes[0]
+            cl_candidates.append(
+                {
+                    "sl_indices": indices,
+                    "name": entity_name,
+                    "descriptions": all_descs,
+                    "types": sorted(labels),
+                }
+            )
 
-        deduplicated_nodes.append(survivor)
-        group_data.append((survivor, group_nodes, descriptions, all_source_ids))
-        gi = len(group_data) - 1
-
-        if is_mixed and (
-            not descriptions or len(descriptions) < force_summary_threshold or llm is None
-        ):
-            # Mixed labels, heuristic already picked the right survivor above
-            pass
-        elif (
-            is_mixed
-            and descriptions
-            and len(descriptions) >= force_summary_threshold
+    # ── Stage 3: build a single LLM batch (summaries + cross-label verifies) ──
+    prompts: list[str] = []
+    summary_prompt_refs: list[tuple[int, list[str]]] = []  # (sl_entry_idx, descs)
+    for i, entry in enumerate(sl_entries):
+        if (
+            entry["is_merge"]
+            and entry["descriptions"]
+            and len(entry["descriptions"]) >= force_summary_threshold
             and llm is not None
         ):
-            # Mixed labels, enough descriptions — enhanced summary prompt picks type
-            mixed_label_groups[gi] = group_nodes
-            entity_name = str(survivor.properties.get("name", survivor.id))
-            summary_requests.append((gi, entity_name, descriptions))
-        elif descriptions and len(descriptions) >= force_summary_threshold and llm is not None:
-            # Same-label group, enough descriptions — standard summary
-            entity_name = str(survivor.properties.get("name", survivor.id))
-            summary_requests.append((gi, entity_name, descriptions))
-
-    # ── Single LLM batch call ────────────────────────────────────────
-    prompts: list[str] = []
-    for gi_ref, en, descs in summary_requests:
-        if gi_ref in mixed_label_groups:
-            types = ", ".join(sorted({n.label for n in mixed_label_groups[gi_ref]}))
-            prompts.append(
-                _SUMMARY_WITH_TYPE_PROMPT.format(
-                    entity_name=en,
-                    max_tokens=max_summary_tokens,
-                    types=types,
-                    descriptions="\n".join(f"- {d}" for d in descs),
-                )
-            )
-        else:
+            name = str(entry["nodes"][0].properties.get("name", ""))
             prompts.append(
                 _SUMMARY_PROMPT.format(
-                    entity_name=en,
+                    entity_name=name,
                     max_tokens=max_summary_tokens,
-                    descriptions="\n".join(f"- {d}" for d in descs),
+                    descriptions="\n".join(f"- {d}" for d in entry["descriptions"]),
                 )
             )
+            summary_prompt_refs.append((i, entry["descriptions"]))
+
+    cl_prompt_start = len(prompts)
+    for cand in cl_candidates:
+        types_str = ", ".join(cand["types"])
+        prompts.append(
+            _SUMMARY_WITH_TYPE_PROMPT.format(
+                entity_name=cand["name"],
+                max_tokens=max_summary_tokens,
+                types=types_str,
+                descriptions="\n".join(f"- {d}" for d in cand["descriptions"]),
+            )
+        )
 
     batch_results: list = []
-    summary_results: dict[int, str] = {}
-    type_results: dict[int, str] = {}
     if prompts and llm is not None:
         batch_results = await llm.abatch_invoke(prompts)
 
+    # ── Stage 4: parse results ──
+    sl_summaries: dict[int, str] = {}  # sl_entry_idx -> summary text
+    cl_approvals: dict[int, tuple[str, str]] = {}  # cl_idx -> (chosen_type, summary)
     for item in batch_results:
-        group_idx, _, descs = summary_requests[item.index]
-        if not item.ok:
-            summary_results[group_idx] = " | ".join(descs)
-            continue
-        content = item.response.content.strip()
-        if group_idx in mixed_label_groups:
-            # First line = chosen type, rest = summary
-            lines = content.split("\n", 1)
-            type_results[group_idx] = lines[0].strip()
-            summary_results[group_idx] = lines[1].strip() if len(lines) > 1 else " | ".join(descs)
+        idx = item.index
+        if idx < cl_prompt_start:
+            sl_entry_idx, descs = summary_prompt_refs[idx]
+            if item.ok:
+                sl_summaries[sl_entry_idx] = item.response.content.strip()
+            else:
+                sl_summaries[sl_entry_idx] = " | ".join(descs)
         else:
-            summary_results[group_idx] = content
-
-    # ── Apply merges ─────────────────────────────────────────────────
-    for gi, (survivor, group_nodes, descriptions, all_source_ids) in enumerate(group_data):
-        if len(group_nodes) == 1:
-            continue
-        if descriptions:
-            survivor.properties["description"] = (
-                summary_results[gi] if gi in summary_results else " | ".join(descriptions)
-            )
-        if all_source_ids:
-            survivor.properties["source_chunk_ids"] = all_source_ids
-        # If LLM picked a different canonical label than the heuristic,
-        # swap survivor to the node whose label matches (keeps ID consistent).
-        if gi in type_results:
-            chosen = type_results[gi]
-            matched = next(
-                (lbl for lbl in {n.label for n in group_nodes} if lbl.lower() == chosen.lower()),
-                None,
-            )
-            if matched and matched != survivor.label:
-                new_survivor = next(
-                    (n for n in group_nodes if n.label == matched),
-                    None,
-                )
-                if new_survivor:
-                    # Swap: move properties to new survivor, replace in list
-                    new_survivor.properties.update(survivor.properties)
-                    idx = deduplicated_nodes.index(survivor)
-                    deduplicated_nodes[idx] = new_survivor
-                    group_data[gi] = (new_survivor, group_nodes, descriptions, all_source_ids)
-                    survivor = new_survivor
-        for duplicate in group_nodes:
-            if duplicate.id == survivor.id:
+            cl_idx = idx - cl_prompt_start
+            if not item.ok:
+                # LLM error on cross-label verification → fail-safe: no merge.
                 continue
-            for key, value in duplicate.properties.items():
-                if key not in survivor.properties:
-                    survivor.properties[key] = value
-            id_remap[duplicate.id] = survivor.id
+            content = item.response.content.strip()
+            first_line = content.split("\n", 1)[0].strip()
+            if not first_line.upper().startswith("YES"):
+                # NO or malformed → fail-safe: preserve homographs.
+                continue
+            parts = first_line.split(None, 1)
+            chosen = parts[1].strip() if len(parts) >= 2 else ""
+            lines = content.split("\n", 1)
+            cl_summary = (
+                lines[1].strip()
+                if len(lines) > 1
+                else " | ".join(cl_candidates[cl_idx]["descriptions"])
+            )
+            cl_approvals[cl_idx] = (chosen, cl_summary)
+
+    # ── Stage 5: apply same-label merges, producing one survivor per sl group ──
+    sl_survivor_by_idx: dict[int, GraphNode] = {}
+    id_remap: dict[str, str] = {}
+    merged_count = 0
+    for i, entry in enumerate(sl_entries):
+        group_nodes = entry["nodes"]
+        if not entry["is_merge"]:
+            sl_survivor_by_idx[i] = group_nodes[0]
+            continue
+        survivor = group_nodes[0]
+        if entry["descriptions"]:
+            survivor.properties["description"] = (
+                sl_summaries[i] if i in sl_summaries else " | ".join(entry["descriptions"])
+            )
+        if entry["all_source_ids"]:
+            survivor.properties["source_chunk_ids"] = entry["all_source_ids"]
+        for dup in group_nodes[1:]:
+            for k, v in dup.properties.items():
+                if k not in survivor.properties:
+                    survivor.properties[k] = v
+            id_remap[dup.id] = survivor.id
             merged_count += 1
+        sl_survivor_by_idx[i] = survivor
+
+    # ── Stage 6: apply approved cross-label merges ──
+    absorbed_sl_ids: set[str] = set()
+    for cl_idx, cand in enumerate(cl_candidates):
+        if cl_idx not in cl_approvals:
+            continue
+        chosen_type, cl_summary = cl_approvals[cl_idx]
+        sl_idx_list = cand["sl_indices"]
+        sl_survivors_in_cand = [sl_survivor_by_idx[i] for i in sl_idx_list]
+        cl_survivor = next(
+            (s for s in sl_survivors_in_cand if s.label.lower() == chosen_type.lower()),
+            None,
+        )
+        if cl_survivor is None:
+            canonical = _pick_canonical_label(sl_survivors_in_cand)
+            cl_survivor = next(
+                (s for s in sl_survivors_in_cand if s.label == canonical),
+                sl_survivors_in_cand[0],
+            )
+        merged_sources: list[str] = []
+        existing_srcs = cl_survivor.properties.get("source_chunk_ids", [])
+        if isinstance(existing_srcs, list):
+            merged_sources.extend(existing_srcs)
+        for s in sl_survivors_in_cand:
+            if s.id == cl_survivor.id:
+                continue
+            for k, v in s.properties.items():
+                if k not in cl_survivor.properties:
+                    cl_survivor.properties[k] = v
+            s_srcs = s.properties.get("source_chunk_ids", [])
+            if isinstance(s_srcs, list):
+                for sid in s_srcs:
+                    if sid not in merged_sources:
+                        merged_sources.append(sid)
+            absorbed_sl_ids.add(s.id)
+            id_remap[s.id] = cl_survivor.id
+            merged_count += 1
+        if merged_sources:
+            cl_survivor.properties["source_chunk_ids"] = merged_sources
+        cl_survivor.properties["description"] = cl_summary
+
+    # ── Stage 7: resolve transitive id_remap chains (sl-loser → sl-survivor →
+    # cl-survivor becomes sl-loser → cl-survivor directly) ──
+    for k in list(id_remap.keys()):
+        target = id_remap[k]
+        seen = {k}
+        while target in id_remap and target not in seen:
+            seen.add(target)
+            target = id_remap[target]
+        id_remap[k] = target
+
+    # ── Stage 8: build final node list in original sl-group order ──
+    deduplicated_nodes: list[GraphNode] = []
+    for i in range(len(sl_entries)):
+        survivor = sl_survivor_by_idx[i]
+        if survivor.id in absorbed_sl_ids:
+            continue
+        deduplicated_nodes.append(survivor)
 
     return deduplicated_nodes, id_remap, merged_count
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
@@ -115,7 +115,11 @@ async def exact_match_merge(
         elif is_mixed and descriptions and len(descriptions) < force_summary_threshold:
             # Mixed labels, few descriptions — use heuristic for label, pipe-join descs
             survivor.label = _pick_canonical_label(group_nodes)
-        elif is_mixed and descriptions and len(descriptions) >= force_summary_threshold and llm is not None:
+        elif (
+            is_mixed and descriptions
+            and len(descriptions) >= force_summary_threshold
+            and llm is not None
+        ):
             # Mixed labels, enough descriptions — enhanced summary prompt picks type
             mixed_label_groups[gi] = group_nodes
             entity_name = str(survivor.properties.get("name", survivor.id))
@@ -178,7 +182,10 @@ async def exact_match_merge(
             chosen = type_results[gi]
             valid_labels = {n.label for n in group_nodes}
             # Validate LLM returned a label that exists in the group
-            matched = next((l for l in valid_labels if l.lower() == chosen.lower()), None)
+            matched = next(
+                (lbl for lbl in valid_labels if lbl.lower() == chosen.lower()),
+                None,
+            )
             survivor.label = matched if matched else _pick_canonical_label(group_nodes)
         for duplicate in group_nodes[1:]:
             for key, value in duplicate.properties.items():

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
@@ -34,7 +34,10 @@ _SUMMARY_WITH_TYPE_PROMPT = (
 
 
 def _pick_canonical_label(nodes: list[GraphNode]) -> str:
-    """Heuristic label selection: most frequent non-Unknown label wins."""
+    """Heuristic label selection: most frequent non-Unknown label wins.
+
+    Ties are broken lexicographically for deterministic results across runs.
+    """
     counts: dict[str, int] = defaultdict(int)
     for n in nodes:
         counts[n.label] += 1
@@ -42,7 +45,8 @@ def _pick_canonical_label(nodes: list[GraphNode]) -> str:
     candidates = {k: v for k, v in counts.items() if k != "Unknown"}
     if not candidates:
         return "Unknown"
-    return max(candidates, key=lambda k: candidates[k])
+    # Sort by (-count, label) for deterministic tie-breaking
+    return sorted(candidates, key=lambda k: (-candidates[k], k))[0]
 
 
 async def exact_match_merge(
@@ -84,10 +88,9 @@ async def exact_match_merge(
     mixed_label_groups: dict[int, list[GraphNode]] = {}
 
     for _key, group_nodes in groups.items():
-        survivor = group_nodes[0]
-        deduplicated_nodes.append(survivor)
-
         if len(group_nodes) == 1:
+            survivor = group_nodes[0]
+            deduplicated_nodes.append(survivor)
             group_data.append((survivor, group_nodes, [], []))
             continue
 
@@ -103,18 +106,29 @@ async def exact_match_merge(
                     if sid not in all_source_ids:
                         all_source_ids.append(sid)
 
-        group_data.append((survivor, group_nodes, descriptions, all_source_ids))
-        gi = len(group_data) - 1
-
         # Check if this group has mixed labels
         is_mixed = len({n.label for n in group_nodes}) >= 2
 
-        if is_mixed and not descriptions:
-            # Mixed labels but no descriptions — use heuristic for label
-            survivor.label = _pick_canonical_label(group_nodes)
-        elif is_mixed and descriptions and len(descriptions) < force_summary_threshold:
-            # Mixed labels, few descriptions — use heuristic for label, pipe-join descs
-            survivor.label = _pick_canonical_label(group_nodes)
+        if is_mixed:
+            # Pick survivor whose label matches the canonical label so that
+            # survivor.id (derived from name+type) stays consistent.
+            canonical = _pick_canonical_label(group_nodes)
+            survivor = next(
+                (n for n in group_nodes if n.label == canonical),
+                group_nodes[0],
+            )
+        else:
+            survivor = group_nodes[0]
+
+        deduplicated_nodes.append(survivor)
+        group_data.append((survivor, group_nodes, descriptions, all_source_ids))
+        gi = len(group_data) - 1
+
+        if is_mixed and (
+            not descriptions or len(descriptions) < force_summary_threshold or llm is None
+        ):
+            # Mixed labels, heuristic already picked the right survivor above
+            pass
         elif (
             is_mixed
             and descriptions
@@ -182,17 +196,29 @@ async def exact_match_merge(
             )
         if all_source_ids:
             survivor.properties["source_chunk_ids"] = all_source_ids
-        # Apply LLM-chosen canonical label for mixed-label groups
+        # If LLM picked a different canonical label than the heuristic,
+        # swap survivor to the node whose label matches (keeps ID consistent).
         if gi in type_results:
             chosen = type_results[gi]
-            valid_labels = {n.label for n in group_nodes}
-            # Validate LLM returned a label that exists in the group
             matched = next(
-                (lbl for lbl in valid_labels if lbl.lower() == chosen.lower()),
+                (lbl for lbl in {n.label for n in group_nodes} if lbl.lower() == chosen.lower()),
                 None,
             )
-            survivor.label = matched if matched else _pick_canonical_label(group_nodes)
-        for duplicate in group_nodes[1:]:
+            if matched and matched != survivor.label:
+                new_survivor = next(
+                    (n for n in group_nodes if n.label == matched),
+                    None,
+                )
+                if new_survivor:
+                    # Swap: move properties to new survivor, replace in list
+                    new_survivor.properties.update(survivor.properties)
+                    idx = deduplicated_nodes.index(survivor)
+                    deduplicated_nodes[idx] = new_survivor
+                    group_data[gi] = (new_survivor, group_nodes, descriptions, all_source_ids)
+                    survivor = new_survivor
+        for duplicate in group_nodes:
+            if duplicate.id == survivor.id:
+                continue
             for key, value in duplicate.properties.items():
                 if key not in survivor.properties:
                     survivor.properties[key] = value

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
@@ -21,16 +21,28 @@ _SUMMARY_PROMPT = (
     "Summary:"
 )
 
-_CROSS_LABEL_PROMPT = (
-    "Entities with the name \"{name}\" exist under different types in the "
-    "knowledge graph:\n\n"
-    "{entries}\n\n"
-    "Do ALL of these refer to the same real-world entity?\n"
-    "If YES, which single type is most accurate?\n\n"
-    "Answer with exactly: YES <chosen_type> or NO\n"
-    "Then on a new line give a brief reason (max 20 words).\n\n"
-    "Answer:"
+_SUMMARY_WITH_TYPE_PROMPT = (
+    "Summarise the following descriptions of the entity '{entity_name}' "
+    "into a single concise description (max {max_tokens} tokens).\n\n"
+    "The descriptions come from entities classified under different types: "
+    "{types}. Pick the single most accurate type.\n\n"
+    "Descriptions:\n{descriptions}\n\n"
+    "Answer on the first line with ONLY the chosen type, then on the next "
+    "line provide the summary.\n\n"
+    "Type:\n"
 )
+
+
+def _pick_canonical_label(nodes: list[GraphNode]) -> str:
+    """Heuristic label selection: most frequent non-Unknown label wins."""
+    counts: dict[str, int] = defaultdict(int)
+    for n in nodes:
+        counts[n.label] += 1
+    # Prefer any specific type over "Unknown"
+    candidates = {k: v for k, v in counts.items() if k != "Unknown"}
+    if not candidates:
+        return "Unknown"
+    return max(candidates, key=lambda k: candidates[k])
 
 
 async def exact_match_merge(
@@ -41,19 +53,25 @@ async def exact_match_merge(
     max_summary_tokens: int = 500,
     cross_label_merge: bool = False,
 ) -> tuple[list[GraphNode], dict[str, str], int]:
-    """Phase 1: group nodes by (normalized_name, label) and merge exact duplicates.
+    """Phase 1: group nodes by normalized name and merge exact duplicates.
 
-    Merges description strings (optionally via LLM batch summarisation) and
-    accumulates source_chunk_ids. Properties from duplicates are copied to the
-    survivor only when the key is absent.
+    When *cross_label_merge* is False (default), groups by
+    ``(normalized_name, label)`` — only same-type duplicates merge.
+
+    When *cross_label_merge* is True, groups by ``(normalized_name,)`` so
+    that same-name entities under different labels also merge. For groups
+    with mixed labels and enough descriptions, the summary prompt is
+    enhanced to also select the canonical type. For smaller groups, a
+    heuristic picks the most frequent non-Unknown label.
 
     Returns:
         (deduplicated_nodes, id_remap, merged_count)
     """
-    groups: dict[tuple[str, str], list[GraphNode]] = defaultdict(list)
+    groups: dict[tuple, list[GraphNode]] = defaultdict(list)
     for node in nodes:
         name = node.properties.get("name", node.id)
-        key = (str(name).strip().lower(), node.label)
+        norm = str(name).strip().lower()
+        key = (norm,) if cross_label_merge else (norm, node.label)
         groups[key].append(node)
 
     id_remap: dict[str, str] = {}
@@ -62,6 +80,8 @@ async def exact_match_merge(
 
     summary_requests: list[tuple[int, str, list[str]]] = []
     group_data: list[tuple[GraphNode, list[GraphNode], list[str], list[str]]] = []
+    # Track which group_data indices are mixed-label (need type selection)
+    mixed_label_groups: dict[int, list[GraphNode]] = {}
 
     for _key, group_nodes in groups.items():
         survivor = group_nodes[0]
@@ -84,68 +104,66 @@ async def exact_match_merge(
                         all_source_ids.append(sid)
 
         group_data.append((survivor, group_nodes, descriptions, all_source_ids))
+        gi = len(group_data) - 1
 
-        if descriptions and len(descriptions) >= force_summary_threshold and llm is not None:
+        # Check if this group has mixed labels
+        is_mixed = len({n.label for n in group_nodes}) >= 2
+
+        if is_mixed and not descriptions:
+            # Mixed labels but no descriptions — use heuristic for label
+            survivor.label = _pick_canonical_label(group_nodes)
+        elif is_mixed and descriptions and len(descriptions) < force_summary_threshold:
+            # Mixed labels, few descriptions — use heuristic for label, pipe-join descs
+            survivor.label = _pick_canonical_label(group_nodes)
+        elif is_mixed and descriptions and len(descriptions) >= force_summary_threshold and llm is not None:
+            # Mixed labels, enough descriptions — enhanced summary prompt picks type
+            mixed_label_groups[gi] = group_nodes
             entity_name = str(survivor.properties.get("name", survivor.id))
-            summary_requests.append((len(group_data) - 1, entity_name, descriptions))
+            summary_requests.append((gi, entity_name, descriptions))
+        elif descriptions and len(descriptions) >= force_summary_threshold and llm is not None:
+            # Same-label group, enough descriptions — standard summary
+            entity_name = str(survivor.properties.get("name", survivor.id))
+            summary_requests.append((gi, entity_name, descriptions))
 
-    # ── Cross-label detection ───────────────────────────────────────
-    # Find same-name entities under different labels (e.g. "FalkorDB"
-    # as Technology vs Organisation vs Unknown).
-    cross_label_requests: list[tuple[int, str, list[GraphNode]]] = []
-    if cross_label_merge and llm is not None:
-        name_to_survivors: dict[str, list[GraphNode]] = defaultdict(list)
-        for node in deduplicated_nodes:
-            norm = str(node.properties.get("name", node.id)).strip().lower()
-            name_to_survivors[norm].append(node)
-
-        for norm_name, candidates in name_to_survivors.items():
-            if len(candidates) < 2:
-                continue
-            labels = {c.label for c in candidates}
-            if len(labels) < 2:
-                continue
-            # One prompt per cross-label group; index offset after summaries
-            cross_label_requests.append((
-                len(summary_requests) + len(cross_label_requests),
-                str(candidates[0].properties.get("name", norm_name)),
-                candidates,
+    # ── Single LLM batch call ────────────────────────────────────────
+    prompts: list[str] = []
+    for gi_ref, en, descs in summary_requests:
+        if gi_ref in mixed_label_groups:
+            types = ", ".join(sorted({n.label for n in mixed_label_groups[gi_ref]}))
+            prompts.append(_SUMMARY_WITH_TYPE_PROMPT.format(
+                entity_name=en,
+                max_tokens=max_summary_tokens,
+                types=types,
+                descriptions="\n".join(f"- {d}" for d in descs),
             ))
-
-    # ── Single LLM batch call (summaries + cross-label verifications) ─
-    prompts: list[str] = [
-        _SUMMARY_PROMPT.format(
-            entity_name=en,
-            max_tokens=max_summary_tokens,
-            descriptions="\n".join(f"- {d}" for d in descs),
-        )
-        for _, en, descs in summary_requests
-    ]
-    for _, name, candidates in cross_label_requests:
-        entries = "\n".join(
-            f"- Type: {c.label}, Description: "
-            f"{c.properties.get('description', '(no description)')}"
-            for c in candidates
-        )
-        prompts.append(_CROSS_LABEL_PROMPT.format(name=name, entries=entries))
+        else:
+            prompts.append(_SUMMARY_PROMPT.format(
+                entity_name=en,
+                max_tokens=max_summary_tokens,
+                descriptions="\n".join(f"- {d}" for d in descs),
+            ))
 
     batch_results: list = []
     summary_results: dict[int, str] = {}
+    type_results: dict[int, str] = {}
     if prompts and llm is not None:
         batch_results = await llm.abatch_invoke(prompts)
 
-    # Process summary results
-    n_summaries = len(summary_requests)
     for item in batch_results:
-        if item.index >= n_summaries:
-            continue  # cross-label result, handled below
         group_idx, _, descs = summary_requests[item.index]
-        if item.ok:
-            summary_results[group_idx] = item.response.content.strip()
-        else:
+        if not item.ok:
             summary_results[group_idx] = " | ".join(descs)
+            continue
+        content = item.response.content.strip()
+        if group_idx in mixed_label_groups:
+            # First line = chosen type, rest = summary
+            lines = content.split("\n", 1)
+            type_results[group_idx] = lines[0].strip()
+            summary_results[group_idx] = lines[1].strip() if len(lines) > 1 else " | ".join(descs)
+        else:
+            summary_results[group_idx] = content
 
-    # ── Apply same-label merges (unchanged logic) ────────────────────
+    # ── Apply merges ─────────────────────────────────────────────────
     for gi, (survivor, group_nodes, descriptions, all_source_ids) in enumerate(group_data):
         if len(group_nodes) == 1:
             continue
@@ -155,79 +173,19 @@ async def exact_match_merge(
             )
         if all_source_ids:
             survivor.properties["source_chunk_ids"] = all_source_ids
+        # Apply LLM-chosen canonical label for mixed-label groups
+        if gi in type_results:
+            chosen = type_results[gi]
+            valid_labels = {n.label for n in group_nodes}
+            # Validate LLM returned a label that exists in the group
+            matched = next((l for l in valid_labels if l.lower() == chosen.lower()), None)
+            survivor.label = matched if matched else _pick_canonical_label(group_nodes)
         for duplicate in group_nodes[1:]:
             for key, value in duplicate.properties.items():
                 if key not in survivor.properties:
                     survivor.properties[key] = value
             id_remap[duplicate.id] = survivor.id
             merged_count += 1
-
-    # ── Apply cross-label merges ─────────────────────────────────────
-    if cross_label_requests and batch_results:
-        result_map = {item.index: item for item in batch_results}
-        merged_away: set[str] = set()
-
-        for prompt_idx, _name, candidates in cross_label_requests:
-            item = result_map.get(prompt_idx)
-            if item is None or not item.ok:
-                continue
-            first_line = item.response.content.strip().split("\n")[0].strip()
-            if not first_line.upper().startswith("YES"):
-                continue
-
-            # Extract canonical type from "YES Technology"
-            parts = first_line.split(None, 1)
-            canonical = parts[1].strip() if len(parts) >= 2 else ""
-
-            # Find survivor: node whose label matches canonical (case-insensitive)
-            survivor = None
-            for c in candidates:
-                if c.label.lower() == canonical.lower():
-                    survivor = c
-                    break
-            if survivor is None:
-                survivor = candidates[0]  # fallback: first node
-
-            # Merge losers into survivor
-            for loser in candidates:
-                if loser.id == survivor.id or loser.id in merged_away:
-                    continue
-                # Merge descriptions
-                surv_desc = str(survivor.properties.get("description", ""))
-                loser_desc = str(loser.properties.get("description", ""))
-                if loser_desc and loser_desc not in surv_desc:
-                    survivor.properties["description"] = (
-                        f"{surv_desc} | {loser_desc}" if surv_desc else loser_desc
-                    )
-                # Merge source_chunk_ids
-                surv_src = survivor.properties.get("source_chunk_ids", [])
-                if not isinstance(surv_src, list):
-                    surv_src = []
-                for sid in loser.properties.get("source_chunk_ids", []):
-                    if sid not in surv_src:
-                        surv_src.append(sid)
-                survivor.properties["source_chunk_ids"] = surv_src
-                # Copy any unique properties
-                for key, value in loser.properties.items():
-                    if key not in survivor.properties:
-                        survivor.properties[key] = value
-
-                id_remap[loser.id] = survivor.id
-                merged_away.add(loser.id)
-                merged_count += 1
-
-        # Remove merged nodes from deduplicated_nodes
-        if merged_away:
-            deduplicated_nodes = [n for n in deduplicated_nodes if n.id not in merged_away]
-
-        # Resolve transitive remap chains (Phase 1 mapped X→B, cross-label B→A → X→A)
-        for k in list(id_remap.keys()):
-            target = id_remap[k]
-            seen = {k}
-            while target in id_remap and target not in seen:
-                seen.add(target)
-                target = id_remap[target]
-            id_remap[k] = target
 
     return deduplicated_nodes, id_remap, merged_count
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
@@ -116,7 +116,8 @@ async def exact_match_merge(
             # Mixed labels, few descriptions — use heuristic for label, pipe-join descs
             survivor.label = _pick_canonical_label(group_nodes)
         elif (
-            is_mixed and descriptions
+            is_mixed
+            and descriptions
             and len(descriptions) >= force_summary_threshold
             and llm is not None
         ):
@@ -134,18 +135,22 @@ async def exact_match_merge(
     for gi_ref, en, descs in summary_requests:
         if gi_ref in mixed_label_groups:
             types = ", ".join(sorted({n.label for n in mixed_label_groups[gi_ref]}))
-            prompts.append(_SUMMARY_WITH_TYPE_PROMPT.format(
-                entity_name=en,
-                max_tokens=max_summary_tokens,
-                types=types,
-                descriptions="\n".join(f"- {d}" for d in descs),
-            ))
+            prompts.append(
+                _SUMMARY_WITH_TYPE_PROMPT.format(
+                    entity_name=en,
+                    max_tokens=max_summary_tokens,
+                    types=types,
+                    descriptions="\n".join(f"- {d}" for d in descs),
+                )
+            )
         else:
-            prompts.append(_SUMMARY_PROMPT.format(
-                entity_name=en,
-                max_tokens=max_summary_tokens,
-                descriptions="\n".join(f"- {d}" for d in descs),
-            ))
+            prompts.append(
+                _SUMMARY_PROMPT.format(
+                    entity_name=en,
+                    max_tokens=max_summary_tokens,
+                    descriptions="\n".join(f"- {d}" for d in descs),
+                )
+            )
 
     batch_results: list = []
     summary_results: dict[int, str] = {}

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/base.py
@@ -21,6 +21,17 @@ _SUMMARY_PROMPT = (
     "Summary:"
 )
 
+_CROSS_LABEL_PROMPT = (
+    "Entities with the name \"{name}\" exist under different types in the "
+    "knowledge graph:\n\n"
+    "{entries}\n\n"
+    "Do ALL of these refer to the same real-world entity?\n"
+    "If YES, which single type is most accurate?\n\n"
+    "Answer with exactly: YES <chosen_type> or NO\n"
+    "Then on a new line give a brief reason (max 20 words).\n\n"
+    "Answer:"
+)
+
 
 async def exact_match_merge(
     nodes: list[GraphNode],
@@ -28,6 +39,7 @@ async def exact_match_merge(
     *,
     force_summary_threshold: int = 3,
     max_summary_tokens: int = 500,
+    cross_label_merge: bool = False,
 ) -> tuple[list[GraphNode], dict[str, str], int]:
     """Phase 1: group nodes by (normalized_name, label) and merge exact duplicates.
 
@@ -77,26 +89,63 @@ async def exact_match_merge(
             entity_name = str(survivor.properties.get("name", survivor.id))
             summary_requests.append((len(group_data) - 1, entity_name, descriptions))
 
-    # Batch LLM description summaries
-    summary_results: dict[int, str] = {}
-    if summary_requests and llm is not None:
-        prompts = [
-            _SUMMARY_PROMPT.format(
-                entity_name=en,
-                max_tokens=max_summary_tokens,
-                descriptions="\n".join(f"- {d}" for d in descs),
-            )
-            for _, en, descs in summary_requests
-        ]
-        batch_results = await llm.abatch_invoke(prompts)
-        for item in batch_results:
-            group_idx, _, descs = summary_requests[item.index]
-            if item.ok:
-                summary_results[group_idx] = item.response.content.strip()
-            else:
-                summary_results[group_idx] = " | ".join(descs)
+    # ── Cross-label detection ───────────────────────────────────────
+    # Find same-name entities under different labels (e.g. "FalkorDB"
+    # as Technology vs Organisation vs Unknown).
+    cross_label_requests: list[tuple[int, str, list[GraphNode]]] = []
+    if cross_label_merge and llm is not None:
+        name_to_survivors: dict[str, list[GraphNode]] = defaultdict(list)
+        for node in deduplicated_nodes:
+            norm = str(node.properties.get("name", node.id)).strip().lower()
+            name_to_survivors[norm].append(node)
 
-    # Apply merges
+        for norm_name, candidates in name_to_survivors.items():
+            if len(candidates) < 2:
+                continue
+            labels = {c.label for c in candidates}
+            if len(labels) < 2:
+                continue
+            # One prompt per cross-label group; index offset after summaries
+            cross_label_requests.append((
+                len(summary_requests) + len(cross_label_requests),
+                str(candidates[0].properties.get("name", norm_name)),
+                candidates,
+            ))
+
+    # ── Single LLM batch call (summaries + cross-label verifications) ─
+    prompts: list[str] = [
+        _SUMMARY_PROMPT.format(
+            entity_name=en,
+            max_tokens=max_summary_tokens,
+            descriptions="\n".join(f"- {d}" for d in descs),
+        )
+        for _, en, descs in summary_requests
+    ]
+    for _, name, candidates in cross_label_requests:
+        entries = "\n".join(
+            f"- Type: {c.label}, Description: "
+            f"{c.properties.get('description', '(no description)')}"
+            for c in candidates
+        )
+        prompts.append(_CROSS_LABEL_PROMPT.format(name=name, entries=entries))
+
+    batch_results: list = []
+    summary_results: dict[int, str] = {}
+    if prompts and llm is not None:
+        batch_results = await llm.abatch_invoke(prompts)
+
+    # Process summary results
+    n_summaries = len(summary_requests)
+    for item in batch_results:
+        if item.index >= n_summaries:
+            continue  # cross-label result, handled below
+        group_idx, _, descs = summary_requests[item.index]
+        if item.ok:
+            summary_results[group_idx] = item.response.content.strip()
+        else:
+            summary_results[group_idx] = " | ".join(descs)
+
+    # ── Apply same-label merges (unchanged logic) ────────────────────
     for gi, (survivor, group_nodes, descriptions, all_source_ids) in enumerate(group_data):
         if len(group_nodes) == 1:
             continue
@@ -112,6 +161,73 @@ async def exact_match_merge(
                     survivor.properties[key] = value
             id_remap[duplicate.id] = survivor.id
             merged_count += 1
+
+    # ── Apply cross-label merges ─────────────────────────────────────
+    if cross_label_requests and batch_results:
+        result_map = {item.index: item for item in batch_results}
+        merged_away: set[str] = set()
+
+        for prompt_idx, _name, candidates in cross_label_requests:
+            item = result_map.get(prompt_idx)
+            if item is None or not item.ok:
+                continue
+            first_line = item.response.content.strip().split("\n")[0].strip()
+            if not first_line.upper().startswith("YES"):
+                continue
+
+            # Extract canonical type from "YES Technology"
+            parts = first_line.split(None, 1)
+            canonical = parts[1].strip() if len(parts) >= 2 else ""
+
+            # Find survivor: node whose label matches canonical (case-insensitive)
+            survivor = None
+            for c in candidates:
+                if c.label.lower() == canonical.lower():
+                    survivor = c
+                    break
+            if survivor is None:
+                survivor = candidates[0]  # fallback: first node
+
+            # Merge losers into survivor
+            for loser in candidates:
+                if loser.id == survivor.id or loser.id in merged_away:
+                    continue
+                # Merge descriptions
+                surv_desc = str(survivor.properties.get("description", ""))
+                loser_desc = str(loser.properties.get("description", ""))
+                if loser_desc and loser_desc not in surv_desc:
+                    survivor.properties["description"] = (
+                        f"{surv_desc} | {loser_desc}" if surv_desc else loser_desc
+                    )
+                # Merge source_chunk_ids
+                surv_src = survivor.properties.get("source_chunk_ids", [])
+                if not isinstance(surv_src, list):
+                    surv_src = []
+                for sid in loser.properties.get("source_chunk_ids", []):
+                    if sid not in surv_src:
+                        surv_src.append(sid)
+                survivor.properties["source_chunk_ids"] = surv_src
+                # Copy any unique properties
+                for key, value in loser.properties.items():
+                    if key not in survivor.properties:
+                        survivor.properties[key] = value
+
+                id_remap[loser.id] = survivor.id
+                merged_away.add(loser.id)
+                merged_count += 1
+
+        # Remove merged nodes from deduplicated_nodes
+        if merged_away:
+            deduplicated_nodes = [n for n in deduplicated_nodes if n.id not in merged_away]
+
+        # Resolve transitive remap chains (Phase 1 mapped X→B, cross-label B→A → X→A)
+        for k in list(id_remap.keys()):
+            target = id_remap[k]
+            seen = {k}
+            while target in id_remap and target not in seen:
+                seen.add(target)
+                target = id_remap[target]
+            id_remap[k] = target
 
     return deduplicated_nodes, id_remap, merged_count
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/llm_verified_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/llm_verified_resolution.py
@@ -152,6 +152,7 @@ class LLMVerifiedResolution(ResolutionStrategy):
             self.llm,
             force_summary_threshold=self.force_summary_threshold,
             max_summary_tokens=self.max_summary_tokens,
+            cross_label_merge=True,
         )
         ctx.log(
             f"Phase 1 (exact-match): {merged_count} merged, {len(deduplicated_nodes)} surviving"

--- a/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
@@ -455,7 +455,7 @@ class VectorStore:
         fallback_query = (
             "MATCH (a:__Entity__)-[r:RELATES]->(b:__Entity__) "
             "WHERE r.embedding IS NOT NULL "
-            "WITH a, r, b, vecf32.distance.cosine(r.embedding, vecf32($vector)) AS dist "
+            "WITH a, r, b, vec.cosineDistance(r.embedding, vecf32($vector)) AS dist "
             "RETURN r.src_name AS src, r.rel_type AS type, "
             "r.tgt_name AS tgt, r.fact AS fact, (1-dist) AS score "
             "ORDER BY dist ASC LIMIT $top_k"

--- a/graphrag_sdk/tests/test_graph_extraction.py
+++ b/graphrag_sdk/tests/test_graph_extraction.py
@@ -592,12 +592,12 @@ class TestEntityTypeDescriptions:
         types = ["Command", "Function", "Concept"]
         descs = {"Command": "FalkorDB GRAPH.* commands", "Function": "Cypher built-in functions"}
         result = _format_entity_types(types, descs)
-        assert "Command -- FalkorDB GRAPH.* commands" in result
-        assert "Function -- Cypher built-in functions" in result
+        assert "Command\n  Description: FalkorDB GRAPH.* commands" in result
+        assert "Function\n  Description: Cypher built-in functions" in result
         assert "\n" in result  # newline-separated when descriptions present
         # Concept has no description — should appear without suffix
         assert "Concept" in result
-        assert "Concept --" not in result
+        assert "Concept\n  Description:" not in result
 
     def test_without_descriptions(self):
         types = ["Person", "Organization"]
@@ -613,7 +613,7 @@ class TestEntityTypeDescriptions:
         types = ["Person", "Vehicle"]
         descs = {"Vehicle": "A car, truck, or other transport"}
         result = _format_entity_types(types, descs)
-        assert "Vehicle -- A car, truck, or other transport" in result
+        assert "Vehicle\n  Description: A car, truck, or other transport" in result
         assert "Person" in result
 
     async def test_descriptions_reach_step2_prompt(self, ctx):
@@ -643,5 +643,5 @@ class TestEntityTypeDescriptions:
         # Step 2 prompt (second call) should contain the descriptions
         assert len(captured_prompts) >= 2
         step2_prompt = captured_prompts[1]
-        assert "Command -- FalkorDB GRAPH.* commands" in step2_prompt
-        assert "Function -- Cypher built-in functions" in step2_prompt
+        assert "Command\n  Description: FalkorDB GRAPH.* commands" in step2_prompt
+        assert "Function\n  Description: Cypher built-in functions" in step2_prompt

--- a/graphrag_sdk/tests/test_graph_extraction.py
+++ b/graphrag_sdk/tests/test_graph_extraction.py
@@ -21,6 +21,8 @@ from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
 )
 from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
     GraphExtraction,
+    VERIFY_EXTRACT_RELS_PROMPT,
+    _format_entity_types,
 )
 
 from .conftest import MockLLM, MockLLMWithGraphExtraction
@@ -568,3 +570,78 @@ class TestSpansMerging:
         assert len(merged) == 1
         assert "chunk-0" in merged[0].spans
         assert "chunk-1" in merged[0].spans
+
+
+class TestNoiseFilteringPrompt:
+    """Bug 4: VERIFY_EXTRACT_RELS_PROMPT should contain noise-filtering instructions."""
+
+    def test_prompt_contains_operator_filtering(self):
+        assert "symbolic" in VERIFY_EXTRACT_RELS_PROMPT.lower()
+
+    def test_prompt_contains_abbreviation_filtering(self):
+        assert "non-domain-specific" in VERIFY_EXTRACT_RELS_PROMPT
+
+    def test_prompt_contains_short_token_filtering(self):
+        assert "1-2 characters" in VERIFY_EXTRACT_RELS_PROMPT
+
+
+class TestEntityTypeDescriptions:
+    """Bug 3: _format_entity_types should include descriptions when available."""
+
+    def test_with_descriptions(self):
+        types = ["Command", "Function", "Concept"]
+        descs = {"Command": "FalkorDB GRAPH.* commands", "Function": "Cypher built-in functions"}
+        result = _format_entity_types(types, descs)
+        assert "Command -- FalkorDB GRAPH.* commands" in result
+        assert "Function -- Cypher built-in functions" in result
+        assert "\n" in result  # newline-separated when descriptions present
+        # Concept has no description — should appear without suffix
+        assert "Concept" in result
+        assert "Concept --" not in result
+
+    def test_without_descriptions(self):
+        types = ["Person", "Organization"]
+        result = _format_entity_types(types)
+        assert result == "Person, Organization"
+
+    def test_empty_descriptions_dict(self):
+        types = ["Person", "Organization"]
+        result = _format_entity_types(types, {})
+        assert result == "Person, Organization"
+
+    def test_partial_descriptions(self):
+        types = ["Person", "Vehicle"]
+        descs = {"Vehicle": "A car, truck, or other transport"}
+        result = _format_entity_types(types, descs)
+        assert "Vehicle -- A car, truck, or other transport" in result
+        assert "Person" in result
+
+    async def test_descriptions_reach_step2_prompt(self, ctx):
+        """Schema entity type descriptions should appear in the Step 2 LLM prompt."""
+        captured_prompts: list[str] = []
+
+        class CaptureLLM(MockLLM):
+            def invoke(self, prompt, **kwargs):
+                captured_prompts.append(prompt)
+                return super().invoke(prompt, **kwargs)
+
+        llm = CaptureLLM(responses=[
+            json.dumps([{"name": "GRAPH.QUERY", "type": "Command", "description": "A cmd"}]),
+            json.dumps({"entities": [{"name": "GRAPH.QUERY", "type": "Command", "description": "A cmd"}],
+                        "relationships": []}),
+        ])
+        schema = GraphSchema(
+            entities=[
+                EntityType(label="Command", description="FalkorDB GRAPH.* commands"),
+                EntityType(label="Function", description="Cypher built-in functions"),
+            ],
+        )
+        extractor = GraphExtraction(llm=llm, entity_extractor=LLMExtractor(llm))
+        chunks = _make_chunks("GRAPH.QUERY is a FalkorDB command.")
+        await extractor.extract(chunks, schema, ctx)
+
+        # Step 2 prompt (second call) should contain the descriptions
+        assert len(captured_prompts) >= 2
+        step2_prompt = captured_prompts[1]
+        assert "Command -- FalkorDB GRAPH.* commands" in step2_prompt
+        assert "Function -- Cypher built-in functions" in step2_prompt

--- a/graphrag_sdk/tests/test_llm_verified_resolution.py
+++ b/graphrag_sdk/tests/test_llm_verified_resolution.py
@@ -88,10 +88,10 @@ class TestPhase1ExactMatch:
         assert result.merged_count == 1
         assert len(result.nodes) == 1
 
-    async def test_same_name_diff_label_merged_cross_label(self, ctx):
-        """'Paris' Person vs 'Paris' Location — merged by cross-label dedup
-        (LLMVerifiedResolution enables cross_label_merge).
-        Heuristic picks the most common non-Unknown label."""
+    async def test_same_name_diff_label_preserved_without_evidence(self, ctx):
+        """'Paris' Person vs 'Paris' Location with no descriptions — homographs
+        are preserved (fail-safe when the LLM cannot verify they're the same
+        real-world entity)."""
         gd = GraphData(
             nodes=[
                 GraphNode(id="p1", label="Person", properties={"name": "Paris"}),
@@ -101,8 +101,10 @@ class TestPhase1ExactMatch:
         )
         resolver = LLMVerifiedResolution()
         result = await resolver.resolve(gd, ctx)
-        assert result.merged_count == 1
-        assert len(result.nodes) == 1
+        assert result.merged_count == 0
+        assert len(result.nodes) == 2
+        labels = {n.label for n in result.nodes}
+        assert labels == {"Person", "Location"}
 
     async def test_no_duplicates_passes_through(self, ctx):
         gd = GraphData(
@@ -443,8 +445,11 @@ class TestEdgeCases:
         assert result.merged_count == 0
         assert len(result.nodes) == 1
 
-    async def test_all_different_labels_cross_merge(self, ctx):
-        """Same-name nodes with different labels merge via cross-label dedup."""
+    async def test_all_different_labels_preserved_without_llm_confirmation(self, ctx):
+        """Same-name cross-label nodes are preserved when the LLM can't
+        verify them as the same real-world entity (here: no descriptions,
+        so Phase 1 never asks the LLM). Homographs such as Paris/Person vs
+        Paris/Location must not be silently fused."""
         vec = _unit([1.0, 0.0, 0.0, 0.0])
         embedder = ControlledEmbedder({"Paris": vec})
 
@@ -462,6 +467,7 @@ class TestEdgeCases:
             soft_threshold=0.10,
         )
         result = await resolver.resolve(gd, ctx)
-        # cross_label_merge=True groups all "Paris" nodes together
-        assert result.merged_count == 2
-        assert len(result.nodes) == 1
+        assert result.merged_count == 0
+        assert len(result.nodes) == 3
+        labels = {n.label for n in result.nodes}
+        assert labels == {"Person", "Location", "Organization"}

--- a/graphrag_sdk/tests/test_llm_verified_resolution.py
+++ b/graphrag_sdk/tests/test_llm_verified_resolution.py
@@ -88,8 +88,10 @@ class TestPhase1ExactMatch:
         assert result.merged_count == 1
         assert len(result.nodes) == 1
 
-    async def test_same_name_diff_label_kept_separate(self, ctx):
-        """'Paris' Person vs 'Paris' Location — never merged regardless of similarity."""
+    async def test_same_name_diff_label_merged_cross_label(self, ctx):
+        """'Paris' Person vs 'Paris' Location — merged by cross-label dedup
+        (LLMVerifiedResolution enables cross_label_merge).
+        Heuristic picks the most common non-Unknown label."""
         gd = GraphData(
             nodes=[
                 GraphNode(id="p1", label="Person", properties={"name": "Paris"}),
@@ -99,8 +101,8 @@ class TestPhase1ExactMatch:
         )
         resolver = LLMVerifiedResolution()
         result = await resolver.resolve(gd, ctx)
-        assert result.merged_count == 0
-        assert len(result.nodes) == 2
+        assert result.merged_count == 1
+        assert len(result.nodes) == 1
 
     async def test_no_duplicates_passes_through(self, ctx):
         gd = GraphData(
@@ -441,8 +443,8 @@ class TestEdgeCases:
         assert result.merged_count == 0
         assert len(result.nodes) == 1
 
-    async def test_all_different_labels_no_cross_merge(self, ctx):
-        """Nodes in different labels never merge even with identical embeddings."""
+    async def test_all_different_labels_cross_merge(self, ctx):
+        """Same-name nodes with different labels merge via cross-label dedup."""
         vec = _unit([1.0, 0.0, 0.0, 0.0])
         embedder = ControlledEmbedder({"Paris": vec})
 
@@ -456,9 +458,10 @@ class TestEdgeCases:
         )
         resolver = LLMVerifiedResolution(
             embedder=embedder,
-            hard_threshold=0.50,  # very low — would merge if cross-label allowed
+            hard_threshold=0.50,
             soft_threshold=0.10,
         )
         result = await resolver.resolve(gd, ctx)
-        assert result.merged_count == 0
-        assert len(result.nodes) == 3
+        # cross_label_merge=True groups all "Paris" nodes together
+        assert result.merged_count == 2
+        assert len(result.nodes) == 1

--- a/graphrag_sdk/tests/test_resolution.py
+++ b/graphrag_sdk/tests/test_resolution.py
@@ -148,8 +148,8 @@ class TestCrossLabelMerge:
         )
         assert len(deduped) == 1
         assert count == 1
-        # Heuristic: both have count 1, picks first non-Unknown alphabetically
-        assert deduped[0].label in ("Technology", "Organization")
+        # Heuristic: both have count 1, tie broken lexicographically
+        assert deduped[0].label == "Organization"  # O < T
 
     async def test_cross_label_merge_prefers_non_unknown(self):
         """Heuristic picks specific type over Unknown."""

--- a/graphrag_sdk/tests/test_resolution.py
+++ b/graphrag_sdk/tests/test_resolution.py
@@ -131,42 +131,40 @@ class TestExactMatchResolution:
 
 
 class TestCrossLabelMerge:
-    """Bug 2: exact_match_merge with cross_label_merge=True should merge
-    same-name entities across different labels when LLM confirms."""
+    """Bug 2: exact_match_merge with cross_label_merge=True groups by name
+    only, merging same-name entities across labels. Uses enhanced summary
+    prompt for type selection when 3+ descriptions; heuristic otherwise."""
 
-    async def test_cross_label_merge_yes(self):
-        """LLM confirms same entity → merged into canonical type."""
+    async def test_cross_label_merge_heuristic(self):
+        """Two cross-label nodes (below summary threshold) → heuristic picks label."""
         nodes = [
             GraphNode(id="fdb__tech", label="Technology",
                       properties={"name": "FalkorDB", "description": "A graph database engine"}),
             GraphNode(id="fdb__org", label="Organization",
                       properties={"name": "FalkorDB", "description": "The company behind FalkorDB"}),
         ]
-        llm = MockLLM(responses=["YES Technology\nSame entity, technology is more accurate."])
         deduped, remap, count = await exact_match_merge(
-            nodes, llm, cross_label_merge=True,
+            nodes, None, cross_label_merge=True,
+        )
+        assert len(deduped) == 1
+        assert count == 1
+        # Heuristic: both have count 1, picks first non-Unknown alphabetically
+        assert deduped[0].label in ("Technology", "Organization")
+
+    async def test_cross_label_merge_prefers_non_unknown(self):
+        """Heuristic picks specific type over Unknown."""
+        nodes = [
+            GraphNode(id="fdb__tech", label="Technology",
+                      properties={"name": "FalkorDB", "description": "A graph DB"}),
+            GraphNode(id="fdb__unk", label="Unknown",
+                      properties={"name": "FalkorDB", "description": "FalkorDB system"}),
+        ]
+        deduped, remap, count = await exact_match_merge(
+            nodes, None, cross_label_merge=True,
         )
         assert len(deduped) == 1
         assert deduped[0].label == "Technology"
         assert count == 1
-        assert "fdb__org" in remap
-        assert remap["fdb__org"] == "fdb__tech"
-
-    async def test_cross_label_merge_no(self):
-        """LLM says different entities → kept separate."""
-        nodes = [
-            GraphNode(id="paris__person", label="Person",
-                      properties={"name": "Paris", "description": "A character named Paris"}),
-            GraphNode(id="paris__loc", label="Location",
-                      properties={"name": "Paris", "description": "Capital of France"}),
-        ]
-        llm = MockLLM(responses=["NO\nDifferent entities — person vs city."])
-        deduped, remap, count = await exact_match_merge(
-            nodes, llm, cross_label_merge=True,
-        )
-        assert len(deduped) == 2
-        assert count == 0
-        assert len(remap) == 0
 
     async def test_cross_label_merge_disabled_by_default(self):
         """Without cross_label_merge=True, same-name cross-label nodes stay separate."""
@@ -176,47 +174,31 @@ class TestCrossLabelMerge:
             GraphNode(id="fdb__org", label="Organization",
                       properties={"name": "FalkorDB", "description": "The company"}),
         ]
-        llm = MockLLM(responses=["YES Technology\nSame entity."])
-        deduped, remap, count = await exact_match_merge(nodes, llm)
+        deduped, remap, count = await exact_match_merge(nodes, None)
         assert len(deduped) == 2
         assert count == 0
 
-    async def test_cross_label_merge_no_llm(self):
-        """cross_label_merge=True but no LLM → no crash, no merge."""
-        nodes = [
-            GraphNode(id="fdb__tech", label="Technology",
-                      properties={"name": "FalkorDB", "description": "DB"}),
-            GraphNode(id="fdb__org", label="Organization",
-                      properties={"name": "FalkorDB", "description": "Company"}),
-        ]
-        deduped, remap, count = await exact_match_merge(
-            nodes, None, cross_label_merge=True,
-        )
-        assert len(deduped) == 2
-        assert count == 0
-
-    async def test_cross_label_merge_three_labels(self):
-        """Three labels for one name → LLM picks canonical, all merge."""
+    async def test_cross_label_merge_three_labels_with_summary(self):
+        """Three labels (3+ descriptions) → enhanced summary prompt picks type."""
         nodes = [
             GraphNode(id="fdb__tech", label="Technology",
                       properties={"name": "FalkorDB", "description": "Graph database engine"}),
             GraphNode(id="fdb__org", label="Organization",
-                      properties={"name": "FalkorDB", "description": "The company"}),
+                      properties={"name": "FalkorDB", "description": "The company behind it"}),
             GraphNode(id="fdb__unk", label="Unknown",
                       properties={"name": "FalkorDB", "description": "FalkorDB system"}),
         ]
-        llm = MockLLM(responses=["YES Technology\nAll refer to the graph database."])
+        # LLM returns: first line = chosen type, second line = summary
+        llm = MockLLM(responses=["Technology\nFalkorDB is a graph database engine."])
         deduped, remap, count = await exact_match_merge(
             nodes, llm, cross_label_merge=True,
         )
         assert len(deduped) == 1
         assert deduped[0].label == "Technology"
         assert count == 2
-        assert remap["fdb__org"] == "fdb__tech"
-        assert remap["fdb__unk"] == "fdb__tech"
 
-    async def test_cross_label_transitive_remap(self):
-        """Phase 1 same-label merge + cross-label merge chains resolve transitively."""
+    async def test_cross_label_all_in_one_group(self):
+        """All same-name nodes land in one group regardless of label."""
         nodes = [
             GraphNode(id="fdb__tech_1", label="Technology",
                       properties={"name": "FalkorDB", "description": "Graph DB v1"}),
@@ -225,17 +207,18 @@ class TestCrossLabelMerge:
             GraphNode(id="fdb__org", label="Organization",
                       properties={"name": "FalkorDB", "description": "The company"}),
         ]
-        llm = MockLLM(responses=["YES Technology\nSame entity."])
+        # 3 descriptions → summary prompt fires, LLM picks type
+        llm = MockLLM(responses=["Technology\nFalkorDB is a graph database."])
         deduped, remap, count = await exact_match_merge(
             nodes, llm, cross_label_merge=True,
         )
-        # fdb__tech_1 and fdb__tech_2 merge in Phase 1 (same label+name)
-        # Then cross-label merges fdb__org into the tech survivor
         assert len(deduped) == 1
-        assert deduped[0].label == "Technology"
-        # fdb__org should transitively point to the tech survivor
-        tech_survivor = deduped[0].id
-        assert remap.get("fdb__org") == tech_survivor
+        assert count == 2
+        # All duplicates remap to the survivor
+        survivor_id = deduped[0].id
+        for node in nodes:
+            if node.id != survivor_id:
+                assert remap[node.id] == survivor_id
 
     async def test_cross_label_merge_preserves_descriptions(self):
         """Merged descriptions from cross-label nodes should be combined."""
@@ -247,12 +230,27 @@ class TestCrossLabelMerge:
                       properties={"name": "FalkorDB", "description": "The company behind FalkorDB",
                                   "source_chunk_ids": ["c2"]}),
         ]
-        llm = MockLLM(responses=["YES Technology\nSame entity."])
         deduped, remap, count = await exact_match_merge(
-            nodes, llm, cross_label_merge=True,
+            nodes, None, cross_label_merge=True,
         )
         survivor = deduped[0]
+        # Descriptions pipe-joined (below summary threshold)
         assert "graph database" in survivor.properties["description"]
         assert "company" in survivor.properties["description"]
         assert "c1" in survivor.properties["source_chunk_ids"]
         assert "c2" in survivor.properties["source_chunk_ids"]
+
+    async def test_cross_label_same_label_unaffected(self):
+        """Same-label groups still merge normally with cross_label_merge=True."""
+        nodes = [
+            GraphNode(id="a1", label="Person", properties={"name": "Alice", "description": "Engineer"}),
+            GraphNode(id="a2", label="Person", properties={"name": "Alice", "description": "Developer"}),
+            GraphNode(id="b1", label="Person", properties={"name": "Bob", "description": "Manager"}),
+        ]
+        deduped, remap, count = await exact_match_merge(
+            nodes, None, cross_label_merge=True,
+        )
+        assert len(deduped) == 2  # Alice (merged) + Bob
+        assert count == 1
+        names = {n.properties["name"] for n in deduped}
+        assert names == {"Alice", "Bob"}

--- a/graphrag_sdk/tests/test_resolution.py
+++ b/graphrag_sdk/tests/test_resolution.py
@@ -132,11 +132,13 @@ class TestExactMatchResolution:
 
 class TestCrossLabelMerge:
     """Bug 2: exact_match_merge with cross_label_merge=True groups by name
-    only, merging same-name entities across labels. Uses enhanced summary
-    prompt for type selection when 3+ descriptions; heuristic otherwise."""
+    only. Same-label duplicates within the group merge as usual; merges
+    ACROSS different labels require LLM YES confirmation — without it
+    (LLM unavailable, not enough descriptions, or LLM says NO), homograph
+    nodes are preserved under their original labels."""
 
-    async def test_cross_label_merge_heuristic(self):
-        """Two cross-label nodes (below summary threshold) → heuristic picks label."""
+    async def test_cross_label_preserved_without_llm(self):
+        """No LLM → fail-safe: cross-label nodes preserved (no silent merge)."""
         nodes = [
             GraphNode(id="fdb__tech", label="Technology",
                       properties={"name": "FalkorDB", "description": "A graph database engine"}),
@@ -146,25 +148,27 @@ class TestCrossLabelMerge:
         deduped, remap, count = await exact_match_merge(
             nodes, None, cross_label_merge=True,
         )
-        assert len(deduped) == 1
-        assert count == 1
-        # Heuristic: both have count 1, tie broken lexicographically
-        assert deduped[0].label == "Organization"  # O < T
+        assert len(deduped) == 2
+        assert count == 0
+        assert remap == {}
+        labels = {n.label for n in deduped}
+        assert labels == {"Technology", "Organization"}
 
-    async def test_cross_label_merge_prefers_non_unknown(self):
-        """Heuristic picks specific type over Unknown."""
+    async def test_cross_label_preserved_below_threshold(self):
+        """Below force_summary_threshold descriptions → fail-safe, no merge."""
         nodes = [
             GraphNode(id="fdb__tech", label="Technology",
                       properties={"name": "FalkorDB", "description": "A graph DB"}),
             GraphNode(id="fdb__unk", label="Unknown",
                       properties={"name": "FalkorDB", "description": "FalkorDB system"}),
         ]
+        # Only 2 descriptions; default threshold is 3, so no LLM call and no merge.
+        llm = MockLLM(responses=["YES Technology\nsummary"])
         deduped, remap, count = await exact_match_merge(
-            nodes, None, cross_label_merge=True,
+            nodes, llm, cross_label_merge=True,
         )
-        assert len(deduped) == 1
-        assert deduped[0].label == "Technology"
-        assert count == 1
+        assert len(deduped) == 2
+        assert count == 0
 
     async def test_cross_label_merge_disabled_by_default(self):
         """Without cross_label_merge=True, same-name cross-label nodes stay separate."""
@@ -178,8 +182,8 @@ class TestCrossLabelMerge:
         assert len(deduped) == 2
         assert count == 0
 
-    async def test_cross_label_merge_three_labels_with_summary(self):
-        """Three labels (3+ descriptions) → enhanced summary prompt picks type."""
+    async def test_cross_label_merge_three_labels_with_yes(self):
+        """Three labels (3+ descriptions) → LLM says YES → merged under chosen type."""
         nodes = [
             GraphNode(id="fdb__tech", label="Technology",
                       properties={"name": "FalkorDB", "description": "Graph database engine"}),
@@ -188,8 +192,8 @@ class TestCrossLabelMerge:
             GraphNode(id="fdb__unk", label="Unknown",
                       properties={"name": "FalkorDB", "description": "FalkorDB system"}),
         ]
-        # LLM returns: first line = chosen type, second line = summary
-        llm = MockLLM(responses=["Technology\nFalkorDB is a graph database engine."])
+        # LLM returns: 'YES <type>' on line 1, summary on line 2
+        llm = MockLLM(responses=["YES Technology\nFalkorDB is a graph database engine."])
         deduped, remap, count = await exact_match_merge(
             nodes, llm, cross_label_merge=True,
         )
@@ -197,8 +201,51 @@ class TestCrossLabelMerge:
         assert deduped[0].label == "Technology"
         assert count == 2
 
+    async def test_cross_label_homograph_llm_says_no(self):
+        """Nas's Paris case: LLM says NO → both homographs preserved."""
+        nodes = [
+            GraphNode(id="paris__loc", label="Location",
+                      properties={"name": "Paris", "description": "Capital city of France."}),
+            GraphNode(id="paris__per_1", label="Person",
+                      properties={"name": "Paris", "description": "American media personality."}),
+            GraphNode(id="paris__per_2", label="Person",
+                      properties={"name": "Paris", "description": "Hilton family member."}),
+        ]
+        llm = MockLLM(responses=["NO\nThese are distinct real-world entities."])
+        deduped, remap, count = await exact_match_merge(
+            nodes, llm, cross_label_merge=True,
+        )
+        # Same-label Paris/Person duplicates still merge (Phase 1a).
+        # Cross-label Paris/Location vs Paris/Person stays separate (fail-safe on NO).
+        labels = sorted(n.label for n in deduped)
+        assert labels == ["Location", "Person"]
+        # The two Person duplicates collapsed into one survivor.
+        assert count == 1
+
+    async def test_cross_label_llm_error_fails_safe(self):
+        """LLM call raises → fail-safe: preserve all nodes."""
+
+        class FailingLLM(MockLLM):
+            def invoke(self, prompt, **kwargs):
+                raise RuntimeError("LLM unavailable")
+
+        nodes = [
+            GraphNode(id="fdb__tech", label="Technology",
+                      properties={"name": "FalkorDB", "description": "Graph database engine"}),
+            GraphNode(id="fdb__org", label="Organization",
+                      properties={"name": "FalkorDB", "description": "The company behind it"}),
+            GraphNode(id="fdb__unk", label="Unknown",
+                      properties={"name": "FalkorDB", "description": "FalkorDB system"}),
+        ]
+        llm = FailingLLM(responses=[])
+        deduped, remap, count = await exact_match_merge(
+            nodes, llm, cross_label_merge=True,
+        )
+        assert len(deduped) == 3
+        assert count == 0
+
     async def test_cross_label_all_in_one_group(self):
-        """All same-name nodes land in one group regardless of label."""
+        """All same-name nodes land in one group regardless of label; LLM YES merges."""
         nodes = [
             GraphNode(id="fdb__tech_1", label="Technology",
                       properties={"name": "FalkorDB", "description": "Graph DB v1"}),
@@ -207,38 +254,16 @@ class TestCrossLabelMerge:
             GraphNode(id="fdb__org", label="Organization",
                       properties={"name": "FalkorDB", "description": "The company"}),
         ]
-        # 3 descriptions → summary prompt fires, LLM picks type
-        llm = MockLLM(responses=["Technology\nFalkorDB is a graph database."])
+        llm = MockLLM(responses=["YES Technology\nFalkorDB is a graph database."])
         deduped, remap, count = await exact_match_merge(
             nodes, llm, cross_label_merge=True,
         )
         assert len(deduped) == 1
         assert count == 2
-        # All duplicates remap to the survivor
         survivor_id = deduped[0].id
         for node in nodes:
             if node.id != survivor_id:
                 assert remap[node.id] == survivor_id
-
-    async def test_cross_label_merge_preserves_descriptions(self):
-        """Merged descriptions from cross-label nodes should be combined."""
-        nodes = [
-            GraphNode(id="fdb__tech", label="Technology",
-                      properties={"name": "FalkorDB", "description": "A graph database",
-                                  "source_chunk_ids": ["c1"]}),
-            GraphNode(id="fdb__org", label="Organization",
-                      properties={"name": "FalkorDB", "description": "The company behind FalkorDB",
-                                  "source_chunk_ids": ["c2"]}),
-        ]
-        deduped, remap, count = await exact_match_merge(
-            nodes, None, cross_label_merge=True,
-        )
-        survivor = deduped[0]
-        # Descriptions pipe-joined (below summary threshold)
-        assert "graph database" in survivor.properties["description"]
-        assert "company" in survivor.properties["description"]
-        assert "c1" in survivor.properties["source_chunk_ids"]
-        assert "c2" in survivor.properties["source_chunk_ids"]
 
     async def test_cross_label_same_label_unaffected(self):
         """Same-label groups still merge normally with cross_label_merge=True."""

--- a/graphrag_sdk/tests/test_resolution.py
+++ b/graphrag_sdk/tests/test_resolution.py
@@ -1,4 +1,4 @@
-"""Tests for ingestion/resolution_strategies/exact_match.py."""
+"""Tests for ingestion/resolution_strategies/exact_match.py and base.py."""
 from __future__ import annotations
 
 import pytest
@@ -6,6 +6,9 @@ import pytest
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import GraphData, GraphNode, GraphRelationship, ResolutionResult
 from graphrag_sdk.ingestion.resolution_strategies.exact_match import ExactMatchResolution
+from graphrag_sdk.ingestion.resolution_strategies.base import exact_match_merge
+
+from .conftest import MockLLM
 
 
 class TestExactMatchResolution:
@@ -125,3 +128,131 @@ class TestExactMatchResolution:
         for rel in result.relationships:
             if rel.type == "LINK":
                 assert rel.end_node_id == survivor_id
+
+
+class TestCrossLabelMerge:
+    """Bug 2: exact_match_merge with cross_label_merge=True should merge
+    same-name entities across different labels when LLM confirms."""
+
+    async def test_cross_label_merge_yes(self):
+        """LLM confirms same entity → merged into canonical type."""
+        nodes = [
+            GraphNode(id="fdb__tech", label="Technology",
+                      properties={"name": "FalkorDB", "description": "A graph database engine"}),
+            GraphNode(id="fdb__org", label="Organization",
+                      properties={"name": "FalkorDB", "description": "The company behind FalkorDB"}),
+        ]
+        llm = MockLLM(responses=["YES Technology\nSame entity, technology is more accurate."])
+        deduped, remap, count = await exact_match_merge(
+            nodes, llm, cross_label_merge=True,
+        )
+        assert len(deduped) == 1
+        assert deduped[0].label == "Technology"
+        assert count == 1
+        assert "fdb__org" in remap
+        assert remap["fdb__org"] == "fdb__tech"
+
+    async def test_cross_label_merge_no(self):
+        """LLM says different entities → kept separate."""
+        nodes = [
+            GraphNode(id="paris__person", label="Person",
+                      properties={"name": "Paris", "description": "A character named Paris"}),
+            GraphNode(id="paris__loc", label="Location",
+                      properties={"name": "Paris", "description": "Capital of France"}),
+        ]
+        llm = MockLLM(responses=["NO\nDifferent entities — person vs city."])
+        deduped, remap, count = await exact_match_merge(
+            nodes, llm, cross_label_merge=True,
+        )
+        assert len(deduped) == 2
+        assert count == 0
+        assert len(remap) == 0
+
+    async def test_cross_label_merge_disabled_by_default(self):
+        """Without cross_label_merge=True, same-name cross-label nodes stay separate."""
+        nodes = [
+            GraphNode(id="fdb__tech", label="Technology",
+                      properties={"name": "FalkorDB", "description": "A graph database"}),
+            GraphNode(id="fdb__org", label="Organization",
+                      properties={"name": "FalkorDB", "description": "The company"}),
+        ]
+        llm = MockLLM(responses=["YES Technology\nSame entity."])
+        deduped, remap, count = await exact_match_merge(nodes, llm)
+        assert len(deduped) == 2
+        assert count == 0
+
+    async def test_cross_label_merge_no_llm(self):
+        """cross_label_merge=True but no LLM → no crash, no merge."""
+        nodes = [
+            GraphNode(id="fdb__tech", label="Technology",
+                      properties={"name": "FalkorDB", "description": "DB"}),
+            GraphNode(id="fdb__org", label="Organization",
+                      properties={"name": "FalkorDB", "description": "Company"}),
+        ]
+        deduped, remap, count = await exact_match_merge(
+            nodes, None, cross_label_merge=True,
+        )
+        assert len(deduped) == 2
+        assert count == 0
+
+    async def test_cross_label_merge_three_labels(self):
+        """Three labels for one name → LLM picks canonical, all merge."""
+        nodes = [
+            GraphNode(id="fdb__tech", label="Technology",
+                      properties={"name": "FalkorDB", "description": "Graph database engine"}),
+            GraphNode(id="fdb__org", label="Organization",
+                      properties={"name": "FalkorDB", "description": "The company"}),
+            GraphNode(id="fdb__unk", label="Unknown",
+                      properties={"name": "FalkorDB", "description": "FalkorDB system"}),
+        ]
+        llm = MockLLM(responses=["YES Technology\nAll refer to the graph database."])
+        deduped, remap, count = await exact_match_merge(
+            nodes, llm, cross_label_merge=True,
+        )
+        assert len(deduped) == 1
+        assert deduped[0].label == "Technology"
+        assert count == 2
+        assert remap["fdb__org"] == "fdb__tech"
+        assert remap["fdb__unk"] == "fdb__tech"
+
+    async def test_cross_label_transitive_remap(self):
+        """Phase 1 same-label merge + cross-label merge chains resolve transitively."""
+        nodes = [
+            GraphNode(id="fdb__tech_1", label="Technology",
+                      properties={"name": "FalkorDB", "description": "Graph DB v1"}),
+            GraphNode(id="fdb__tech_2", label="Technology",
+                      properties={"name": "FalkorDB", "description": "Graph DB v2"}),
+            GraphNode(id="fdb__org", label="Organization",
+                      properties={"name": "FalkorDB", "description": "The company"}),
+        ]
+        llm = MockLLM(responses=["YES Technology\nSame entity."])
+        deduped, remap, count = await exact_match_merge(
+            nodes, llm, cross_label_merge=True,
+        )
+        # fdb__tech_1 and fdb__tech_2 merge in Phase 1 (same label+name)
+        # Then cross-label merges fdb__org into the tech survivor
+        assert len(deduped) == 1
+        assert deduped[0].label == "Technology"
+        # fdb__org should transitively point to the tech survivor
+        tech_survivor = deduped[0].id
+        assert remap.get("fdb__org") == tech_survivor
+
+    async def test_cross_label_merge_preserves_descriptions(self):
+        """Merged descriptions from cross-label nodes should be combined."""
+        nodes = [
+            GraphNode(id="fdb__tech", label="Technology",
+                      properties={"name": "FalkorDB", "description": "A graph database",
+                                  "source_chunk_ids": ["c1"]}),
+            GraphNode(id="fdb__org", label="Organization",
+                      properties={"name": "FalkorDB", "description": "The company behind FalkorDB",
+                                  "source_chunk_ids": ["c2"]}),
+        ]
+        llm = MockLLM(responses=["YES Technology\nSame entity."])
+        deduped, remap, count = await exact_match_merge(
+            nodes, llm, cross_label_merge=True,
+        )
+        survivor = deduped[0]
+        assert "graph database" in survivor.properties["description"]
+        assert "company" in survivor.properties["description"]
+        assert "c1" in survivor.properties["source_chunk_ids"]
+        assert "c2" in survivor.properties["source_chunk_ids"]


### PR DESCRIPTION
…ltering

Bug 2: Extend exact_match_merge() with cross_label_merge flag that detects same-name entities across different labels and uses LLM verification to merge them into a canonical type. Enabled in LLMVerifiedResolution. Appends verification prompts to the existing batch call (no extra LLM calls).

Bug 3: Propagate EntityType.description from schema into Step 1 NER and Step 2 verify prompts. Types now render as "Command -- FalkorDB GRAPH.* commands" instead of bare "Command". Falls back to comma-separated labels when no descriptions exist.

Bug 4: Add noise-filtering instructions to VERIFY_EXTRACT_RELS_PROMPT telling the LLM to remove operator tokens, shell abbreviations, and generic short tokens during entity verification.