### PR TITLE
docs: GraphRAG-Bench Novel benchmark refresh + 256-dim embedder default

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -233,7 +233,7 @@ This step is important for query accuracy. It merges duplicate entities (e.g., "
 
 - [docs/configuration.md](configuration.md) -- Tuning connection settings, chunking parameters, and retrieval options.
 - [docs/strategies.md](strategies.md) -- Custom extraction and resolution strategies.
-- [docs/benchmark.md](benchmark.md) -- Reproducing benchmark results on the 100-question novel corpus.
+- [docs/benchmark.md](benchmark.md) -- Reproducing benchmark results on the GraphRAG-Bench Novel corpus (20 novels, 2,010 questions).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ GraphRAG SDK builds knowledge graphs from documents and answers questions over t
 
 ## Key Highlights
 
-- **~85% accuracy** on a 100-question benchmark
+- **#1 on GraphRAG-Bench Novel** — 63.73 ACC on 2,010 questions ([benchmark](benchmark.md))
 - **Simple API** -- `ingest()` + `completion()` with sensible defaults
 - **100+ LLM providers** via LiteLLM (OpenAI, Azure, Anthropic, Cohere, Ollama, and more)
 - **Fully modular** -- swap chunking, extraction, resolution, retrieval, and reranking strategies

--- a/graphrag_sdk/README.md
+++ b/graphrag_sdk/README.md
@@ -152,16 +152,18 @@ Every algorithmic concern is a swappable strategy behind an abstract base class:
 
 ## Benchmark
 
-**~85% accuracy** (8.5/10) on a 100-question benchmark over 20 Project Gutenberg novels.
+**#1 on [GraphRAG-Bench](https://graphrag-bench.github.io) Novel** — 63.73 ACC, ahead of MS-GraphRAG (50.93) and LightRAG (45.09).
 
 | Metric | Value |
 |--------|-------|
-| **Accuracy** | ~85% (8.5/10) |
-| **Questions** | 100 (fact retrieval, complex reasoning, summarization) |
-| **Documents** | 20 novels (Project Gutenberg) |
-| **Query P50** | 5.4s |
+| **Novel ACC** | 63.73 (#1) |
+| **Fact retrieval** | 65.22 |
+| **Complex reasoning** | 58.63 |
+| **Contextual summarization** | 69.54 |
+| **Creative generation** | 57.08 |
+| **Questions** | 2,010 across 20 novels |
 
-See [docs/benchmark.md](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/docs/benchmark.md) for full methodology and reproduction instructions.
+See [docs/benchmark.md](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/docs/benchmark.md) for methodology and reproduction.
 
 ## Examples
 

--- a/graphrag_sdk/examples/01_quickstart.py
+++ b/graphrag_sdk/examples/01_quickstart.py
@@ -40,7 +40,7 @@ def get_providers():
 
     # ── Option A: OpenAI (default) ──────────────────────────────
     llm = LiteLLM(model="openai/gpt-4o")
-    embedder = LiteLLMEmbedder(model="openai/text-embedding-3-small")
+    embedder = LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=256)
 
     # ── Option B: Azure OpenAI ──────────────────────────────────
     # llm = LiteLLM(
@@ -66,6 +66,7 @@ async def main():
         connection=ConnectionConfig(host="localhost", graph_name="quickstart"),
         llm=llm,
         embedder=embedder,
+        embedding_dimension=256,
     ) as rag:
         # 1. Ingest text
         result = await rag.ingest("quickstart_doc", text=TEXT)


### PR DESCRIPTION
## Summary
Cherry-picks the accurate pieces of #224 (which won't be merged as a whole).

- \`docs/getting-started.md\` and \`docs/index.md\`: replace "~85% / 100-question" wording with the GraphRAG-Bench Novel numbers (63.73 ACC / 2,010 questions)
- \`graphrag_sdk/README.md\`: refresh benchmark table with the Novel sub-category breakdown
- \`graphrag_sdk/examples/01_quickstart.py\`: switch default embedder to \`text-embedding-3-large\` with \`dimensions=256\` and pass matching \`embedding_dimension=256\` to \`GraphRAG\`

Skipped from #224: migration guide + FAQ (stale v0.8.2 framing and three inaccuracies — nonexistent \`[semantic]\` extra, fake \`ChainedResolution\` class, and \`gpt-5.4\` model).

## Test plan
- [ ] CI passes
- [ ] \`examples/01_quickstart.py\` runs end-to-end with an OpenAI key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark documentation with specific GraphRAG-Bench Novel results (63.73 ACC over 2,010 questions)

* **Chores**
  * Updated quickstart example with revised embedder configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->