### PR TITLE
docs(readme): onboarding polish; align default embedding_dimension to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Default `embedding_dimension` lowered from 1536 to 256.** Aligns
+  the out-of-the-box default with the `text-embedding-3-large`
+  Matryoshka 256-dim configuration used in the benchmark (overall
+  ACC 69.73). Affects `GraphRAG(...)` and `VectorStore(...)` when
+  `embedding_dimension` is left unset; existing graphs created
+  with the prior default continue to work because the dimension
+  is stored in the FalkorDB vector index. To preserve the old
+  behavior on new graphs, pass `embedding_dimension=1536`
+  explicitly. README, getting-started, api-reference, storage,
+  graph-schema docs, and the custom-provider example updated to
+  match.
+
 ## [1.0.1] - 2026-04-28
 
 Security and API hygiene release addressing findings from a full

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <h1 align="center">GraphRAG-SDK</h1>
 <h2 align="center">The simplest, most accurate GraphRAG framework built on FalkorDB</h2>
 
-<p align="center"><b>Benchmark-leading accuracy</b> · <b>FalkorDB-fast</b> · <b>Multi-tenant</b> · <b>Graph traversal</b> · <b>5-minute setup</b></p>
-
-<p align="center"><b>→ <a href="#quick-start">Get started in 5 minutes</a></b></p>
+<p align="center"><b>Benchmark-leading accuracy</b> · <b>FalkorDB-fast</b> · <b>Multi-tenant</b> · <b>Graph traversal</b> · <b><a href="#quick-start">5-minute setup</a></b></p>
 
 <p align="center">
   <a href="https://pypi.org/project/graphrag-sdk/"><img src="https://img.shields.io/pypi/v/graphrag-sdk.svg?label=pypi" alt="PyPI version"></a>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-> 📦 Still on the v0.x API? Pin the legacy release: `pip install graphrag-sdk==0.8.2`.
-
 <h1 align="center">GraphRAG-SDK</h1>
 <h2 align="center">The simplest, most accurate GraphRAG framework built on FalkorDB</h2>
 
 <p align="center"><b>Benchmark-leading accuracy</b> · <b>FalkorDB-fast</b> · <b>Multi-tenant</b> · <b>Graph traversal</b> · <b>5-minute setup</b></p>
+
+<p align="center"><b>→ <a href="#quick-start">Get started in 5 minutes</a></b></p>
 
 <p align="center">
   <a href="https://pypi.org/project/graphrag-sdk/"><img src="https://img.shields.io/pypi/v/graphrag-sdk.svg?label=pypi" alt="PyPI version"></a>
