### PR TITLE
docs: rc1 banner on README; fix CHANGELOG stable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0rc1] - 2026-04-16
 
 Release candidate for v1.0. Opt-in via `pip install graphrag-sdk --pre`. Stable
-installs (`pip install graphrag-sdk`) continue to resolve to v0.8.1 by design.
+installs (`pip install graphrag-sdk`) continue to resolve to v0.8.2 by design.
 
 Everything below this line is the v1.0 changelog, unchanged from the `[1.0.0]`
 draft — content is final for the stable release.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> 🧪 **v1.0.0rc1 is available as a pre-release.** Install with `pip install graphrag-sdk --pre` or pin `==1.0.0rc1`. This is a **breaking** rewrite from v0.x. Stable users: `pip install graphrag-sdk` still gives you v0.8.2 by default.
+
 <h1 align="center">GraphRAG-SDK</h1>
 <h2 align="center">The simplest, most accurate GraphRAG framework built on FalkorDB</h2>
 


### PR DESCRIPTION
## Summary

- Add a pre-release banner to the top of `README.md` — `v1.0.0rc1` is available opt-in via `pip install graphrag-sdk --pre`, stable users unaffected.
- Fix `CHANGELOG.md` wording: stable on PyPI is `0.8.2`, not `0.8.1`.

## Context

`1.0.0rc1` is now live on PyPI as a pre-release. `pip install graphrag-sdk` still resolves to `0.8.2` (stable), verified in a clean venv. Banner makes the opt-in discoverable for users browsing the repo.

Remove the banner (one-line revert) when cutting stable `1.0.0`.

## Test plan

- [x] `pip install graphrag-sdk` → `0.8.2`
- [x] `pip install graphrag-sdk --pre` → `1.0.0rc1`
- [ ] Banner renders correctly on GitHub README preview after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Announced v1.0.0rc1 pre-release availability with clear installation instructions for users who want to test the breaking rewrite
  * Clarified that stable installs continue to default to v0.8.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->