### PR TITLE
Docs/readme quickstart first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> 🧪 **v1.0.0rc1 is available as a pre-release.** Install with `pip install graphrag-sdk --pre` or pin `==1.0.0rc1`. This is a **breaking** rewrite from v0.x. Stable users: `pip install graphrag-sdk` still gives you v0.8.2 by default.
+> 📦 Still on the v0.x API? Pin the legacy release: `pip install graphrag-sdk==0.8.2`.
 
 <h1 align="center">GraphRAG-SDK</h1>
 <h2 align="center">The simplest, most accurate GraphRAG framework built on FalkorDB</h2>

--- a/README.md
+++ b/README.md
@@ -35,31 +35,6 @@ Most GraphRAG systems work in demos and break under production constraints. Grap
 
 ---
 
-![document-to-provenance-answer-flow-v1](https://github.com/user-attachments/assets/afd1607e-20e1-4954-95f2-274701f5d61d)
-
-
-## Ingestion & Retrieval Pipeline
-
-| Area | Item | Execution | Description |
-| --- | --- | --- | --- |
-| Ingestion | 1. Load | Sequential | Read raw text from files (PDF, TXT) or strings. |
-| Ingestion | 2. Chunk | Sequential | Split content into overlapping text chunks. |
-| Ingestion | 3. Lexical Graph | Sequential | Create `Document` and `Chunk` nodes with provenance edges. |
-| Ingestion | 4. Extract | Sequential | Run GLiNER2 local NER and LLM-based relationship extraction. |
-| Ingestion | 5. Quality Filter | Sequential | Remove invalid extracted nodes (empty IDs, malformed shape). |
-| Ingestion | 6. Prune | Sequential | Filter nodes/relations against the schema; drop orphan relations. |
-| Ingestion | 7. Resolve | Sequential | Deduplicate entities (exact match, semantic, LLM-verified). |
-| Ingestion | 8. Write | Sequential | Persist graph updates with batched `MERGE` operations in FalkorDB. |
-| Ingestion | 9a. Mentions | Parallel | Link entities back to source chunks. |
-| Ingestion | 9b. Index | Parallel | Embed and index chunks for retrieval. |
-| Retrieval | Vector search | Runtime | Finds semantically similar chunks. |
-| Retrieval | Full-text search | Runtime | Matches exact terms and keywords. |
-| Retrieval | Cypher queries | Runtime | Executes structured graph lookups. |
-| Retrieval | Relationship expansion | Runtime | Traverses connected entities and context. |
-| Retrieval | Cosine reranking | Runtime | Reorders candidates by relevance. |
-
-> 💡 Every answer is traceable to its source chunks via `MENTIONS` edges. Pass `return_context=True` to `completion()` to get the retrieval trail alongside the answer.
-
 ## Quick Start
 
 ### 1. Install and start FalkorDB
@@ -127,6 +102,34 @@ async with GraphRAG(
 ) as rag:
     ...  # ingest / completion as above
 ```
+
+---
+
+![document-to-provenance-answer-flow-v1](https://github.com/user-attachments/assets/afd1607e-20e1-4954-95f2-274701f5d61d)
+
+
+## Ingestion & Retrieval Pipeline
+
+| Area | Item | Execution | Description |
+| --- | --- | --- | --- |
+| Ingestion | 1. Load | Sequential | Read raw text from files (PDF, TXT) or strings. |
+| Ingestion | 2. Chunk | Sequential | Split content into overlapping text chunks. |
+| Ingestion | 3. Lexical Graph | Sequential | Create `Document` and `Chunk` nodes with provenance edges. |
+| Ingestion | 4. Extract | Sequential | Run GLiNER2 local NER and LLM-based relationship extraction. |
+| Ingestion | 5. Quality Filter | Sequential | Remove invalid extracted nodes (empty IDs, malformed shape). |
+| Ingestion | 6. Prune | Sequential | Filter nodes/relations against the schema; drop orphan relations. |
+| Ingestion | 7. Resolve | Sequential | Deduplicate entities (exact match, semantic, LLM-verified). |
+| Ingestion | 8. Write | Sequential | Persist graph updates with batched `MERGE` operations in FalkorDB. |
+| Ingestion | 9a. Mentions | Parallel | Link entities back to source chunks. |
+| Ingestion | 9b. Index | Parallel | Embed and index chunks for retrieval. |
+| Retrieval | Vector search | Runtime | Finds semantically similar chunks. |
+| Retrieval | Full-text search | Runtime | Matches exact terms and keywords. |
+| Retrieval | Cypher queries | Runtime | Executes structured graph lookups. |
+| Retrieval | Relationship expansion | Runtime | Traverses connected entities and context. |
+| Retrieval | Cosine reranking | Runtime | Reorders candidates by relevance. |
+
+> 💡 Every answer is traceable to its source chunks via `MENTIONS` edges. Pass `return_context=True` to `completion()` to get the retrieval trail alongside the answer.
+
 ---
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ async with GraphRAG(
 
 ---
 
+## Development Milestones
+- 2024-06: First public release
+- 2024-Q4: PDF ingestion and multi-provider LLMs
+- 2025-Q1–Q2: Pluggable providers and pipeline tuning
+- 2025-Q3: Sharper retrieval, deeper test coverage
+- 🎉 2026-04: Version 1.0 is released
+- 2026-Q2: Increase production capabilities — timeouts, logs; expand ingestion support — tables, structured data
+- 2026-Q3: Introduce Agentic GraphRAG; complete PDF ingestion
+- 2026-Q4: Smarter retrieval — dynamic traversal, temporal graph
+
+---
+
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and code style guidelines.


### PR DESCRIPTION
This pull request updates the `README.md` to improve clarity for users on legacy and current versions, reorganizes the ingestion and retrieval pipeline documentation, and adds a new section outlining development milestones. The changes mainly focus on documentation clarity and project roadmap visibility.

Documentation improvements:

* Clarified installation instructions for users on the v0.x API by explicitly suggesting to pin to version `0.8.2` for legacy usage.
* Moved the ingestion and retrieval pipeline section, including its diagram and detailed step table, to a later part of the README for better flow and readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-L62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R105-R132)

Project roadmap:

* Added a new "Development Milestones" section outlining major planned features and release targets through 2026, giving users visibility into the project's future direction.## Summary



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance with clear instructions to pin the legacy v0.x API version via pip for users requiring the older version.
  * Reorganized README structure by moving the Ingestion & Retrieval Pipeline section to follow Quick Start for improved documentation flow.
  * Introduced Development Milestones section showcasing historical releases and upcoming roadmap targets including Version 1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->