### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0rc1] - 2026-04-16
+## [1.0.0] - 2026-04-21
 
-Release candidate for v1.0. Opt-in via `pip install graphrag-sdk --pre`. Stable
-installs (`pip install graphrag-sdk`) continue to resolve to v0.8.2 by design.
-
-Everything below this line is the v1.0 changelog, unchanged from the `[1.0.0]`
-draft — content is final for the stable release.
+First stable release of the v1.0 rewrite. `pip install graphrag-sdk` now resolves
+to this version by default. Legacy v0.x users can pin `graphrag-sdk==0.8.2`.
 
 ### Added
 

--- a/graphrag_sdk/README.md
+++ b/graphrag_sdk/README.md
@@ -4,7 +4,7 @@
 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/LICENSE)
-[![Version: 1.0.0rc1](https://img.shields.io/badge/version-1.0.0rc1-blue.svg)](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/pyproject.toml)
+[![Version: 1.0.0](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/pyproject.toml)
 [![Tests: 582 passing](https://img.shields.io/badge/tests-582%20passing-brightgreen.svg)](https://github.com/FalkorDB/GraphRAG-SDK/tree/main/graphrag_sdk/tests/)
 
 GraphRAG SDK builds knowledge graphs from documents and answers questions over them using retrieval-augmented generation. Every algorithmic concern (chunking, extraction, resolution, retrieval, reranking) is a swappable strategy behind an abstract interface. The default pipeline scores **~85% accuracy** on a 100-question benchmark using GPT-4.1.

--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphrag-sdk"
-version = "1.0.0rc1"
+version = "1.0.0"
 description = "The most accurate Graph RAG framework. Build knowledge graphs and query them with natural language. Built on FalkorDB."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -11,7 +11,7 @@
 #   Adaptability — Optimization-ready core, strategies are swappable.
 #   Velocity — Production-grade throughput.
 
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0"
 
 # ── API Surface (Facade) ────────────────────────────────────────
 from graphrag_sdk.api.main import GraphRAG


### PR DESCRIPTION
## Summary
- Bump version from \`1.0.0rc1\` to \`1.0.0\` in \`pyproject.toml\` and \`__version__\`
- Update version badge in \`graphrag_sdk/README.md\`
- Rewrite CHANGELOG heading \`[1.0.0rc1]\` → \`[1.0.0] - 2026-04-21\`

Once merged, tag \`v1.0.0\` on the merge commit and publish a GitHub Release (not pre-release) to trigger the PyPI publish workflow. After that, \`pip install graphrag-sdk\` resolves to 1.0.0 by default instead of falling back to the legacy 0.8.2.

## Test plan
- [x] \`__version__\` matches \`pyproject.toml\` version (workflow tag-check parity)
- [x] \`test_integration.TestTopLevelImports::test_version\` regex accepts \`1.0.0\`
- [ ] CI passes on this branch
- [ ] After merge: tag \`v1.0.0\`, create Release with "Set as a pre-release" unchecked, verify PyPI publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.0.0 with updated package metadata across all configuration files. Default pip install now resolves to 1.0.0. Previous stable versions remain available for users requiring pinned dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->