@@ -171,6 +171,7 @@ async with GraphRAG(
 - 2025-Q1–Q2: Pluggable providers and pipeline tuning
 - 2025-Q3: Sharper retrieval, deeper test coverage
 - 🎉 2026-04: Version 1.0 is released
+  - 📦 Still on the v0.x API? Pin the legacy release: `pip install graphrag-sdk==0.8.2`
 - 2026-Q2: Production observability; expand ingestion support — tables, structured data
 - 2026-Q3: Introduce Agentic GraphRAG; complete PDF ingestion
 - 2026-Q4: Smarter retrieval — dynamic traversal, temporal graph

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ async with GraphRAG(
 - 2024-Q4: PDF ingestion and multi-provider LLMs
 - 2025-Q1–Q2: Pluggable providers and pipeline tuning
 - 2025-Q3: Sharper retrieval, deeper test coverage
-- 🎉 2026-04: Version 1.0 is released
+- 🎉 2026-04: Version 1.0 is released with a new set of benchmarks based on a year's worth of research and customer PoCs
   - 📦 Still on the v0.x API? Pin the legacy release: `pip install graphrag-sdk==0.8.2`
 - 2026-Q2: Production observability; expand ingestion support — tables, structured data
 - 2026-Q3: Introduce Agentic GraphRAG; complete PDF ingestion

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 <h1 align="center">GraphRAG-SDK</h1>
 <h2 align="center">The simplest, most accurate GraphRAG framework built on FalkorDB</h2>
 
+<p align="center"><b>Benchmark-leading accuracy</b> · <b>FalkorDB-fast</b> · <b>Multi-tenant</b> · <b>Graph traversal</b> · <b>5-minute setup</b></p>
+
 <p align="center">
+  <a href="https://pypi.org/project/graphrag-sdk/"><img src="https://img.shields.io/pypi/v/graphrag-sdk.svg?label=pypi" alt="PyPI version"></a>
+  <a href="https://pepy.tech/projects/graphrag-sdk"><img src="https://img.shields.io/pepy/dt/graphrag-sdk?label=downloads&color=16A534" alt="Downloads"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python 3.10+"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-green.svg" alt="License: Apache 2.0"></a>
   <a href="https://github.com/FalkorDB/GraphRAG-SDK/actions"><img src="https://img.shields.io/github/actions/workflow/status/FalkorDB/GraphRAG-SDK/ci.yml?label=CI" alt="CI"></a>
@@ -14,7 +18,7 @@
 ![knowledge-graph-construction-b](https://github.com/user-attachments/assets/69066899-0168-4e14-b359-f68c5b6c1e75)
 
 
-Most GraphRAG systems work in demos and break under production constraints. GraphRAG SDK was built from real deployments around a simple idea: the retrieval harness matters more than the model. The result is a modular, benchmark-leading framework with predictable cost and sensible defaults that gets you from raw documents to cited answers quickly.
+Most GraphRAG systems work in demos and break under production constraints. GraphRAG SDK was built from real deployments around a simple idea: the retrieval harness matters more than the model. The result is a modular, benchmark-leading framework with predictable cost and sensible defaults that gets you from raw documents to cited answers in under 5 minutes.
 
 ---
 
@@ -32,6 +36,8 @@ Most GraphRAG systems work in demos and break under production constraints. Grap
 | 9 | MS-GraphRAG (local) | 50.93 | 45.16 | 48.05 |
 
 > Overall ACC on [GraphRAG-Bench](https://graphrag-bench.github.io) Novel (20 novels, 2,010 questions) and Medical (1 corpus, 2,062 questions) datasets. FalkorDB scored with `gpt-4o-mini` (Azure OpenAI); competitor numbers are from the published leaderboard. Overall = mean of Novel and Medical ACC. See [docs/benchmark.md](docs/benchmark.md) for per-category breakdowns, methodology, and reproduction instructions.
+
+Vectors match similar chunks. The graph traverses relationships. Every answer cites its source.
 
 ---
 
@@ -56,9 +62,9 @@ from graphrag_sdk import GraphRAG, ConnectionConfig, LiteLLM, LiteLLMEmbedder
 
 async def main():
     async with GraphRAG(
-        connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
+        connection=ConnectionConfig(host="localhost", graph_name="my_graph"),  # graph_name = per-tenant isolation
         llm=LiteLLM(model="openai/gpt-5.5"),
-        embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=1536),
+        embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=256),
     ) as rag:
         # Ingest raw text (pass a file path with the `pdf` extra installed for PDFs)
         result = await rag.ingest(
@@ -97,11 +103,16 @@ schema = GraphSchema(
 async with GraphRAG(
     connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
     llm=LiteLLM(model="openai/gpt-5.5"),
-    embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=1536),
+    embedder=LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=256),
     schema=schema,
 ) as rag:
     ...  # ingest / completion as above
 ```
+
+<p align="center">
+  <b>→ Full walkthrough: <a href="docs/getting-started.md">Getting Started</a></b><br/>
+  <b>→ Benchmark-winning recipe: <a href="graphrag_sdk/examples/03_custom_strategies.py">Custom Strategies</a></b>
+</p>
 
 ---
 
@@ -110,23 +121,17 @@ async with GraphRAG(
 
 ## Ingestion & Retrieval Pipeline
 
-| Area | Item | Execution | Description |
-| --- | --- | --- | --- |
-| Ingestion | 1. Load | Sequential | Read raw text from files (PDF, TXT) or strings. |
-| Ingestion | 2. Chunk | Sequential | Split content into overlapping text chunks. |
-| Ingestion | 3. Lexical Graph | Sequential | Create `Document` and `Chunk` nodes with provenance edges. |
-| Ingestion | 4. Extract | Sequential | Run GLiNER2 local NER and LLM-based relationship extraction. |
-| Ingestion | 5. Quality Filter | Sequential | Remove invalid extracted nodes (empty IDs, malformed shape). |
-| Ingestion | 6. Prune | Sequential | Filter nodes/relations against the schema; drop orphan relations. |
-| Ingestion | 7. Resolve | Sequential | Deduplicate entities (exact match, semantic, LLM-verified). |
-| Ingestion | 8. Write | Sequential | Persist graph updates with batched `MERGE` operations in FalkorDB. |
-| Ingestion | 9a. Mentions | Parallel | Link entities back to source chunks. |
-| Ingestion | 9b. Index | Parallel | Embed and index chunks for retrieval. |
-| Retrieval | Vector search | Runtime | Finds semantically similar chunks. |
-| Retrieval | Full-text search | Runtime | Matches exact terms and keywords. |
-| Retrieval | Cypher queries | Runtime | Executes structured graph lookups. |
-| Retrieval | Relationship expansion | Runtime | Traverses connected entities and context. |
-| Retrieval | Cosine reranking | Runtime | Reorders candidates by relevance. |
+| Area | Step | Cost |
+| --- | --- | --- |
+| Ingestion | Extract entities & relations | LLM |
+| Ingestion | Resolve & deduplicate entities | LLM |
+| Ingestion | Embed & index | LLM |
+| Retrieval | Vector search | DB |
+| Retrieval | Full-text search | DB |
+| Retrieval | Text-to-Cypher *(experimental)* | LLM |
+| Retrieval | Cypher queries | DB |
+| Retrieval | Relationship expansion | DB |
+| Retrieval | Cosine reranking | Local |
 
 > 💡 Every answer is traceable to its source chunks via `MENTIONS` edges. Pass `return_context=True` to `completion()` to get the retrieval trail alongside the answer.
 
@@ -134,13 +139,15 @@ async with GraphRAG(
 
 ## Examples
 
-| # | Example | What it demonstrates |
-|---|---------|---------------------|
-| 1 | [Quick Start](graphrag_sdk/examples/01_quickstart.py) | Minimal ingest + query |
-| 2 | [PDF with Schema](graphrag_sdk/examples/02_pdf_with_schema.py) | PDF ingestion with custom entity types |
-| 3 | [Custom Strategies](graphrag_sdk/examples/03_custom_strategies.py) | Benchmark-winning pipeline configuration |
-| 4 | [Custom Provider](graphrag_sdk/examples/04_custom_provider.py) | Implement your own LLM/Embedder |
-| 5 | [Notebook Demo](graphrag_sdk/examples/05_notebook_demo.ipynb) | Interactive walkthrough with provenance inspection |
+> **Working starters — clone, plug in your source, ship.**
+
+| # | Example | What you'll build |
+|---|---------|-------------------|
+| 1 | [Quick Start](graphrag_sdk/examples/01_quickstart.py) | Your first ingest-and-query loop in under 30 lines |
+| 2 | [PDF with Schema](graphrag_sdk/examples/02_pdf_with_schema.py) | A PDF Q&A bot with your own entity and relation types |
+| 3 | [Custom Strategies](graphrag_sdk/examples/03_custom_strategies.py) | The benchmark-winning pipeline, ready to drop in |
+| 4 | [Custom Provider](graphrag_sdk/examples/04_custom_provider.py) | Plug in any LLM or embedder behind a clean interface |
+| 5 | [Notebook Demo](graphrag_sdk/examples/05_notebook_demo.ipynb) | An interactive walkthrough that shows the provenance trail |
 
 ---
 
@@ -164,7 +171,7 @@ async with GraphRAG(
 - 2025-Q1–Q2: Pluggable providers and pipeline tuning
 - 2025-Q3: Sharper retrieval, deeper test coverage
 - 🎉 2026-04: Version 1.0 is released
-- 2026-Q2: Increase production capabilities — timeouts, logs; expand ingestion support — tables, structured data
+- 2026-Q2: Production observability; expand ingestion support — tables, structured data
 - 2026-Q3: Introduce Agentic GraphRAG; complete PDF ingestion
 - 2026-Q4: Smarter retrieval — dynamic traversal, temporal graph
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -720,7 +720,7 @@ GraphStore(connection: FalkorDBConnection)
 ### VectorStore
 
 ```python
-VectorStore(connection, embedder=None, index_name="chunk_embeddings", embedding_dimension=1536, similarity_function="cosine")
+VectorStore(connection, embedder=None, index_name="chunk_embeddings", embedding_dimension=256, similarity_function="cosine")
 ```
 
 | Method | Signature | Description |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,13 +96,13 @@ from graphrag_sdk import GraphRAG, ConnectionConfig, LiteLLM, LiteLLMEmbedder
 rag = GraphRAG(
     connection=ConnectionConfig(host="localhost", graph_name="my_graph"),
     llm=LiteLLM(model="azure/gpt-4.1"),
-    embedder=LiteLLMEmbedder(model="azure/text-embedding-ada-002"),
+    embedder=LiteLLMEmbedder(model="azure/text-embedding-3-large", dimensions=256),
     schema=schema,
-    embedding_dimension=1536,  # must match your embedding model's output dimension
+    embedding_dimension=256,  # must match your embedding model's output dimension
 )
 ```
 
-If your embedding model produces vectors with a different dimensionality (e.g., `text-embedding-3-large` at 256 or 1024 dimensions), set `embedding_dimension` accordingly. The default is `1536`.
+The default is `256` (matched-Matryoshka dimensions of `text-embedding-3-large`). If your embedding model produces a different dimensionality (e.g., 1024, 1536, or 3072), set `embedding_dimension` accordingly.
 
 `ConnectionConfig` accepts additional parameters such as `port`, `username`, `password`, and `query_timeout_ms`. See [docs/configuration.md](configuration.md) for the full list.
 

--- a/docs/graph-schema.md
+++ b/docs/graph-schema.md
@@ -162,7 +162,7 @@ The SDK creates 5 standard indexes during `finalize()` (or `ensure_indices()`). 
 **Syntax:**
 ```
 CREATE VECTOR INDEX FOR (n:Chunk) ON (n.embedding)
-OPTIONS {dimension:1536, similarityFunction:'cosine'}
+OPTIONS {dimension:256, similarityFunction:'cosine'}
 ```
 
 ### Fulltext Indexes (2)

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -98,7 +98,7 @@ Node labels and relationship types are sanitized via `sanitize_cypher_label()` t
 
 ```
 CREATE VECTOR INDEX FOR (n:Chunk) ON (n.embedding)
-OPTIONS {dimension:1536, similarityFunction:'cosine'}
+OPTIONS {dimension:256, similarityFunction:'cosine'}
 ```
 
 **Fulltext indexes** use the RediSearch-based fulltext API:
@@ -112,7 +112,7 @@ CALL db.idx.fulltext.createNodeIndex('__Entity__', 'name', 'description')
 
 ```
 CREATE VECTOR INDEX FOR ()-[e:`RELATES`]->() ON (e.embedding)
-OPTIONS {dimension:1536, similarityFunction:'cosine'}
+OPTIONS {dimension:256, similarityFunction:'cosine'}
 ```
 
 All index creation is idempotent — if the index already exists, the error is silently caught and logged at debug level.

--- a/graphrag_sdk/examples/04_custom_provider.py
+++ b/graphrag_sdk/examples/04_custom_provider.py
@@ -76,7 +76,7 @@ class MyCustomEmbedder(Embedder):
     / `aembed_documents()` for async support.
     """
 
-    def __init__(self, dimension: int = 1536) -> None:
+    def __init__(self, dimension: int = 256) -> None:
         self.dimension = dimension
         # Initialize your embedding model here, e.g.:
         # self.model = SentenceTransformer("all-MiniLM-L6-v2")
@@ -113,7 +113,7 @@ async def main():
     rag = GraphRAG(
         connection=ConnectionConfig(host="localhost", graph_name="custom_provider_demo"),
         llm=MyCustomLLM(model_name="my-local-llama"),
-        embedder=MyCustomEmbedder(dimension=1536),
+        embedder=MyCustomEmbedder(dimension=256),
     )
 
     # Ingest with custom providers

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -159,7 +159,7 @@ class GraphRAG:
         embedder: Embedder,
         schema: GraphSchema | None = None,
         retrieval_strategy: RetrievalStrategy | None = None,
-        embedding_dimension: int = 1536,
+        embedding_dimension: int = 256,
     ) -> None:
         # Connection
         if isinstance(connection, ConnectionConfig):

--- a/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
@@ -61,7 +61,7 @@ class VectorStore:
 
     Example::
 
-        store = VectorStore(connection, embedder=my_embedder, embedding_dimension=1536)
+        store = VectorStore(connection, embedder=my_embedder, embedding_dimension=256)
         await store.ensure_indices()
         await store.index_chunks(chunks)
         results = await store.search_chunks(query_vector, top_k=5)
@@ -71,7 +71,7 @@ class VectorStore:
         self,
         connection: FalkorDBConnection,
         embedder: Any | None = None,
-        embedding_dimension: int = 1536,
+        embedding_dimension: int = 256,
     ) -> None:
         if not 1 <= embedding_dimension <= _MAX_EMBEDDING_DIMENSION:
             raise ValueError(


### PR DESCRIPTION
This pull request updates the default embedding dimension throughout the SDK and documentation from 1536 to 256 to align with the `text-embedding-3-large` Matryoshka 256-dim configuration used in benchmarks. It also updates documentation and examples to reflect this new default, clarifies usage instructions, and makes minor improvements to the README for clarity and accuracy.

**Default embedding dimension update:**

* The default `embedding_dimension` parameter is now 256 (was 1536) in `GraphRAG(...)`, `VectorStore(...)`, and all related APIs and examples. This affects new graphs unless the dimension is explicitly set; existing graphs are unaffected as the dimension is stored in the vector index. [[1]](diffhunk://#diff-9021fcf2be09d0797f9189a88453a04b70ee82ff409944b539fd2167110b3286L162-R162) [[2]](diffhunk://#diff-2c59502af5eb4e61a8ce4013c7b752eb81495eb137b453f41a180106d0f6148dL74-R74) [[3]](diffhunk://#diff-2c59502af5eb4e61a8ce4013c7b752eb81495eb137b453f41a180106d0f6148dL64-R64) [[4]](diffhunk://#diff-3a26a919d9ee36557b790fb33d6efb9513add5b51b9ae2dde248a0a6ae313c64L79-R79) [[5]](diffhunk://#diff-3a26a919d9ee36557b790fb33d6efb9513add5b51b9ae2dde248a0a6ae313c64L116-R116) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R23)

**Documentation and example updates:**

* Updated all code snippets, API references, and schema/storage documentation to use the new default of 256 for `embedding_dimension`, including `README.md`, `docs/api-reference.md`, `docs/getting-started.md`, `docs/graph-schema.md`, `docs/storage.md`, and example scripts. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R67) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L100-R150) [[3]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cL723-R723) [[4]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L99-R105) [[5]](diffhunk://#diff-fe25f4f07c6665ccab0512e4b3a607153e070befaa81f8e2d107e11d195911d4L165-R165) [[6]](diffhunk://#diff-1e47e7218df597c79a882aa1c109e42c332234bd8c92e1c493a788f8f64bb328L101-R101) [[7]](diffhunk://#diff-1e47e7218df597c79a882aa1c109e42c332234bd8c92e1c493a788f8f64bb328L115-R115)

**README and onboarding improvements:**

* Enhanced the README with clearer feature highlights, updated quick start instructions, clarified example descriptions, and reworded several sections for improved onboarding and transparency about default behaviors and supported features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R6-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R21) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R40-R41) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L167-R174)

These changes ensure that new users default to a strong, benchmark-aligned configuration and that all documentation is consistent and easy to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Default embedding dimension reduced from 1536 → 256 for GraphRAG/VectorStore
  * Existing graphs remain compatible
  * Pass embedding_dimension=1536 to preserve prior behavior for new graphs

* **Documentation**
  * README, guides, API docs, examples, and walkthroughs updated to reflect new defaults, clarified dimensionality guidance, refreshed examples/badges, and added an experimental "Text-to-Cypher" step
<!-- end of auto-generated comment: release notes by coderabbit.ai -->