### PR TITLE
Fix/entity discovery keyword quota

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
@@ -87,15 +87,65 @@ async def discover_entities(
             found[eid] = info
             sources[eid] = source
 
-    # Path a: Cypher CONTAINS on entity names (batched UNWIND)
-    kw_batch = [kw for kw in llm_kw[:8] if kw]
+    # Path a: Cypher name match (exact-first, then CONTAINS). Both use a
+    # per-keyword quota so a broad keyword (e.g. "FalkorDB") cannot starve
+    # rare keywords (e.g. "indegree") out of downstream entity-list caps,
+    # even when the graph has many homonyms of the broad term.
+    seen_kw: set[str] = set()
+    kw_batch: list[str] = []
+    for kw in llm_kw[:8]:
+        if not kw:
+            continue
+        k_low = kw.lower()
+        if k_low in seen_kw:
+            continue
+        seen_kw.add(k_low)
+        kw_batch.append(kw)
+
     if kw_batch:
+        # Pass a1: exact-name matches, capped per keyword. Inserted first
+        # so exact matches land at the head of `found` and survive the
+        # downstream max_entities / result_assembly caps.
         try:
             result = await graph_store.query_raw(
                 "UNWIND $keywords AS kw "
-                "MATCH (e:__Entity__) WHERE toLower(e.name) CONTAINS toLower(kw) "
-                "RETURN e.id AS id, e.name AS name, e.description AS desc "
-                "LIMIT 40",
+                "CALL { "
+                "  WITH kw "
+                "  MATCH (e:__Entity__) WHERE toLower(e.name) = toLower(kw) "
+                "  RETURN e.id AS id, e.name AS name, e.description AS desc "
+                "  LIMIT 3 "
+                "} "
+                "RETURN id, name, desc",
+                {"keywords": kw_batch},
+            )
+            for row in result.result_set:
+                _add(
+                    row[0],
+                    {
+                        "name": row[1] if len(row) > 1 else "",
+                        "description": row[2] if len(row) > 2 else "",
+                    },
+                    "cypher_exact",
+                )
+        except Exception as exc:
+            logger.debug("Entity exact-name search failed: %s", exc)
+
+        # Pass a2: CONTAINS with per-keyword quota and shorter-name priority.
+        # Excludes exact matches (already added in pass a1) so the quota
+        # isn't spent re-fetching them.
+        try:
+            result = await graph_store.query_raw(
+                "UNWIND $keywords AS kw "
+                "CALL { "
+                "  WITH kw "
+                "  MATCH (e:__Entity__) "
+                "  WHERE toLower(e.name) CONTAINS toLower(kw) "
+                "    AND toLower(e.name) <> toLower(kw) "
+                "  RETURN e.id AS id, e.name AS name, e.description AS desc "
+                "  ORDER BY size(e.name) ASC "
+                "  LIMIT 5 "
+                "} "
+                "RETURN id, name, desc",
                 {"keywords": kw_batch},
             )
             for row in result.result_set:

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
@@ -142,7 +142,7 @@ async def discover_entities(
                 "  WHERE toLower(e.name) CONTAINS toLower(kw) "
                 "    AND toLower(e.name) <> toLower(kw) "
                 "  RETURN e.id AS id, e.name AS name, e.description AS desc "
-                "  ORDER BY size(e.name) ASC "
+                "  ORDER BY size(e.name) ASC, toLower(e.name) ASC, e.id ASC "
                 "  LIMIT 5 "
                 "} "
                 "RETURN id, name, desc",


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the entity extraction, deduplication, and retrieval logic in the GraphRAG SDK. The main changes include enhanced noise filtering in extraction prompts, support for including entity type descriptions in LLM prompts, improved cross-label entity deduplication with LLM-assisted type selection, and more precise entity discovery in retrieval. Additionally, new tests have been added to ensure these behaviors. Below are the most important changes grouped by theme:

**Entity Extraction and Prompt Improvements**
- Added explicit noise-filtering instructions to the `VERIFY_EXTRACT_RELS_PROMPT` to remove symbolic tokens, non-domain-specific abbreviations, and generic short tokens from entity extraction. (_[graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.pyR55-R60](diffhunk://#diff-07f34dda21f9a54444bcf81107d99fb17ebcfdf64342ce30c7b6238926b2e188R55-R60)_)
- Introduced the `_format_entity_types` function to include entity type descriptions in prompts when available, improving LLM context for extraction and verification steps. This is now used throughout the extraction pipeline. (_[[1]](diffhunk://#diff-07f34dda21f9a54444bcf81107d99fb17ebcfdf64342ce30c7b6238926b2e188R95-R113) [[2]](diffhunk://#diff-07f34dda21f9a54444bcf81107d99fb17ebcfdf64342ce30c7b6238926b2e188L135-R167) [[3]](diffhunk://#diff-07f34dda21f9a54444bcf81107d99fb17ebcfdf64342ce30c7b6238926b2e188L176-R206) [[4]](diffhunk://#diff-07f34dda21f9a54444bcf81107d99fb17ebcfdf64342ce30c7b6238926b2e188L239-R269)_)

**Entity Deduplication and Resolution**
- Enhanced the `exact_match_merge` function to support cross-label deduplication: when enabled, entities with the same name but different types can be merged. For mixed-label groups, the LLM prompt now asks for both a summary and the canonical type, with logic to update the survivor node accordingly. (_[[1]](diffhunk://#diff-1e5a3cac7eb7f58ac325d758d56247ac82851c5556f644a457a49f43bafc876eR24-R78) [[2]](diffhunk://#diff-1e5a3cac7eb7f58ac325d758d56247ac82851c5556f644a457a49f43bafc876eR87-L58) [[3]](diffhunk://#diff-1e5a3cac7eb7f58ac325d758d56247ac82851c5556f644a457a49f43bafc876eR109-R189) [[4]](diffhunk://#diff-1e5a3cac7eb7f58ac325d758d56247ac82851c5556f644a457a49f43bafc876eL109-R221)_)
- Enabled cross-label deduplication in LLM-based resolution strategies by setting `cross_label_merge=True`. (_[graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/llm_verified_resolution.pyR155](diffhunk://#diff-eb1b8f9053df382c0d8f50057cd3d79d5fb00f05ecb09af52a6d5aa8abb56e44R155)_)

**Retrieval Improvements**
- Refined entity discovery to prioritize exact-name matches before substring (CONTAINS) matches, with per-keyword quotas and deduplication to ensure rare keywords are not overshadowed by common ones. Exact matches are now inserted first and prioritized in downstream processing. (_[graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.pyL90-R148](diffhunk://#diff-f8df8c9ab8db52d6e383e23289e29a9f689afddf6b582cc42c86bd49d5dbc9a6L90-R148)_)
- Updated the fallback relationship search Cypher query to use the correct vector distance function (`vec.cosineDistance`). (_[graphrag_sdk/src/graphrag_sdk/storage/vector_store.pyL458-R458](diffhunk://#diff-2c59502af5eb4e61a8ce4013c7b752eb81495eb137b453f41a180106d0f6148dL458-R458)_)

**Testing Enhancements**
- Added comprehensive tests for noise-filtering in prompts and for the inclusion of entity type descriptions in prompts and extraction logic. (_[graphrag_sdk/tests/test_graph_extraction.pyR573-R647](diffhunk://#diff-3086129684ec65826945027d15b0f1ac1954b23cf847f90adb4c18a3e4012d8dR573-R647)_)
- Updated tests to reflect the new cross-label merging behavior in entity resolution. (_[graphrag_sdk/tests/test_llm_verified_resolution.pyL91-R94](diffhunk://#diff-3dd22f47850868e1e5690572f64f9a8019f56136d74d7c59f758c0e11b117acbL91-R94)_)

These changes collectively improve the accuracy, robustness, and explainability of entity extraction and graph construction in the SDK.