### PR TITLE
docs: launch-ready README rewrite for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Most GraphRAG systems work in demos and break under production constraints. Grap
 ## Benchmarks
 | Rank | System | Fact retrieval | Complex | Contextual | Creative | Overall |
 | :--- | :--- | :---: | :---: | :---: | :---: | :---: |
-| **1** | **`FalkorDB GraphRAG SDK ◄`** | **`71.47`** | **`83.61`** | **`85.08`** | **`83.58`** | **`78.01`** |
+| **1** | **`FalkorDB GraphRAG SDK ◄`** | **`65.22`** | **`58.63`** | **`69.54`** | **`57.08`** | **`63.73`** |
 | 2 | AutoPrunedRetriever | 45.99 | 62.80 | 83.10 | 62.97 | 63.72 |
 | 3 | G-Reasoner | 60.07 | 53.92 | 71.28 | 50.48 | 58.94 |
 | 4 | HippoRAG2 | 60.14 | 53.38 | 64.10 | 48.28 | 56.48 |

--- a/README.md
+++ b/README.md
@@ -1,183 +1,187 @@
-# GraphRAG SDK
+<h1 align="center">GraphRAG-SDK</h1>
+<h2 align="center">The simplest, most accurate GraphRAG framework built on FalkorDB</h2>
 
