### PR TITLE
Fix Cypher parse errors from control chars in GraphStore upserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ export OPENAI_API_KEY="sk-..."
 ```
 
 > For PDF ingestion, install the `pdf` extra instead: `pip install graphrag-sdk[litellm,pdf]`.
+> Ingestion sanitizes unsupported control characters in IDs and string properties before graph upserts, which helps avoid FalkorDB Cypher parse errors on noisy PDFs.
 
 ### 2. Ingest a document
 

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import unicodedata
 from typing import Any
 
 from graphrag_sdk.core.connection import FalkorDBConnection
@@ -78,14 +79,21 @@ class GraphStore:
             safe_label = sanitize_cypher_label(label)
             is_entity = label not in self._STRUCTURAL_LABELS
             # Filter out nodes with None or empty id (bad LLM extraction)
-            group = [n for n in group if n.id is not None and str(n.id).strip()]
+            group = [
+                n
+                for n in group
+                if n.id is not None and self._clean_identifier(n.id).strip()
+            ]
             if not group:
                 continue
             # Process in batches
             for start in range(0, len(group), self._BATCH_SIZE):
                 batch = group[start : start + self._BATCH_SIZE]
                 batch_data = [
-                    {"id": str(n.id), "properties": self._clean_properties(n.properties)}
+                    {
+                        "id": self._clean_identifier(n.id),
+                        "properties": self._clean_properties(n.properties),
+                    }
                     for n in batch
                 ]
                 query = (
@@ -110,7 +118,7 @@ class GraphStore:
                         if is_entity:
                             q += " SET n:__Entity__"
                         params = {
-                            "id": str(node.id),
+                            "id": self._clean_identifier(node.id),
                             "properties": self._clean_properties(node.properties),
                         }
                         try:
@@ -146,12 +154,20 @@ class GraphStore:
         count = 0
         for rel_type, group in by_type.items():
             safe_rel_type = sanitize_cypher_label(rel_type)
+            group = [
+                rel
+                for rel in group
+                if self._clean_identifier(rel.start_node_id).strip()
+                and self._clean_identifier(rel.end_node_id).strip()
+            ]
+            if not group:
+                continue
             for start in range(0, len(group), self._BATCH_SIZE):
                 batch = group[start : start + self._BATCH_SIZE]
                 batch_data = [
                     {
-                        "start_id": str(r.start_node_id),
-                        "end_id": str(r.end_node_id),
+                        "start_id": self._clean_identifier(r.start_node_id),
+                        "end_id": self._clean_identifier(r.end_node_id),
                         "properties": self._clean_properties(r.properties),
                     }
                     for r in batch
@@ -192,8 +208,8 @@ class GraphStore:
                             f"SET r += $properties"
                         )
                         params = {
-                            "start_id": str(rel.start_node_id),
-                            "end_id": str(rel.end_node_id),
+                            "start_id": self._clean_identifier(rel.start_node_id),
+                            "end_id": self._clean_identifier(rel.end_node_id),
                             "properties": self._clean_properties(rel.properties),
                         }
                         try:
@@ -327,6 +343,20 @@ class GraphStore:
     # ── Helpers ──────────────────────────────────────────────────
 
     @staticmethod
+    def _sanitize_string(value: str) -> str:
+        """Strip control chars that can break FalkorDB CYPHER param parsing."""
+        return "".join(
+            ch
+            for ch in value
+            if ch in "\t\n\r" or unicodedata.category(ch) != "Cc"
+        )
+
+    @classmethod
+    def _clean_identifier(cls, value: Any) -> str:
+        """Normalise IDs used in Cypher params."""
+        return cls._sanitize_string(str(value))
+
+    @staticmethod
     def _clean_properties(props: dict[str, Any]) -> dict[str, Any]:
         """Remove None values and non-serialisable types from properties.
 
@@ -338,10 +368,19 @@ class GraphStore:
             if value is None:
                 continue
             if isinstance(value, (str, int, float, bool)):
-                cleaned[key] = value
+                cleaned[key] = (
+                    GraphStore._sanitize_string(value) if isinstance(value, str) else value
+                )
             elif isinstance(value, list):
                 # FalkorDB supports lists of primitives — filter items
-                filtered = [item for item in value if isinstance(item, (str, int, float, bool))]
+                filtered: list[str | int | float | bool] = []
+                for item in value:
+                    if not isinstance(item, (str, int, float, bool)):
+                        continue
+                    if isinstance(item, str):
+                        filtered.append(GraphStore._sanitize_string(item))
+                    else:
+                        filtered.append(item)
                 if filtered:
                     cleaned[key] = filtered
             elif isinstance(value, dict):

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -78,23 +78,32 @@ class GraphStore:
         for label, group in by_label.items():
             safe_label = sanitize_cypher_label(label)
             is_entity = label not in self._STRUCTURAL_LABELS
-            # Filter out nodes with None or empty id (bad LLM extraction)
-            group = [
-                n
+            # Sanitize IDs once and filter out None / empty (bad LLM extraction)
+            pre_filter = len(group)
+            cleaned_group: list[tuple[GraphNode, str]] = [
+                (n, self._clean_identifier(n.id))
                 for n in group
-                if n.id is not None and self._clean_identifier(n.id).strip()
+                if n.id is not None
             ]
-            if not group:
+            cleaned_group = [(n, cid) for n, cid in cleaned_group if cid.strip()]
+            dropped = pre_filter - len(cleaned_group)
+            if dropped:
+                logger.warning(
+                    "Dropped %d %s node(s) with empty id after sanitization",
+                    dropped,
+                    safe_label,
+                )
+            if not cleaned_group:
                 continue
             # Process in batches
-            for start in range(0, len(group), self._BATCH_SIZE):
-                batch = group[start : start + self._BATCH_SIZE]
+            for start in range(0, len(cleaned_group), self._BATCH_SIZE):
+                batch = cleaned_group[start : start + self._BATCH_SIZE]
                 batch_data = [
                     {
-                        "id": self._clean_identifier(n.id),
+                        "id": cid,
                         "properties": self._clean_properties(n.properties),
                     }
-                    for n in batch
+                    for n, cid in batch
                 ]
                 query = (
                     f"UNWIND $batch AS item "
@@ -112,13 +121,13 @@ class GraphStore:
                         f"falling back to individual: {exc}"
                     )
                     # Per-item fallback
-                    for node in batch:
+                    for node, cid in batch:
                         safe_node_label = sanitize_cypher_label(node.label)
                         q = f"MERGE (n:`{safe_node_label}` {{id: $id}}) SET n += $properties"
                         if is_entity:
                             q += " SET n:__Entity__"
                         params = {
-                            "id": self._clean_identifier(node.id),
+                            "id": cid,
                             "properties": self._clean_properties(node.properties),
                         }
                         try:
@@ -126,7 +135,7 @@ class GraphStore:
                             count += 1
                         except Exception as inner_exc:
                             logger.warning(
-                                f"Failed to upsert node {node.id} "
+                                f"Failed to upsert node {cid} "
                                 f"(label={safe_node_label}): {inner_exc}"
                             )
                             raise DatabaseError(f"Node upsert failed: {inner_exc}") from inner_exc
@@ -154,23 +163,35 @@ class GraphStore:
         count = 0
         for rel_type, group in by_type.items():
             safe_rel_type = sanitize_cypher_label(rel_type)
-            group = [
-                rel
+            # Sanitize IDs once and filter out empty endpoints
+            pre_filter = len(group)
+            cleaned_group: list[tuple[GraphRelationship, str, str]] = [
+                (rel, self._clean_identifier(rel.start_node_id),
+                 self._clean_identifier(rel.end_node_id))
                 for rel in group
-                if self._clean_identifier(rel.start_node_id).strip()
-                and self._clean_identifier(rel.end_node_id).strip()
             ]
-            if not group:
+            cleaned_group = [
+                (rel, sid, eid) for rel, sid, eid in cleaned_group
+                if sid.strip() and eid.strip()
+            ]
+            dropped = pre_filter - len(cleaned_group)
+            if dropped:
+                logger.warning(
+                    "Dropped %d [%s] relationship(s) with empty endpoint id after sanitization",
+                    dropped,
+                    safe_rel_type,
+                )
+            if not cleaned_group:
                 continue
-            for start in range(0, len(group), self._BATCH_SIZE):
-                batch = group[start : start + self._BATCH_SIZE]
+            for start in range(0, len(cleaned_group), self._BATCH_SIZE):
+                batch = cleaned_group[start : start + self._BATCH_SIZE]
                 batch_data = [
                     {
-                        "start_id": self._clean_identifier(r.start_node_id),
-                        "end_id": self._clean_identifier(r.end_node_id),
+                        "start_id": sid,
+                        "end_id": eid,
                         "properties": self._clean_properties(r.properties),
                     }
-                    for r in batch
+                    for r, sid, eid in batch
                 ]
                 src_label, tgt_label = self._REL_LABEL_HINTS.get(
                     rel_type, ("__Entity__", "__Entity__")
@@ -194,7 +215,7 @@ class GraphStore:
                         f"falling back to individual: {exc}"
                     )
                     # Per-item fallback
-                    for rel in batch:
+                    for rel, sid, eid in batch:
                         fb_src, fb_tgt = self._REL_LABEL_HINTS.get(
                             rel.type, ("__Entity__", "__Entity__")
                         )
@@ -208,8 +229,8 @@ class GraphStore:
                             f"SET r += $properties"
                         )
                         params = {
-                            "start_id": self._clean_identifier(rel.start_node_id),
-                            "end_id": self._clean_identifier(rel.end_node_id),
+                            "start_id": sid,
+                            "end_id": eid,
                             "properties": self._clean_properties(rel.properties),
                         }
                         try:
@@ -218,7 +239,7 @@ class GraphStore:
                         except Exception as inner_exc:
                             logger.warning(
                                 f"Failed to upsert relationship "
-                                f"{rel.start_node_id}-[{safe_fb_rel}]->{rel.end_node_id} "
+                                f"{sid}-[{safe_fb_rel}]->{eid} "
                                 f"({safe_fb_src}→{safe_fb_tgt}): {inner_exc}"
                             )
 
@@ -356,12 +377,14 @@ class GraphStore:
         """Normalise IDs used in Cypher params."""
         return cls._sanitize_string(str(value))
 
-    @staticmethod
-    def _clean_properties(props: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def _clean_properties(cls, props: dict[str, Any]) -> dict[str, Any]:
         """Remove None values and non-serialisable types from properties.
 
-        - Lists: filter items to primitives only, drop None/empty.
+        - Strings: strip control characters.
+        - Lists: filter items to primitives only, strip control chars from strings.
         - Dicts: serialise to JSON string.
+        - Other: convert to string and strip control characters.
         """
         cleaned: dict[str, Any] = {}
         for key, value in props.items():
@@ -369,7 +392,7 @@ class GraphStore:
                 continue
             if isinstance(value, (str, int, float, bool)):
                 cleaned[key] = (
-                    GraphStore._sanitize_string(value) if isinstance(value, str) else value
+                    cls._sanitize_string(value) if isinstance(value, str) else value
                 )
             elif isinstance(value, list):
                 # FalkorDB supports lists of primitives — filter items
@@ -378,7 +401,7 @@ class GraphStore:
                     if not isinstance(item, (str, int, float, bool)):
                         continue
                     if isinstance(item, str):
-                        filtered.append(GraphStore._sanitize_string(item))
+                        filtered.append(cls._sanitize_string(item))
                     else:
                         filtered.append(item)
                 if filtered:
@@ -386,5 +409,5 @@ class GraphStore:
             elif isinstance(value, dict):
                 cleaned[key] = json.dumps(value)
             else:
-                cleaned[key] = str(value)
+                cleaned[key] = cls._sanitize_string(str(value))
         return cleaned

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -81,9 +81,7 @@ class GraphStore:
             # Sanitize IDs once and filter out None / empty (bad LLM extraction)
             pre_filter = len(group)
             cleaned_group: list[tuple[GraphNode, str]] = [
-                (n, self._clean_identifier(n.id))
-                for n in group
-                if n.id is not None
+                (n, self._clean_identifier(n.id)) for n in group if n.id is not None
             ]
             cleaned_group = [(n, cid) for n, cid in cleaned_group if cid.strip()]
             dropped = pre_filter - len(cleaned_group)
@@ -166,13 +164,15 @@ class GraphStore:
             # Sanitize IDs once and filter out empty endpoints
             pre_filter = len(group)
             cleaned_group: list[tuple[GraphRelationship, str, str]] = [
-                (rel, self._clean_identifier(rel.start_node_id),
-                 self._clean_identifier(rel.end_node_id))
+                (
+                    rel,
+                    self._clean_identifier(rel.start_node_id),
+                    self._clean_identifier(rel.end_node_id),
+                )
                 for rel in group
             ]
             cleaned_group = [
-                (rel, sid, eid) for rel, sid, eid in cleaned_group
-                if sid.strip() and eid.strip()
+                (rel, sid, eid) for rel, sid, eid in cleaned_group if sid.strip() and eid.strip()
             ]
             dropped = pre_filter - len(cleaned_group)
             if dropped:
@@ -366,11 +366,7 @@ class GraphStore:
     @staticmethod
     def _sanitize_string(value: str) -> str:
         """Strip control chars that can break FalkorDB CYPHER param parsing."""
-        return "".join(
-            ch
-            for ch in value
-            if ch in "\t\n\r" or unicodedata.category(ch) != "Cc"
-        )
+        return "".join(ch for ch in value if ch in "\t\n\r" or unicodedata.category(ch) != "Cc")
 
     @classmethod
     def _clean_identifier(cls, value: Any) -> str:
@@ -391,9 +387,7 @@ class GraphStore:
             if value is None:
                 continue
             if isinstance(value, (str, int, float, bool)):
-                cleaned[key] = (
-                    cls._sanitize_string(value) if isinstance(value, str) else value
-                )
+                cleaned[key] = cls._sanitize_string(value) if isinstance(value, str) else value
             elif isinstance(value, list):
                 # FalkorDB supports lists of primitives — filter items
                 filtered: list[str | int | float | bool] = []

--- a/graphrag_sdk/tests/test_graph_store.py
+++ b/graphrag_sdk/tests/test_graph_store.py
@@ -1,4 +1,5 @@
 """Tests for storage/graph_store.py — Repository pattern for graph operations."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
@@ -45,14 +46,10 @@ class TestGraphStoreUpsertNodes:
     async def test_upsert_raises_on_error(self, graph_store, mock_connection):
         mock_connection.query = AsyncMock(side_effect=Exception("db error"))
         with pytest.raises(DatabaseError, match="Node upsert failed"):
-            await graph_store.upsert_nodes(
-                [GraphNode(id="x", label="T", properties={})]
-            )
+            await graph_store.upsert_nodes([GraphNode(id="x", label="T", properties={})])
 
     async def test_upsert_passes_id_in_batch_param(self, graph_store, mock_connection):
-        await graph_store.upsert_nodes(
-            [GraphNode(id="test-id", label="X", properties={})]
-        )
+        await graph_store.upsert_nodes([GraphNode(id="test-id", label="X", properties={})])
         params = mock_connection.query.call_args[0][1]
         assert params["batch"][0]["id"] == "test-id"
 
@@ -70,9 +67,7 @@ class TestGraphStoreUpsertNodes:
         self, graph_store, mock_connection
     ):
         """Per-item fallback path should also use sanitized IDs and properties."""
-        mock_connection.query = AsyncMock(
-            side_effect=[Exception("batch fail"), MagicMock()]
-        )
+        mock_connection.query = AsyncMock(side_effect=[Exception("batch fail"), MagicMock()])
         await graph_store.upsert_nodes(
             [GraphNode(id="id\x00\x01", label="X", properties={"t": "A\x00B"})]
         )
@@ -114,9 +109,7 @@ class TestGraphStoreUpsertRelationships:
         assert params["batch"][0]["end_id"] == "b"
         assert params["batch"][0]["properties"]["note"] == "ABC"
 
-    async def test_upsert_drops_rels_with_empty_sanitized_ids(
-        self, graph_store, mock_connection
-    ):
+    async def test_upsert_drops_rels_with_empty_sanitized_ids(self, graph_store, mock_connection):
         rels = [
             GraphRelationship(start_node_id="\x00", end_node_id="valid", type="R"),
             GraphRelationship(start_node_id="ok", end_node_id="also-ok", type="R"),
@@ -217,9 +210,7 @@ class TestCleanProperties:
         assert result["c"] == "ok"
 
     def test_preserves_primitives(self):
-        result = GraphStore._clean_properties(
-            {"s": "text", "i": 42, "f": 3.14, "b": True}
-        )
+        result = GraphStore._clean_properties({"s": "text", "i": 42, "f": 3.14, "b": True})
         assert result == {"s": "text", "i": 42, "f": 3.14, "b": True}
 
     def test_strips_control_chars_from_strings(self):
@@ -247,8 +238,10 @@ class TestRelationshipLabelHints:
         """Known relationship types should use label hints in MATCH."""
         rels = [
             GraphRelationship(
-                start_node_id="doc1", end_node_id="chunk1",
-                type="PART_OF", properties={"index": 0},
+                start_node_id="doc1",
+                end_node_id="chunk1",
+                type="PART_OF",
+                properties={"index": 0},
             )
         ]
         await graph_store.upsert_relationships(rels)
@@ -260,8 +253,10 @@ class TestRelationshipLabelHints:
         """Unknown relationship types should default to __Entity__ labels."""
         rels = [
             GraphRelationship(
-                start_node_id="a", end_node_id="b",
-                type="CUSTOM_REL", properties={},
+                start_node_id="a",
+                end_node_id="b",
+                type="CUSTOM_REL",
+                properties={},
             )
         ]
         await graph_store.upsert_relationships(rels)
@@ -272,8 +267,10 @@ class TestRelationshipLabelHints:
         """MENTIONED_IN should use __Entity__ → Chunk labels."""
         rels = [
             GraphRelationship(
-                start_node_id="entity1", end_node_id="chunk1",
-                type="MENTIONED_IN", properties={},
+                start_node_id="entity1",
+                end_node_id="chunk1",
+                type="MENTIONED_IN",
+                properties={},
             )
         ]
         await graph_store.upsert_relationships(rels)

--- a/graphrag_sdk/tests/test_graph_store.py
+++ b/graphrag_sdk/tests/test_graph_store.py
@@ -66,6 +66,21 @@ class TestGraphStoreUpsertNodes:
         assert params["batch"][0]["id"] == "id"
         assert params["batch"][0]["properties"]["text"] == "ABC"
 
+    async def test_upsert_sanitizes_control_chars_in_fallback_params(
+        self, graph_store, mock_connection
+    ):
+        """Per-item fallback path should also use sanitized IDs and properties."""
+        mock_connection.query = AsyncMock(
+            side_effect=[Exception("batch fail"), MagicMock()]
+        )
+        await graph_store.upsert_nodes(
+            [GraphNode(id="id\x00\x01", label="X", properties={"t": "A\x00B"})]
+        )
+        # Second call is the per-item fallback
+        fallback_params = mock_connection.query.call_args_list[1][0][1]
+        assert fallback_params["id"] == "id"
+        assert fallback_params["properties"]["t"] == "AB"
+
 
 class TestGraphStoreUpsertRelationships:
     async def test_upsert_relationship(self, graph_store, mock_connection):
@@ -81,6 +96,36 @@ class TestGraphStoreUpsertRelationships:
         assert "KNOWS" in cypher
         # Unknown rel type defaults to __Entity__ labels
         assert "`__Entity__`" in cypher
+
+    async def test_upsert_sanitizes_control_chars_in_batch_params(
+        self, graph_store, mock_connection
+    ):
+        rels = [
+            GraphRelationship(
+                start_node_id="a\x00\x01",
+                end_node_id="b\x00\x01",
+                type="RELATES",
+                properties={"note": "A\x00B\x01C"},
+            )
+        ]
+        await graph_store.upsert_relationships(rels)
+        params = mock_connection.query.call_args[0][1]
+        assert params["batch"][0]["start_id"] == "a"
+        assert params["batch"][0]["end_id"] == "b"
+        assert params["batch"][0]["properties"]["note"] == "ABC"
+
+    async def test_upsert_drops_rels_with_empty_sanitized_ids(
+        self, graph_store, mock_connection
+    ):
+        rels = [
+            GraphRelationship(start_node_id="\x00", end_node_id="valid", type="R"),
+            GraphRelationship(start_node_id="ok", end_node_id="also-ok", type="R"),
+        ]
+        result = await graph_store.upsert_relationships(rels)
+        assert result == 1
+        params = mock_connection.query.call_args[0][1]
+        assert len(params["batch"]) == 1
+        assert params["batch"][0]["start_id"] == "ok"
 
     async def test_upsert_empty_relationships(self, graph_store, mock_connection):
         result = await graph_store.upsert_relationships([])

--- a/graphrag_sdk/tests/test_graph_store.py
+++ b/graphrag_sdk/tests/test_graph_store.py
@@ -56,6 +56,16 @@ class TestGraphStoreUpsertNodes:
         params = mock_connection.query.call_args[0][1]
         assert params["batch"][0]["id"] == "test-id"
 
+    async def test_upsert_sanitizes_control_chars_in_batch_params(
+        self, graph_store, mock_connection
+    ):
+        await graph_store.upsert_nodes(
+            [GraphNode(id="id\x00\x01", label="Chunk", properties={"text": "A\x00B\x01C"})]
+        )
+        params = mock_connection.query.call_args[0][1]
+        assert params["batch"][0]["id"] == "id"
+        assert params["batch"][0]["properties"]["text"] == "ABC"
+
 
 class TestGraphStoreUpsertRelationships:
     async def test_upsert_relationship(self, graph_store, mock_connection):
@@ -167,9 +177,17 @@ class TestCleanProperties:
         )
         assert result == {"s": "text", "i": 42, "f": 3.14, "b": True}
 
+    def test_strips_control_chars_from_strings(self):
+        result = GraphStore._clean_properties({"text": "a\x00b\x01c\t\n\r"})
+        assert result["text"] == "abc\t\n\r"
+
     def test_preserves_lists(self):
         result = GraphStore._clean_properties({"tags": ["a", "b"]})
         assert result["tags"] == ["a", "b"]
+
+    def test_strips_control_chars_from_list_strings(self):
+        result = GraphStore._clean_properties({"tags": ["a\x00", "b\x01", 3]})
+        assert result["tags"] == ["a", "b", 3]
 
     def test_converts_objects_to_str(self):
         result = GraphStore._clean_properties({"obj": {"nested": True}})


### PR DESCRIPTION
## Summary
- sanitize control characters in IDs and string properties before parameterized graph upserts
- apply sanitization in both batched and per-item fallback paths for nodes and relationships
- add regression tests covering control-char sanitization in batch params and cleaned properties

## Validation
- `/Users/shaharbiron/Documents/FalkorDB/Poc/GraphRAG-SDK-Docs-Example/.venv/bin/python -m pytest /Users/shaharbiron/Documents/FalkorDB/Poc/GraphRAG-SDK-Docs-Example/GraphRAG-SDK/graphrag_sdk/tests/test_graph_store.py -q`
- targeted ingestion of `docs/2603.25874v1.pdf` now succeeds (`INGEST_OK 143 368 52`)
- ingestion of all demo PDFs now succeeds (`2603.20674v1.pdf`, `2603.23825v1.pdf`, `2603.25874v1.pdf`)

Conversation: https://app.warp.dev/conversation/4136209a-ba0b-438b-a95d-d603404f0029

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strip unsupported control characters from node IDs, relationship endpoint IDs, and string property values before graph upserts; drop items that become empty after sanitization to avoid parse errors.
* **Documentation**
  * Added README note describing ingestion sanitization behavior for IDs and string properties.
* **Tests**
  * Added tests validating control-character removal (including strings inside lists) and proper handling of dropped items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->