### PR TITLE
feat: re-export concrete chunking & resolution strategies

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -53,6 +53,16 @@ from graphrag_sdk.core.providers import (
 
 # ── Ingestion Strategies ────────────────────────────────────────
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
+from graphrag_sdk.ingestion.chunking_strategies.callable_chunking import (
+    CallableChunking,
+)
+from graphrag_sdk.ingestion.chunking_strategies.contextual_chunking import (
+    ContextualChunking,
+)
+from graphrag_sdk.ingestion.chunking_strategies.fixed_size import FixedSizeChunking
+from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
+    SentenceTokenCapChunking,
+)
 from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
 from graphrag_sdk.ingestion.extraction_strategies.coref_resolvers import (
     CorefResolver,
@@ -69,6 +79,18 @@ from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
 from graphrag_sdk.ingestion.pipeline import IngestionPipeline
 from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+from graphrag_sdk.ingestion.resolution_strategies.description_merge import (
+    DescriptionMergeResolution,
+)
+from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+    ExactMatchResolution,
+)
+from graphrag_sdk.ingestion.resolution_strategies.llm_verified_resolution import (
+    LLMVerifiedResolution,
+)
+from graphrag_sdk.ingestion.resolution_strategies.semantic_resolution import (
+    SemanticResolution,
+)
 
 # ── Retrieval Strategies ────────────────────────────────────────
 from graphrag_sdk.retrieval.reranking_strategies.base import RerankingStrategy
@@ -118,6 +140,10 @@ __all__ = [
     "TextChunks",
     # Ingestion
     "ChunkingStrategy",
+    "CallableChunking",
+    "ContextualChunking",
+    "FixedSizeChunking",
+    "SentenceTokenCapChunking",
     "ExtractionStrategy",
     "GraphExtraction",
     "EntityExtractor",
@@ -128,6 +154,10 @@ __all__ = [
     "IngestionPipeline",
     "LoaderStrategy",
     "ResolutionStrategy",
+    "DescriptionMergeResolution",
+    "ExactMatchResolution",
+    "LLMVerifiedResolution",
+    "SemanticResolution",
     # Retrieval
     "CosineReranker",
     "MultiPathRetrieval",


### PR DESCRIPTION
## Summary

Promote the concrete strategy classes to the top-level public API so consumers can import them from `graphrag_sdk` instead of deep submodule paths. Additive only — no breaking changes.

**Added to `graphrag_sdk/__init__.py` and `__all__`:**

| Category | Classes |
|---|---|
| Chunking (4) | `FixedSizeChunking`, `SentenceTokenCapChunking`, `CallableChunking`, `ContextualChunking` |
| Resolution (4) | `ExactMatchResolution`, `SemanticResolution`, `LLMVerifiedResolution`, `DescriptionMergeResolution` |

## Why

External reviewers (GraphRAG-UI integration) reported they had to write `try/except ImportError` blocks probing deep paths like `graphrag_sdk.ingestion.resolution_strategies.semantic_resolution` to reach the concrete strategies advertised in the README's strategy table. Base ABCs and facade classes were already re-exported, but the classes consumers actually instantiate were not — leaking internal module structure as a contract and breaking downstream code on every internal reorg.

## Test plan

- [x] `python -c "import graphrag_sdk; assert all(hasattr(graphrag_sdk, n) for n in ['FixedSizeChunking','SentenceTokenCapChunking','CallableChunking','ContextualChunking','ExactMatchResolution','SemanticResolution','LLMVerifiedResolution','DescriptionMergeResolution'])"` — passes
- [x] All 8 names present in `graphrag_sdk.__all__`
- [x] `python -m compileall graphrag_sdk/src/graphrag_sdk/__init__.py` — passes
- [ ] Existing test suite passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)