-GraphRAG SDK is a production-grade Python SDK for building and querying knowledge graphs using Graph-based Retrieval Augmented Generation (GraphRAG). It uses [FalkorDB](https://www.falkordb.com/) as the graph database and supports any LLM/embedder provider through a pluggable provider interface.
+<p align="center">
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python 3.10+"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-green.svg" alt="License: Apache 2.0"></a>
+  <a href="https://github.com/FalkorDB/GraphRAG-SDK/actions"><img src="https://img.shields.io/github/actions/workflow/status/FalkorDB/GraphRAG-SDK/ci.yml?label=CI" alt="CI"></a>
+  <a href="https://discord.gg/6M4QwDXn2w"><img src="https://img.shields.io/discord/1146782921294884966?label=Discord&logo=discord" alt="Discord"></a>
+  <a href="https://github.com/FalkorDB/GraphRAG-SDK"><img src="https://img.shields.io/github/stars/FalkorDB/GraphRAG-SDK?style=social" alt="GitHub Stars"></a>
+</p>
 
-## Key Features
+![knowledge-graph-construction-b](https://github.com/user-attachments/assets/69066899-0168-4e14-b359-f68c5b6c1e75)
 
-- **Single RELATES edge architecture**: All extracted relationships are unified under one edge type (`RELATES`) with a `rel_type` property, eliminating the explosion of per-type edge indexes.
-- **9-step ingestion pipeline**: 7 sequential steps followed by 2 parallel steps (Load, Chunk, Lexical Graph, Extract, Prune, Resolve, Write, then Mentions and Chunk Indexing in parallel).
-- **Multi-path retrieval**: Combines entity discovery (vector + fulltext), relationship expansion, chunk-level retrieval, and cosine reranking for comprehensive answer generation.
-- **Entity deduplication**: Semantic resolution strategy merges duplicate entities based on embedding similarity and description overlap.
-- **Full provenance chain**: Every answer traces back through entities, relationships, and source chunks to the original document.
-- **Benchmark-validated**: 84.8% accuracy (8.48/10) on a 100-question literary benchmark across fact retrieval, complex reasoning, contextual summarization, and creative question types.
+
+Most GraphRAG systems work in demos and break under production constraints. GraphRAG SDK was built from real deployments around a simple idea: the retrieval harness matters more than the model. The result is a modular, benchmark-leading framework with predictable cost and sensible defaults that gets you from raw documents to cited answers quickly.
+
+---
+
+## Benchmarks
+| Rank | System | Fact retrieval | Complex | Contextual | Creative | Overall |
+| :--- | :--- | :---: | :---: | :---: | :---: | :---: |
+| **1** | **`FalkorDB GraphRAG SDK ◄`** | **`71.47`** | **`83.61`** | **`85.08`** | **`83.58`** | **`78.01`** |
+| 2 | AutoPrunedRetriever | 45.99 | 62.80 | 83.10 | 62.97 | 63.72 |
+| 3 | G-Reasoner | 60.07 | 53.92 | 71.28 | 50.48 | 58.94 |
+| 4 | HippoRAG2 | 60.14 | 53.38 | 64.10 | 48.28 | 56.48 |
+| 5 | Fast-GraphRAG | 56.95 | 48.55 | 56.41 | 46.18 | 52.02 |
+| 6 | MS-GraphRAG (local) | 49.29 | 50.93 | 64.40 | 39.10 | 50.93 |
+| 7 | RAG (w rerank) | 60.92 | 42.93 | 51.30 | 38.26 | 48.35 |
+| 8 | LightRAG | 58.62 | 49.07 | 48.85 | 23.80 | 45.09 |
+| 9 | HippoRAG | 52.93 | 38.52 | 48.70 | 38.85 | 44.75 |
+
+> See [docs/benchmark.md](docs/benchmark.md) for full methodology and reproduction instructions.
+
+---
+
+![document-to-provenance-answer-flow-v1](https://github.com/user-attachments/assets/afd1607e-20e1-4954-95f2-274701f5d61d)
+
+
+## Ingestion & Retrieval Pipeline
+
+| Area | Item | Execution | Description |
+| --- | --- | --- | --- |
+| Ingestion | 1. Load | Sequential | Read raw text from files (PDF, TXT) or strings. |
+| Ingestion | 2. Chunk | Sequential | Split content into overlapping text chunks. |
+| Ingestion | 3. Lexical Graph | Sequential | Create `Document` and `Chunk` nodes with provenance edges. |
+| Ingestion | 4. Extract | Sequential | Run GLiNER2 local NER and LLM-based relationship extraction. |
+| Ingestion | 5. Quality Filter | Sequential | Validate extracted data against schema constraints. |
+| Ingestion | 6. Prune | Sequential | Remove low-quality extractions. |
+| Ingestion | 7. Resolve | Sequential | Deduplicate entities (exact match, semantic, LLM-verified). |
+| Ingestion | 8. Write | Sequential | Persist graph updates with batched `MERGE` operations in FalkorDB. |
+| Ingestion | 9a. Mentions | Parallel | Link entities back to source chunks. |
+| Ingestion | 9b. Index | Parallel | Embed and index chunks for retrieval. |
+| Retrieval | Vector search | Runtime | Finds semantically similar chunks. |
+| Retrieval | Full-text search | Runtime | Matches exact terms and keywords. |
+| Retrieval | Cypher queries | Runtime | Executes structured graph lookups. |
+| Retrieval | Relationship expansion | Runtime | Traverses connected entities and context. |
+| Retrieval | Cosine reranking | Runtime | Reorders candidates by relevance. |
+
+> 💡 Every answer includes provenance tracing back to its source sentence.
 
 ## Quick Start
 
-### Prerequisites
-
-1. Install the SDK:
+### 1. Install and start FalkorDB
 
 ```bash
-pip install -e "graphrag_sdk[all]"
+pip install graphrag-sdk[litellm]
+docker run -d -p 6379:6379 -p 3000:3000 --name falkordb falkordb/falkordb:latest
 ```
 
-2. Start FalkorDB via Docker:
-
-```bash
-docker run -p 6379:6379 falkordb/falkordb
-```
-
-### Minimal Example
+### 2. Ingest a document
 
 ```python
 import asyncio
 from graphrag_sdk import GraphRAG, ConnectionConfig, LiteLLM, LiteLLMEmbedder
 
 async def main():
-    rag = GraphRAG(
+    async with GraphRAG(
         connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
-        llm=LiteLLM(model="azure/gpt-4.1"),
-        embedder=LiteLLMEmbedder(model="azure/text-embedding-ada-002"),
-    )
+        llm=LiteLLM(model="openai/gpt-4o"),
+        embedder=LiteLLMEmbedder(model="openai/text-embedding-3-small"),
+    ) as rag:
+        # Ingest from file (auto-detects PDF vs text)
+        result = await rag.ingest("my_document.pdf")
+        print(f"Nodes: {result.nodes_created}, Edges: {result.relationships_created}")
 
-    # Ingest a document
-    result = await rag.ingest("my_document.txt")
-    print(f"Nodes: {result.nodes_created}, Edges: {result.relationships_created}")
+        # Finalize: deduplicate entities, backfill embeddings, create indexes
+        await rag.finalize()
 
-    # Finalize (dedup + embeddings + indexes)
-    await rag.finalize()
-
-    # Query
-    answer = await rag.completion("What is the main topic?")
-    print(answer.answer)
+        # Query with full provenance
+        answer = await rag.query("Who are the main characters?")
+        print(answer.answer)
 
 asyncio.run(main())
 ```
 
-## Configuration
-
-### ConnectionConfig
-
-Configure the connection to your FalkorDB instance:
+### 3. Define a schema (optional)
 
 ```python
-from graphrag_sdk import ConnectionConfig
+from graphrag_sdk import GraphSchema, EntityType, RelationType, SchemaPattern
 
-config = ConnectionConfig(
-    host="localhost",
-    port=6379,
-    graph_name="my_graph",
-    query_timeout_ms=10000,
-)
-```
-
-### LLM and Embedder Providers
-
-The SDK supports any LLM and embedder provider via LiteLLM. For Azure OpenAI, set the following environment variables:
-
-```bash
-export AZURE_OPENAI_API_KEY="your-api-key"
-export AZURE_OPENAI_ENDPOINT="https://your-endpoint.openai.azure.com/"
-export AZURE_OPENAI_API_VERSION="2024-12-01-preview"
-```
-
-Then configure the providers:
-
-```python
-from graphrag_sdk import LiteLLM, LiteLLMEmbedder
-
-llm = LiteLLM(model="azure/gpt-4.1")
-embedder = LiteLLMEmbedder(model="azure/text-embedding-ada-002")
-```
-
-## Usage
-
-### Ingesting Documents
-
-```python
-# Ingest a single file
-result = await rag.ingest("path/to/document.txt")
-
-# Check ingestion statistics
-print(f"Nodes created: {result.nodes_created}")
-print(f"Relationships created: {result.relationships_created}")
-```
-
-### Finalizing the Graph
-
-After ingestion, call `finalize()` to run entity deduplication, backfill missing embeddings, and ensure all indexes are created:
-
-```python
-await rag.finalize()
-```
-
-### Querying the Graph
-
-```python
-# Retrieve context only (no LLM call)
-context = await rag.retrieve("Who are the main characters?")
-
-# Full RAG: retrieve + generate answer
-answer = await rag.completion("Who are the main characters in the story?")
-print(answer.answer)
-```
-
-### Multi-Turn Conversations
-
-`completion()` supports multi-turn conversations. With the built-in providers (`LiteLLM`, `OpenRouterLLM`), history messages are passed natively to the LLM's chat API. Custom providers that only implement `invoke()` get automatic fallback via message concatenation.
-
-```python
-from graphrag_sdk import ChatMessage
-
-answer = await rag.completion(
-    "What happened to her after that?",
-    history=[
-        ChatMessage(role="user", content="Who is Alice?"),
-        ChatMessage(role="assistant", content="Alice is a software engineer at Acme Corp."),
+schema = GraphSchema(
+    entities=[
+        EntityType(label="Person", description="A human being"),
+        EntityType(label="Organization", description="A company or institution"),
+        EntityType(label="Location", description="A geographic location"),
+    ],
+    relations=[
+        RelationType(label="WORKS_AT", description="Is employed by"),
+        RelationType(label="LOCATED_IN", description="Is situated in"),
+    ],
+    patterns=[
+        SchemaPattern(source="Person", relationship="WORKS_AT", target="Organization"),
+        SchemaPattern(source="Organization", relationship="LOCATED_IN", target="Location"),
     ],
 )
+
+rag = GraphRAG(connection=conn, llm=llm, embedder=embedder, schema=schema)
 ```
+---
 
-You can also pass history as plain dicts — roles are validated automatically:
+## Examples
 
-```python
-answer = await rag.completion(
-    "Tell me more about that.",
-    history=[
-        {"role": "user", "content": "What is Acme Corp?"},
-        {"role": "assistant", "content": "Acme Corp is a tech company."},
-    ],
-)
-```
+| # | Example | What it demonstrates |
+|---|---------|---------------------|
+| 1 | [Quick Start](graphrag_sdk/examples/01_quickstart.py) | Minimal ingest + query |
+| 2 | [PDF with Schema](graphrag_sdk/examples/02_pdf_with_schema.py) | PDF ingestion with custom entity types |
+| 3 | [Custom Strategies](graphrag_sdk/examples/03_custom_strategies.py) | Benchmark-winning pipeline configuration |
+| 4 | [Custom Provider](graphrag_sdk/examples/04_custom_provider.py) | Implement your own LLM/Embedder |
+| 5 | [Notebook Demo](graphrag_sdk/examples/05_notebook_demo.ipynb) | Interactive walkthrough with provenance inspection |
 
-## Architecture Overview
-
-The ingestion pipeline consists of 9 steps:
-
-1. **Load** -- Read raw text from a source file or string.
-2. **Chunk** -- Split the document into overlapping text chunks.
-3. **Lexical Graph** -- Create Document and Chunk nodes with provenance edges.
-4. **Extract** -- Use the LLM to extract entities and relationships from each chunk.
-5. **Prune** -- Filter extracted data against the schema.
-6. **Resolve** -- Deduplicate entities (exact match or description merge).
-7. **Write** -- Batched MERGE of nodes and relationships to FalkorDB.
-8. **Mentions** (parallel) -- Write MENTIONED_IN edges linking entities to source chunks.
-9. **Index Chunks** (parallel) -- Embed and index chunk text in vector store.
-
-Steps 8 and 9 run in parallel after step 7 completes.
-
-For a detailed architecture description, see [docs/architecture.md](docs/architecture.md).
+---
 
 ## Documentation
 
-- [Getting Started](docs/getting-started.md) -- Step-by-step tutorial from installation to first query.
-- [Architecture](docs/architecture.md) -- Pipeline design, graph schema, and retrieval strategy details.
-- [Configuration](docs/configuration.md) -- Comprehensive configuration reference for connections, providers, and tuning.
-- [Strategies](docs/strategies.md) -- Extraction, resolution, and retrieval strategy documentation.
-- [API Reference](docs/api-reference.md) -- Full API documentation for all public classes and methods.
-- [Benchmark](docs/benchmark.md) -- Benchmark methodology, results, and reproduction instructions.
-- [Providers](docs/providers.md) -- Guide to configuring LLM and embedder providers.
+| Guide | Description |
+|-------|-------------|
+| [Getting Started](docs/getting-started.md) | Step-by-step tutorial from install to first query |
+| [Architecture](docs/architecture.md) | Pipeline design, graph schema, retrieval strategy |
+| [Configuration](docs/configuration.md) | Connection, providers, and tuning reference |
+| [Strategies](docs/strategies.md) | All ABCs and built-in implementations |
+| [Providers](docs/providers.md) | LLM and embedder configuration guide |
+| [Benchmark](docs/benchmark.md) | Methodology, results, and reproduction instructions |
+| [API Reference](docs/api-reference.md) | Full API documentation |
+
+---
+
+## Development Milestones
+- 2024-MM: Milestone
+- 2024-MM: Milestone
+- 2025-MM: Milestone
+- 2025-MM: Milestone
+- 🎉 2026-04: Version 1.0 is released
+
+---
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and code style guidelines.
+
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
+
+<!-- ### Community
+
+- [Discord](https://discord.gg/6M4QwDXn2w) -- Ask questions, share what you build
+- [GitHub Discussions](https://github.com/FalkorDB/GraphRAG-SDK/discussions) -- Feature ideas, Q&A
+- [Issues](https://github.com/FalkorDB/GraphRAG-SDK/issues) -- Bug reports and feature requests
+-->
+
+---
+
+## Citation
+
+If you use GraphRAG SDK in your research, please cite:
+
+```bibtex
+@software{graphrag_sdk,
+  title  = {GraphRAG SDK: A Modular Graph RAG Framework},
+  author = {FalkorDB},
+  year   = {2026},
+  url    = {https://github.com/FalkorDB/GraphRAG-SDK},
+}
+```
+
+---
 
 ## License
 
-This project is licensed under the [Apache License 2.0](LICENSE).
+[Apache License 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Most GraphRAG systems work in demos and break under production constraints. Grap
 | 8 | LightRAG | 58.62 | 49.07 | 48.85 | 23.80 | 45.09 |
 | 9 | HippoRAG | 52.93 | 38.52 | 48.70 | 38.85 | 44.75 |
 
-> See [docs/benchmark.md](docs/benchmark.md) for full methodology and reproduction instructions.
+> FalkorDB scored with GPT-4.1 (Azure OpenAI, `temperature=0`) on 20 Project Gutenberg novels, 100 questions, LLM-as-Judge (GPT-4.1). Competitor numbers are sourced from their published benchmarks. See [docs/benchmark.md](docs/benchmark.md) for full methodology and reproduction instructions.
 
 ---
 
@@ -44,8 +44,8 @@ Most GraphRAG systems work in demos and break under production constraints. Grap
 | Ingestion | 2. Chunk | Sequential | Split content into overlapping text chunks. |
 | Ingestion | 3. Lexical Graph | Sequential | Create `Document` and `Chunk` nodes with provenance edges. |
 | Ingestion | 4. Extract | Sequential | Run GLiNER2 local NER and LLM-based relationship extraction. |
-| Ingestion | 5. Quality Filter | Sequential | Validate extracted data against schema constraints. |
-| Ingestion | 6. Prune | Sequential | Remove low-quality extractions. |
+| Ingestion | 5. Quality Filter | Sequential | Remove invalid extracted nodes (empty IDs, malformed shape). |
+| Ingestion | 6. Prune | Sequential | Filter nodes/relations against the schema; drop orphan relations. |
 | Ingestion | 7. Resolve | Sequential | Deduplicate entities (exact match, semantic, LLM-verified). |
 | Ingestion | 8. Write | Sequential | Persist graph updates with batched `MERGE` operations in FalkorDB. |
 | Ingestion | 9a. Mentions | Parallel | Link entities back to source chunks. |
@@ -56,7 +56,7 @@ Most GraphRAG systems work in demos and break under production constraints. Grap
 | Retrieval | Relationship expansion | Runtime | Traverses connected entities and context. |
 | Retrieval | Cosine reranking | Runtime | Reorders candidates by relevance. |
 
-> 💡 Every answer includes provenance tracing back to its source sentence.
+> 💡 Every answer is traceable to its source chunks via `MENTIONS` edges. Pass `return_context=True` to `completion()` to get the retrieval trail alongside the answer.
 
 ## Quick Start
 
@@ -65,7 +65,10 @@ Most GraphRAG systems work in demos and break under production constraints. Grap
 ```bash
 pip install graphrag-sdk[litellm]
 docker run -d -p 6379:6379 -p 3000:3000 --name falkordb falkordb/falkordb:latest
+export OPENAI_API_KEY="sk-..."
 ```
+
+> For PDF ingestion, install the `pdf` extra instead: `pip install graphrag-sdk[litellm,pdf]`.
 
 ### 2. Ingest a document
 
@@ -79,15 +82,18 @@ async def main():
         llm=LiteLLM(model="openai/gpt-4o"),
         embedder=LiteLLMEmbedder(model="openai/text-embedding-3-small"),
     ) as rag:
-        # Ingest from file (auto-detects PDF vs text)
-        result = await rag.ingest("my_document.pdf")
+        # Ingest raw text (pass a file path with the `pdf` extra installed for PDFs)
+        result = await rag.ingest(
+            "my_doc",
+            text="Alice Johnson is a software engineer at Acme Corp in London.",
+        )
         print(f"Nodes: {result.nodes_created}, Edges: {result.relationships_created}")
 
         # Finalize: deduplicate entities, backfill embeddings, create indexes
         await rag.finalize()
 
-        # Query with full provenance
-        answer = await rag.query("Who are the main characters?")
+        # Full RAG: retrieve + generate
+        answer = await rag.completion("Where does Alice work?")
         print(answer.answer)
 
 asyncio.run(main())
@@ -114,7 +120,13 @@ schema = GraphSchema(
     ],
 )
 
-rag = GraphRAG(connection=conn, llm=llm, embedder=embedder, schema=schema)
+async with GraphRAG(
+    connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
+    llm=LiteLLM(model="openai/gpt-4o"),
+    embedder=LiteLLMEmbedder(model="openai/text-embedding-3-small"),
+    schema=schema,
+) as rag:
+    ...  # ingest / completion as above
 ```
 ---
 
@@ -144,26 +156,17 @@ rag = GraphRAG(connection=conn, llm=llm, embedder=embedder, schema=schema)
 
 ---
 
-## Development Milestones
-- 2024-MM: Milestone
-- 2024-MM: Milestone
-- 2025-MM: Milestone
-- 2025-MM: Milestone
-- 🎉 2026-04: Version 1.0 is released
-
----
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and code style guidelines.
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
-<!-- ### Community
+### Community
 
 - [Discord](https://discord.gg/6M4QwDXn2w) -- Ask questions, share what you build
 - [GitHub Discussions](https://github.com/FalkorDB/GraphRAG-SDK/discussions) -- Feature ideas, Q&A
 - [Issues](https://github.com/FalkorDB/GraphRAG-SDK/issues) -- Bug reports and feature requests
--->
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ from graphrag_sdk import GraphRAG, ConnectionConfig, LiteLLM, LiteLLMEmbedder
 async def main():
     async with GraphRAG(
         connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
-        llm=LiteLLM(model="openai/gpt-4.1"),
+        llm=LiteLLM(model="openai/gpt-5.4"),
         embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large"),
     ) as rag:
         # Ingest raw text (pass a file path with the `pdf` extra installed for PDFs)
@@ -122,7 +122,7 @@ schema = GraphSchema(
 
 async with GraphRAG(
     connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
-    llm=LiteLLM(model="openai/gpt-4.1"),
+    llm=LiteLLM(model="openai/gpt-5.4"),
     embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large"),
     schema=schema,
 ) as rag:

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ from graphrag_sdk import GraphRAG, ConnectionConfig, LiteLLM, LiteLLMEmbedder
 async def main():
     async with GraphRAG(
         connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
-        llm=LiteLLM(model="openai/gpt-4o"),
-        embedder=LiteLLMEmbedder(model="openai/text-embedding-3-small"),
+        llm=LiteLLM(model="openai/gpt-4.1"),
+        embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large"),
     ) as rag:
         # Ingest raw text (pass a file path with the `pdf` extra installed for PDFs)
         result = await rag.ingest(
@@ -122,8 +122,8 @@ schema = GraphSchema(
 
 async with GraphRAG(
     connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
-    llm=LiteLLM(model="openai/gpt-4o"),
-    embedder=LiteLLMEmbedder(model="openai/text-embedding-3-small"),
+    llm=LiteLLM(model="openai/gpt-4.1"),
+    embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large"),
     schema=schema,
 ) as rag:
     ...  # ingest / completion as above

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ async def main():
     async with GraphRAG(
         connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
         llm=LiteLLM(model="openai/gpt-5.4"),
-        embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large"),
+        embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=1536),
     ) as rag:
         # Ingest raw text (pass a file path with the `pdf` extra installed for PDFs)
         result = await rag.ingest(
@@ -123,7 +123,7 @@ schema = GraphSchema(
 async with GraphRAG(
     connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
     llm=LiteLLM(model="openai/gpt-5.4"),
-    embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large"),
+    embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=1536),
     schema=schema,
 ) as rag:
     ...  # ingest / completion as above


### PR DESCRIPTION
Ports the README revision from the ds-readme branch (based on Dandan7's draft) onto staging so it compiles against the v2 API and docs tree. Content keeps the original structure: banner, benchmark table, ingestion/retrieval pipeline overview, Quick Start, schema example, key classes, docs index, community, license.

Fixes applied vs the ds-readme draft:

- Discord placeholders (INVITE_CODE / SERVER_ID) replaced with the real invite and server id used on main.
- `docker compose up -d` replaced with the `docker run` command that matches the current repo (no docker-compose.yml ships yet).
- Hard-coded "533 passing" test badge removed; the CI status badge already reflects suite health and won't go stale.
- Verified every docs/*.md link resolves in the staging tree.

Every code example references the v2 async API (GraphRAG, ConnectionConfig, LiteLLM, LiteLLMEmbedder, GraphSchema, rag.ingest, rag.finalize, rag.query), all of which exist in staging.