### PR TITLE
fix(examples): guard against None score in PDF example context printing

### DIFF
--- a/graphrag_sdk/examples/02_pdf_with_schema.py
+++ b/graphrag_sdk/examples/02_pdf_with_schema.py
@@ -104,7 +104,8 @@ async def main():
     # Show what was retrieved
     print(f"\nRetrieved {len(answer.retriever_result.items)} context items:")
     for i, item in enumerate(answer.retriever_result.items[:5]):
-        print(f"  [{i+1}] (score={item.score:.3f}) {item.content[:100]}...")
+        score = item.score if item.score is not None else 0.0
+        print(f"  [{i+1}] (score={score:.3f}) {item.content[:100]}...")
 
     # Show graph stats
     stats = await rag.graph_store.get_statistics()


### PR DESCRIPTION
Example 02 (PDF with schema) crashed formatting `item.score:.3f` when the retriever returned items with `score=None`. Fix by defaulting to 0.0 when score is None — matching the existing defensive pattern in the notebook demo (05_notebook_demo.ipynb).

Reproduced with a real PDF: ingestion succeeds (~500 nodes, ~1,600 edges), answer generation succeeds, only the final context-inspection loop crashed. Post-fix the full example runs end-to-end.

## Summary

Brief description of what this PR does and why.

## Changes

- Change 1
- Change 2

## Test Plan

- [ ] All existing tests pass (`pytest tests/ -q`)
- [ ] New tests added for new functionality (if applicable)
- [ ] Lint passes (`ruff check src/`)

## Notes

Any additional context for reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of score display by handling cases where score values may be missing, ensuring consistent numeric output in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->