### PR TITLE
feat: introduce StructuralChunking, add MarkdownLoader

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -6,8 +6,8 @@ GraphRAG SDK uses the **Strategy pattern** for every algorithmic concern. Each c
 
 | # | Concern | ABC | Built-in Implementations |
 |---|---------|-----|------------------------|
-| 1 | Loading | `LoaderStrategy` | `TextLoader`, `PdfLoader` |
-| 2 | Chunking | `ChunkingStrategy` | `FixedSizeChunking`, `SentenceTokenCapChunking`, `ContextualChunking`, `CallableChunking` |
+| 1 | Loading | `LoaderStrategy` | `TextLoader`, `PdfLoader`, `MarkdownLoader` |
+| 2 | Chunking | `ChunkingStrategy` | `FixedSizeChunking`, `SentenceTokenCapChunking`, `ContextualChunking`, `CallableChunking`, `StructuralChunking` |
 | 3 | Extraction | `ExtractionStrategy` | `GraphExtraction` |
 | 4 | Resolution | `ResolutionStrategy` | `ExactMatchResolution`, `DescriptionMergeResolution` |
 | 5 | Retrieval | `RetrievalStrategy` | `LocalRetrieval`, `MultiPathRetrieval` |
@@ -51,11 +51,22 @@ from graphrag_sdk.ingestion.loaders.pdf_loader import PdfLoader
 loader = PdfLoader()
 ```
 
+### Built-in: MarkdownLoader
+
+Extracts text from Markdown files. Requires `pip install graphrag-sdk[markdown]`.
+
+```python
+from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+
+loader = MarkdownLoader()
+```
+
 ### Default Behavior
 
 If no loader is specified in `ingest()`:
 - `.pdf` files use `PdfLoader`
-- Everything else uses `TextLoader`
+- `.md` files use `MarkdownLoader`
+-   Everything else uses `TextLoader`
 - If `text=` is passed directly, the loader is skipped
 
 ### Writing Your Own
@@ -150,6 +161,20 @@ from graphrag_sdk.ingestion.chunking_strategies.callable_chunking import Callabl
 # Plain function
 chunker = CallableChunking(lambda text: text.split("\n\n"))
 ```
+
+### Built-in: StructuralChunking
+
+Groups content by heading hierarchy into token-bounded chunks. Each chunk stores a breadcrumbs metadata field that is written as a property on the Chunk node in the knowledge graph, making section paths directly queryable via Cypher.
+
+```python
+from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+
+chunker = StructuralChunking(
+    max_tokens=512,  # max tokens per chunk (default: 512)
+    overlap_sentences=2,  # sentences shared between chunks (default: 2)
+)
+```
+
 
 ### Writing Your Own
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -178,6 +178,7 @@ chunker = StructuralChunking(
 **Design Features:**
 - **Strict Fallback Configuration:** If you supply a custom `fallback_chunker` (to handle elements that individually exceed `max_tokens`), you **cannot** pass shorthand arguments like `overlap_sentences` or `encoding_name` to `StructuralChunking`. Those must be configured directly on your custom fallback chunker instance. This prevents configuration parameters from being silently dropped.
 - **Deep-Tree Resilience:** While loaders like `MarkdownLoader` produce flat element lists, the internal `_flatten` algorithm uses a recursive DFS approach. This guarantees future compatibility with highly nested DOM structures (like HTML or DOCX parsers) while preserving full hierarchical breadcrumbs.
+- **Graceful Raw Text Fallback:** Designed to compose safely with *any* loader. If the preceding loader does not extract structural AST elements (e.g., `PdfLoader` or `TextLoader` which output `elements=None`), the chunker gracefully bypasses its structural logic and delegates the entire raw text to the fallback chunker, without crashing or dropping content.
 
 
 ### Writing Your Own

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -175,6 +175,10 @@ chunker = StructuralChunking(
 )
 ```
 
+**Design Features:**
+- **Strict Fallback Configuration:** If you supply a custom `fallback_chunker` (to handle elements that individually exceed `max_tokens`), you **cannot** pass shorthand arguments like `overlap_sentences` or `encoding_name` to `StructuralChunking`. Those must be configured directly on your custom fallback chunker instance. This prevents configuration parameters from being silently dropped.
+- **Deep-Tree Resilience:** While loaders like `MarkdownLoader` produce flat element lists, the internal `_flatten` algorithm uses a recursive DFS approach. This guarantees future compatibility with highly nested DOM structures (like HTML or DOCX parsers) while preserving full hierarchical breadcrumbs.
+
 
 ### Writing Your Own
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -61,6 +61,9 @@ from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
 loader = MarkdownLoader()
 ```
 
+**Design Note: Markup Preservation**
+For complex elements like tables, lists, and code blocks, `MarkdownLoader` intentionally outputs the raw markdown source (including pipes `|`, list dashes `-`, and code fences) rather than stripping the syntax. While this introduces minor syntax "noise", it preserves critical structural cues (such as spatial column alignment and nested indentation) that the LLM requires during the Extraction phase to accurately parse relational data.
+
 ### Default Behavior
 
 If no loader is specified in `ingest()`:

--- a/graphrag_sdk/examples/06_markdown_document_aware.py
+++ b/graphrag_sdk/examples/06_markdown_document_aware.py
@@ -1,0 +1,226 @@
+"""
+GraphRAG SDK -- Document-Aware Markdown Ingestion
+===================================================
+Ingest a Markdown file using structure-preserving chunking.
+
+Unlike fixed-size or sentence chunking, StructuralChunking groups
+content by heading hierarchy.  Each chunk carries ``breadcrumbs``
+(e.g. ["Installation", "Prerequisites"]) that become queryable
+properties on the Chunk nodes in the knowledge graph.
+
+MarkdownLoader strips raw markup from header content before the text
+reaches the LLM, so embeddings are clean and co-reference resolution
+works correctly.
+
+Prerequisites:
+    pip install graphrag-sdk[litellm,markdown]
+    docker run -p 6379:6379 falkordb/falkordb
+
+Usage:
+    # Generate a ready-to-use sample document and print its content:
+    python 06_markdown_document_aware.py --sample
+
+    # Ingest any markdown file:
+    python 06_markdown_document_aware.py path/to/document.md
+
+    # Quick end-to-end demo with the generated sample:
+    python 06_markdown_document_aware.py --sample          # creates sample_doc.md
+    python 06_markdown_document_aware.py sample_doc.md     # ingests it
+"""
+
+import asyncio
+import os
+import sys
+
+from graphrag_sdk import (
+    ConnectionConfig,
+    EntityType,
+    GraphRAG,
+    GraphSchema,
+    LiteLLM,
+    LiteLLMEmbedder,
+    RelationType,
+)
+from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+
+
+def create_schema() -> GraphSchema:
+    """Generic schema suitable for technical documentation."""
+    return GraphSchema(
+        entities=[
+            EntityType(label="Concept",      description="A technical concept, feature, or abstraction"),
+            EntityType(label="Component",    description="A software module, library, or service"),
+            EntityType(label="Technology",   description="A programming language, framework, or tool"),
+            EntityType(label="Person",       description="An author, contributor, or mentioned individual"),
+            EntityType(label="Organization", description="A company, team, or standards body"),
+        ],
+        relations=[
+            RelationType(
+                label="DEPENDS_ON",
+                description="Requires another component or technology",
+                patterns=[("Component", "Component"), ("Component", "Technology")],
+            ),
+            RelationType(
+                label="IMPLEMENTS",
+                description="Provides a concrete implementation of a concept",
+                patterns=[("Component", "Concept")],
+            ),
+            RelationType(
+                label="CREATED_BY",
+                description="Was authored or maintained by a person or organization",
+                patterns=[("Component", "Person"), ("Component", "Organization")],
+            ),
+            RelationType(
+                label="RELATED_TO",
+                description="Has a general relationship with",
+                patterns=[
+                    ("Concept", "Concept"),
+                    ("Component", "Concept"),
+                    ("Technology", "Concept"),
+                ],
+            ),
+        ],
+    )
+
+
+_SAMPLE_DOC = """
+# GraphRAG SDK
+
+GraphRAG SDK is an open-source Python library created by FalkorDB for building
+knowledge-graph-augmented retrieval systems.
+
+## Core Concepts
+
+### Knowledge Graph
+
+A knowledge graph stores entities and the relationships between them.
+GraphRAG SDK uses FalkorDB, a Redis-based graph database that supports
+the openCypher query language, as its graph backend.
+
+### Retrieval-Augmented Generation
+
+Retrieval-Augmented Generation (RAG) grounds language model responses in
+external knowledge by injecting retrieved context into the prompt before
+generation. GraphRAG SDK extends this pattern with a graph-structured index.
+
+## Components
+
+### IngestionPipeline
+
+The IngestionPipeline orchestrates loading, chunking, entity extraction,
+resolution, graph writing, and vector indexing in a fixed nine-step sequence.
+It depends on a LoaderStrategy, a ChunkingStrategy, an ExtractionStrategy,
+a ResolutionStrategy, a GraphStore, and a VectorStore.
+
+### MarkdownLoader
+
+MarkdownLoader parses Markdown files using markdown-it-py and produces
+structured DocumentElement objects that carry heading breadcrumbs.
+It was created by the FalkorDB engineering team and implements the
+LoaderStrategy interface.
+
+### StructuralChunking
+
+StructuralChunking groups DocumentElement objects by heading hierarchy
+into token-bounded chunks. Each chunk stores a breadcrumbs metadata field
+that is written as a property on the Chunk node in the knowledge graph,
+making section paths directly queryable via Cypher.
+
+### GraphExtraction
+
+GraphExtraction runs a two-step pipeline: local named-entity recognition
+powered by GLiNER, followed by LLM-assisted relationship extraction.
+It implements the ExtractionStrategy interface and depends on an LLM provider.
+"""
+
+
+def _write_sample_doc(path: str = "sample_doc.md") -> str:
+    """Write a compact sample markdown document to *path* and return the path."""
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(_SAMPLE_DOC.lstrip("\n"))
+    return path
+
+
+async def main():
+    if len(sys.argv) < 2 or sys.argv[1] == "--sample":
+        out = _write_sample_doc()
+        print(f"Sample document written to: {out}")
+        print()
+        print("Content preview:")
+        print("-" * 60)
+        print(_SAMPLE_DOC.strip())
+        print("-" * 60)
+        print()
+        print("Run the ingestion with:")
+        print(f"  python {sys.argv[0]} {out}")
+        sys.exit(0)
+
+    md_path = sys.argv[1]
+
+    # Providers
+    llm = LiteLLM(
+        model=f"gemini/{os.getenv('GEMINI_MODEL', 'gemini-3.1-pro-preview')}",
+        api_key=f"{os.getenv("GEMINI_API_KEY")}",
+    )
+    embedder = LiteLLMEmbedder(
+        model=f"gemini/{os.getenv('GEMINI_MODEL', 'gemini-embedding-002')}",
+        api_key=f"{os.getenv("GEMINI_API_KEY")}",
+    )
+
+    rag = GraphRAG(
+        connection=ConnectionConfig(host="localhost", graph_name="markdown_demo"),
+        llm=llm,
+        embedder=embedder,
+        schema=create_schema(),
+    )
+
+    # delete_all() must come BEFORE ingest().
+    # ingest() calls _validate_graph_config() as its first step, which reads the
+    # __GraphRAGConfig__ node from FalkorDB and raises ConfigError if the stored
+    # embedding model doesn't match the current one.  Wiping the graph here
+    # removes that stale node so the new run starts clean.
+    try:
+        await rag.delete_all()
+    except Exception:
+        pass  # Graph doesn't exist yet on first run — that's fine
+
+    # Ingest the markdown file.
+    # - MarkdownLoader parses heading hierarchy and produces structured elements.
+    # - StructuralChunking groups those elements into token-bounded chunks and
+    #   attaches breadcrumbs to each chunk's metadata so the graph is queryable
+    #   by section path (e.g. MATCH (c:Chunk) WHERE 'Installation' IN c.breadcrumbs).
+    print(f"Ingesting {md_path}...")
+    result = await rag.ingest(
+        md_path,
+        loader=MarkdownLoader(),
+        chunker=StructuralChunking(max_tokens=512),
+    )
+    print(f"Done: {result.nodes_created} nodes, {result.relationships_created} edges, "
+          f"{result.chunks_indexed} chunks indexed")
+
+    # Post-ingestion: dedup entities, embed entity/relationship descriptions,
+    # and build full-text + vector indexes.  Required before retrieval works.
+    await rag.finalize()
+
+    # Query the ingested document
+    question = "What are the main components or concepts described in this document?"
+    print(f"\nQ: {question}")
+
+    answer = await rag.completion(question, return_context=True)
+    print(f"A: {answer.answer}")
+
+    # Show retrieved context items
+    print(f"\nRetrieved {len(answer.retriever_result.items)} context items:")
+    for i, item in enumerate(answer.retriever_result.items[:5]):
+        score = item.score if item.score is not None else 0.0
+        print(f"  [{i+1}] (score={score:.3f}) {item.content[:120]}...")
+
+    # Graph statistics
+    stats = await rag.get_statistics()
+    print(f"\nGraph: {stats['node_count']} nodes, {stats['edge_count']} edges")
+    print(f"Entity types: {stats['entity_types']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/graphrag_sdk/examples/06_markdown_document_aware.py
+++ b/graphrag_sdk/examples/06_markdown_document_aware.py
@@ -161,11 +161,11 @@ async def main():
     # Providers
     llm = LiteLLM(
         model=f"gemini/{os.getenv('GEMINI_MODEL', 'gemini-3.1-pro-preview')}",
-        api_key=f"{os.getenv("GEMINI_API_KEY")}",
+        api_key=os.environ["GEMINI_API_KEY"],
     )
     embedder = LiteLLMEmbedder(
-        model=f"gemini/{os.getenv('GEMINI_MODEL', 'gemini-embedding-002')}",
-        api_key=f"{os.getenv("GEMINI_API_KEY")}",
+        model=f"gemini/{os.getenv('GEMINI_EMBED_MODEL', 'gemini-embedding-002')}",
+        api_key=os.environ["GEMINI_API_KEY"],
     )
 
     rag = GraphRAG(

--- a/graphrag_sdk/examples/sample_doc.md
+++ b/graphrag_sdk/examples/sample_doc.md
@@ -1,0 +1,47 @@
+# GraphRAG SDK
+
+GraphRAG SDK is an open-source Python library created by FalkorDB for building
+knowledge-graph-augmented retrieval systems.
+
+## Core Concepts
+
+### Knowledge Graph
+
+A knowledge graph stores entities and the relationships between them.
+GraphRAG SDK uses FalkorDB, a Redis-based graph database that supports
+the openCypher query language, as its graph backend.
+
+### Retrieval-Augmented Generation
+
+Retrieval-Augmented Generation (RAG) grounds language model responses in
+external knowledge by injecting retrieved context into the prompt before
+generation. GraphRAG SDK extends this pattern with a graph-structured index.
+
+## Components
+
+### IngestionPipeline
+
+The IngestionPipeline orchestrates loading, chunking, entity extraction,
+resolution, graph writing, and vector indexing in a fixed nine-step sequence.
+It depends on a LoaderStrategy, a ChunkingStrategy, an ExtractionStrategy,
+a ResolutionStrategy, a GraphStore, and a VectorStore.
+
+### MarkdownLoader
+
+MarkdownLoader parses Markdown files using markdown-it-py and produces
+structured DocumentElement objects that carry heading breadcrumbs.
+It was created by the FalkorDB engineering team and implements the
+LoaderStrategy interface.
+
+### StructuralChunking
+
+StructuralChunking groups DocumentElement objects by heading hierarchy
+into token-bounded chunks. Each chunk stores a breadcrumbs metadata field
+that is written as a property on the Chunk node in the knowledge graph,
+making section paths directly queryable via Cypher.
+
+### GraphExtraction
+
+GraphExtraction runs a two-step pipeline: local named-entity recognition
+powered by GLiNER, followed by LLM-assisted relationship extraction.
+It implements the ExtractionStrategy interface and depends on an LLM provider.

--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "gliner>=0.2,<1",
     "hnswlib>=0.8",
     "scipy>=1.11,<2",
+    "markdown-it-py>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -10,7 +10,17 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [{ name = "FalkorDB", email = "support@falkordb.com" }]
-keywords = ["graphrag", "rag", "falkordb", "knowledge-graph", "llm", "graph-database", "retrieval-augmented-generation", "nlp", "ai"]
+keywords = [
+    "graphrag",
+    "rag",
+    "falkordb",
+    "knowledge-graph",
+    "llm",
+    "graph-database",
+    "retrieval-augmented-generation",
+    "nlp",
+    "ai",
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -30,7 +40,6 @@ dependencies = [
     "gliner>=0.2,<1",
     "hnswlib>=0.8",
     "scipy>=1.11,<2",
-    "markdown-it-py>=3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -39,6 +48,7 @@ anthropic = ["anthropic>=0.20,<1.0"]
 cohere = ["cohere>=5.0"]
 sentence-transformers = ["sentence-transformers>=2.0"]
 pdf = ["pypdf>=6.9.2"]
+markdown = ["markdown-it-py>=3.0.0"]
 # Optional faster/table-aware PDF backend. PyMuPDF is AGPL-3.0 — if that is
 # incompatible with your project's license, stick with the default `pdf` extra.
 pdf-fast = ["pymupdf>=1.24"]

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -28,6 +28,7 @@ from graphrag_sdk.ingestion.chunking_strategies.fixed_size import FixedSizeChunk
 from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
 from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import GraphExtraction
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
+from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
 from graphrag_sdk.ingestion.loaders.pdf_loader import PdfLoader
 from graphrag_sdk.ingestion.loaders.text_loader import TextLoader
 from graphrag_sdk.ingestion.pipeline import IngestionPipeline
@@ -410,6 +411,8 @@ class GraphRAG:
         if loader is None and text is None:
             if source.lower().endswith(".pdf"):
                 loader = PdfLoader()
+            elif source.lower().endswith(".md"):
+                loader = MarkdownLoader()
             else:
                 loader = TextLoader()
 

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -101,11 +101,23 @@ class DocumentInfo(DataModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
+class DocumentElement(DataModel):
+    """A structural element parsed from a document (e.g., section, paragraph, table)."""
+
+    type: str  # e.g., "header", "paragraph", "list", "table", "code"
+    content: str | None = None
+    level: int | None = None  # e.g., 1 for H1
+    breadcrumbs: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    children: list["DocumentElement"] = Field(default_factory=list)
+
+
 class DocumentOutput(DataModel):
-    """Output from a data loader — document text + metadata."""
+    """Output from a data loader — document text + metadata + structural elements."""
 
     text: str
     document_info: DocumentInfo = Field(default_factory=DocumentInfo)
+    elements: list[DocumentElement] | None = None
 
 
 # ── Schema Types ─────────────────────────────────────────────────

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -109,7 +109,7 @@ class DocumentElement(DataModel):
     level: int | None = None  # e.g., 1 for H1
     breadcrumbs: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
-    children: list["DocumentElement"] = Field(default_factory=list)
+    children: list[DocumentElement] = Field(default_factory=list)
 
 
 class DocumentOutput(DataModel):

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/__init__.py
@@ -5,6 +5,7 @@ from graphrag_sdk.ingestion.chunking_strategies.callable_chunking import Callabl
 from graphrag_sdk.ingestion.chunking_strategies.contextual_chunking import ContextualChunking
 from graphrag_sdk.ingestion.chunking_strategies.fixed_size import FixedSizeChunking
 from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import SentenceTokenCapChunking
+from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
 
 __all__ = [
     "ChunkingStrategy",
@@ -12,4 +13,5 @@ __all__ = [
     "ContextualChunking",
     "FixedSizeChunking",
     "SentenceTokenCapChunking",
+    "StructuralChunking",
 ]

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from graphrag_sdk.core.context import Context
-from graphrag_sdk.core.models import TextChunks
+from graphrag_sdk.core.models import DocumentOutput, TextChunks
 
 
 class ChunkingStrategy(ABC):
@@ -35,3 +35,18 @@ class ChunkingStrategy(ABC):
             TextChunks collection.
         """
         ...
+
+    async def chunk_document(self, document: DocumentOutput, ctx: Context) -> TextChunks:
+        """Split a document into chunks.
+
+        By default, delegates to ``chunk`` using the raw text. Strategies that need
+        structural elements can override this method.
+
+        Args:
+            document: DocumentOutput with text and optional structural elements.
+            ctx: Execution context.
+
+        Returns:
+            TextChunks collection.
+        """
+        return await self.chunk(document.text, ctx)

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
@@ -41,20 +41,22 @@ _CONTEXT_PROMPT = (
 
 
 class ContextualChunking(ChunkingStrategy):
-    """Contextual chunking: sentence-boundary split + LLM-generated context prefix.
+    """Contextual chunking: chunking + LLM-generated context prefix.
 
     Each chunk gets a short LLM-generated context summary prepended to
     its text before storage and embedding.  This dramatically improves
     retrieval for questions that require cross-chunk co-reference
     resolution (e.g. pronouns, "the town", "the battle").
 
-    Chunks are first produced by sentence-boundary splitting with a token
-    cap, then enriched with LLM context in a single batched call.
+    Chunks are first produced by the ``base_chunker``, then enriched 
+    with LLM context in a single batched call.
 
     Args:
         llm: LLM provider used to generate context summaries.
-        max_tokens: Token cap per chunk. Default 512.
-        overlap_sentences: Sentences shared between consecutive chunks. Default 2.
+        base_chunker: The underlying chunking strategy to use. If None,
+            defaults to ``SentenceTokenCapChunking(max_tokens, overlap_sentences)``.
+        max_tokens: Token cap per chunk (used if base_chunker is None). Default 512.
+        overlap_sentences: Sentences shared between chunks (used if base_chunker is None). Default 2.
         encoding_name: tiktoken encoding for token counting. Default ``cl100k_base``.
         max_document_tokens: Maximum tokens of the source document included in each
             context prompt. Documents exceeding this are truncated before being sent
@@ -62,13 +64,14 @@ class ContextualChunking(ChunkingStrategy):
 
     Example::
 
-        chunker = ContextualChunking(llm=my_llm, max_tokens=512)
-        result = await chunker.chunk(text, ctx)
+        chunker = ContextualChunking(llm=my_llm, base_chunker=StructuralChunking())
+        result = await chunker.chunk_document(doc, ctx)
     """
 
     def __init__(
         self,
         llm: LLMInterface,
+        base_chunker: ChunkingStrategy | None = None,
         max_tokens: int = 512,
         overlap_sentences: int = 2,
         encoding_name: str = "cl100k_base",
@@ -76,57 +79,38 @@ class ContextualChunking(ChunkingStrategy):
     ) -> None:
         super().__init__()
         self.llm = llm
-        self.max_tokens = max_tokens
-        self.overlap_sentences = overlap_sentences
+        
+        if base_chunker is None:
+            from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import SentenceTokenCapChunking
+            self.base_chunker = SentenceTokenCapChunking(
+                max_tokens=max_tokens,
+                overlap_sentences=overlap_sentences,
+                encoding_name=encoding_name,
+            )
+        else:
+            self.base_chunker = base_chunker
+            
         self.encoding_name = encoding_name
         self.max_document_tokens = max_document_tokens
 
     async def chunk(self, text: str, ctx: Context) -> TextChunks:
-        ctx.log(
-            f"Chunking text ({len(text)} chars) with "
-            f"ContextualChunking(max_tokens={self.max_tokens})"
-        )
+        ctx.log(f"Chunking text via base chunker: {self.base_chunker.__class__.__name__}")
+        raw_chunks = await self.base_chunker.chunk(text, ctx)
+        return await self._enrich_chunks(raw_chunks, text, ctx)
+
+    async def chunk_document(self, document: DocumentOutput, ctx: Context) -> TextChunks:
+        ctx.log(f"Chunking document via base chunker: {self.base_chunker.__class__.__name__}")
+        raw_chunks = await self.base_chunker.chunk_document(document, ctx)
+        return await self._enrich_chunks(raw_chunks, document.text, ctx)
+
+    async def _enrich_chunks(self, raw_chunks: TextChunks, document_text: str, ctx: Context) -> TextChunks:
+        if not raw_chunks.chunks:
+            return raw_chunks
 
         enc = tiktoken.get_encoding(self.encoding_name)
-        # ── 1. Sentence split ────────────────────────────────────────
-        sentences = [s.strip() for s in _SENTENCE_END.split(text.strip()) if s.strip()]
-        if not sentences:
-            return TextChunks(chunks=[])
-
-        token_counts = [len(enc.encode(s)) for s in sentences]
-
-        # ── 2. Greedily merge into token-capped chunks ───────────────
-        raw_chunks: list[tuple[str, int]] = []  # (text, token_count)
-        start = 0
-
-        while start < len(sentences):
-            buf: list[str] = []
-            buf_tokens = 0
-            j = start
-
-            while j < len(sentences):
-                needed = token_counts[j] + (1 if buf else 0)
-                if buf_tokens + needed <= self.max_tokens:
-                    buf.append(sentences[j])
-                    buf_tokens += needed
-                    j += 1
-                else:
-                    break
-
-            if not buf:
-                buf = [sentences[start]]
-                buf_tokens = token_counts[start]
-                j = start + 1
-
-            raw_chunks.append((" ".join(buf), buf_tokens))
-
-            if j >= len(sentences):
-                break
-            start = max(j - self.overlap_sentences, start + 1)
-
-        # ── 3. Batch LLM call for context generation ─────────────────
+        
         # Truncate the document reference to avoid exceeding the LLM context window.
-        doc_tokens = enc.encode(text)
+        doc_tokens = enc.encode(document_text)
         if len(doc_tokens) > self.max_document_tokens:
             ctx.log(
                 f"Document ({len(doc_tokens)} tokens) exceeds max_document_tokens "
@@ -134,13 +118,13 @@ class ContextualChunking(ChunkingStrategy):
             )
             document_ref = enc.decode(doc_tokens[: self.max_document_tokens])
         else:
-            document_ref = text
+            document_ref = document_text
 
         prompts = [
             _CONTEXT_PROMPT.replace("{full_document}", document_ref).replace(
-                "{chunk_text}", chunk_text
+                "{chunk_text}", chunk.text
             )
-            for chunk_text, _ in raw_chunks
+            for chunk in raw_chunks.chunks
         ]
 
         ctx.log(f"Generating context for {len(prompts)} chunks via LLM...")
@@ -157,28 +141,30 @@ class ContextualChunking(ChunkingStrategy):
                 )
                 context_map[item.index] = ""
 
-        # ── 4. Build final TextChunk list ────────────────────────────
-        chunks: list[TextChunk] = []
-        for i, (chunk_text, tok_count) in enumerate(raw_chunks):
+        # Build final TextChunk list
+        enriched_chunks: list[TextChunk] = []
+        for i, chunk in enumerate(raw_chunks.chunks):
             context = context_map.get(i, "")
-            # Prepend context to the chunk text for embedding/storage
-            enriched_text = f"{context}\n\n{chunk_text}" if context else chunk_text
-            chunks.append(
+            enriched_text = f"{context}\n\n{chunk.text}" if context else chunk.text
+            
+            # Merge metadata
+            new_metadata = dict(chunk.metadata)
+            new_metadata.update({
+                "contextual_enriched": True,
+                "context_prefix": context,
+                "original_chunk": chunk.text,
+                "token_count": len(enc.encode(enriched_text)),
+                "char_count": len(enriched_text),
+            })
+            
+            enriched_chunks.append(
                 TextChunk(
                     text=enriched_text,
-                    index=i,
-                    metadata={
-                        "strategy": "contextual_chunking",
-                        "max_tokens": self.max_tokens,
-                        "overlap_sentences": self.overlap_sentences,
-                        "token_count": len(enc.encode(enriched_text)),
-                        "raw_token_count": tok_count,
-                        "char_count": len(enriched_text),
-                        "context_prefix": context,
-                        "original_chunk": chunk_text,
-                    },
+                    index=chunk.index,
+                    metadata=new_metadata,
+                    uid=chunk.uid,  # Preserve the UID for graph provenance
                 )
             )
 
-        ctx.log(f"ContextualChunking produced {len(chunks)} enriched chunks")
-        return TextChunks(chunks=chunks)
+        ctx.log(f"ContextualChunking produced {len(enriched_chunks)} enriched chunks")
+        return TextChunks(chunks=enriched_chunks)

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
@@ -155,7 +155,7 @@ class ContextualChunking(ChunkingStrategy):
             # Merge metadata
             new_metadata = dict(chunk.metadata)
             new_metadata.update({
-                "contextual_enriched": True,
+                "contextual_enriched": bool(context),
                 "context_prefix": context,
                 "original_chunk": chunk.text,
                 "token_count": len(enc.encode(enriched_text)),

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
@@ -48,7 +48,7 @@ class ContextualChunking(ChunkingStrategy):
     retrieval for questions that require cross-chunk co-reference
     resolution (e.g. pronouns, "the town", "the battle").
 
-    Chunks are first produced by the ``base_chunker``, then enriched 
+    Chunks are first produced by the ``base_chunker``, then enriched
     with LLM context in a single batched call.
 
     Args:

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
@@ -110,8 +110,16 @@ class ContextualChunking(ChunkingStrategy):
             _encoding_name = "cl100k_base"
         else:
             _max_tokens = max_tokens if max_tokens is not ContextualChunking._UNSET else 512
-            _overlap = overlap_sentences if overlap_sentences is not ContextualChunking._UNSET else 2
-            _encoding_name = encoding_name if encoding_name is not ContextualChunking._UNSET else "cl100k_base"
+            _overlap = (
+                overlap_sentences
+                if overlap_sentences is not ContextualChunking._UNSET
+                else 2
+            )
+            _encoding_name = (
+                encoding_name
+                if encoding_name is not ContextualChunking._UNSET
+                else "cl100k_base"
+            )
 
             from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
                 SentenceTokenCapChunking,

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
@@ -85,6 +85,7 @@ class ContextualChunking(ChunkingStrategy):
             from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
                 SentenceTokenCapChunking,
             )
+
             self.base_chunker = SentenceTokenCapChunking(
                 max_tokens=max_tokens,
                 overlap_sentences=overlap_sentences,
@@ -154,13 +155,15 @@ class ContextualChunking(ChunkingStrategy):
 
             # Merge metadata
             new_metadata = dict(chunk.metadata)
-            new_metadata.update({
-                "contextual_enriched": bool(context),
-                "context_prefix": context,
-                "original_chunk": chunk.text,
-                "token_count": len(enc.encode(enriched_text)),
-                "char_count": len(enriched_text),
-            })
+            new_metadata.update(
+                {
+                    "contextual_enriched": bool(context),
+                    "context_prefix": context,
+                    "original_chunk": chunk.text,
+                    "token_count": len(enc.encode(enriched_text)),
+                    "char_count": len(enriched_text),
+                }
+            )
 
             enriched_chunks.append(
                 TextChunk(

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
@@ -111,14 +111,10 @@ class ContextualChunking(ChunkingStrategy):
         else:
             _max_tokens = max_tokens if max_tokens is not ContextualChunking._UNSET else 512
             _overlap = (
-                overlap_sentences
-                if overlap_sentences is not ContextualChunking._UNSET
-                else 2
+                overlap_sentences if overlap_sentences is not ContextualChunking._UNSET else 2
             )
             _encoding_name = (
-                encoding_name
-                if encoding_name is not ContextualChunking._UNSET
-                else "cl100k_base"
+                encoding_name if encoding_name is not ContextualChunking._UNSET else "cl100k_base"
             )
 
             from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
@@ -18,7 +18,7 @@ import re
 import tiktoken
 
 from graphrag_sdk.core.context import Context
-from graphrag_sdk.core.models import TextChunk, TextChunks
+from graphrag_sdk.core.models import DocumentOutput, TextChunk, TextChunks
 from graphrag_sdk.core.providers import LLMInterface
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
 
@@ -56,7 +56,8 @@ class ContextualChunking(ChunkingStrategy):
         base_chunker: The underlying chunking strategy to use. If None,
             defaults to ``SentenceTokenCapChunking(max_tokens, overlap_sentences)``.
         max_tokens: Token cap per chunk (used if base_chunker is None). Default 512.
-        overlap_sentences: Sentences shared between chunks (used if base_chunker is None). Default 2.
+        overlap_sentences: Sentences shared between chunks (used if base_chunker is None).
+            Default 2.
         encoding_name: tiktoken encoding for token counting. Default ``cl100k_base``.
         max_document_tokens: Maximum tokens of the source document included in each
             context prompt. Documents exceeding this are truncated before being sent
@@ -79,9 +80,11 @@ class ContextualChunking(ChunkingStrategy):
     ) -> None:
         super().__init__()
         self.llm = llm
-        
+
         if base_chunker is None:
-            from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import SentenceTokenCapChunking
+            from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
+                SentenceTokenCapChunking,
+            )
             self.base_chunker = SentenceTokenCapChunking(
                 max_tokens=max_tokens,
                 overlap_sentences=overlap_sentences,
@@ -89,7 +92,7 @@ class ContextualChunking(ChunkingStrategy):
             )
         else:
             self.base_chunker = base_chunker
-            
+
         self.encoding_name = encoding_name
         self.max_document_tokens = max_document_tokens
 
@@ -103,12 +106,14 @@ class ContextualChunking(ChunkingStrategy):
         raw_chunks = await self.base_chunker.chunk_document(document, ctx)
         return await self._enrich_chunks(raw_chunks, document.text, ctx)
 
-    async def _enrich_chunks(self, raw_chunks: TextChunks, document_text: str, ctx: Context) -> TextChunks:
+    async def _enrich_chunks(
+        self, raw_chunks: TextChunks, document_text: str, ctx: Context
+    ) -> TextChunks:
         if not raw_chunks.chunks:
             return raw_chunks
 
         enc = tiktoken.get_encoding(self.encoding_name)
-        
+
         # Truncate the document reference to avoid exceeding the LLM context window.
         doc_tokens = enc.encode(document_text)
         if len(doc_tokens) > self.max_document_tokens:
@@ -146,7 +151,7 @@ class ContextualChunking(ChunkingStrategy):
         for i, chunk in enumerate(raw_chunks.chunks):
             context = context_map.get(i, "")
             enriched_text = f"{context}\n\n{chunk.text}" if context else chunk.text
-            
+
             # Merge metadata
             new_metadata = dict(chunk.metadata)
             new_metadata.update({
@@ -156,7 +161,7 @@ class ContextualChunking(ChunkingStrategy):
                 "token_count": len(enc.encode(enriched_text)),
                 "char_count": len(enriched_text),
             })
-            
+
             enriched_chunks.append(
                 TextChunk(
                     text=enriched_text,

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/contextual_chunking.py
@@ -13,16 +13,12 @@
 
 from __future__ import annotations
 
-import re
-
 import tiktoken
 
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import DocumentOutput, TextChunk, TextChunks
 from graphrag_sdk.core.providers import LLMInterface
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
-
-_SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
 
 _CONTEXT_PROMPT = (
     "Here is a document:\n"
@@ -53,48 +49,81 @@ class ContextualChunking(ChunkingStrategy):
 
     Args:
         llm: LLM provider used to generate context summaries.
-        base_chunker: The underlying chunking strategy to use. If None,
-            defaults to ``SentenceTokenCapChunking(max_tokens, overlap_sentences)``.
-        max_tokens: Token cap per chunk (used if base_chunker is None). Default 512.
-        overlap_sentences: Sentences shared between chunks (used if base_chunker is None).
-            Default 2.
+        base_chunker: The underlying chunking strategy to use. When supplied,
+            ``max_tokens``, ``overlap_sentences``, and ``encoding_name`` must
+            **not** be passed — configure those directly on the base chunker.
+            If omitted, defaults to
+            ``SentenceTokenCapChunking(max_tokens, overlap_sentences, encoding_name)``.
+        max_tokens: Token cap per chunk for the default base chunker. Default 512.
+            Ignored (and forbidden) when *base_chunker* is provided.
+        overlap_sentences: Sentence overlap for the default base chunker. Default 2.
+            Ignored (and forbidden) when *base_chunker* is provided.
         encoding_name: tiktoken encoding for token counting. Default ``cl100k_base``.
+            Ignored (and forbidden) when *base_chunker* is provided.
         max_document_tokens: Maximum tokens of the source document included in each
             context prompt. Documents exceeding this are truncated before being sent
             to the LLM, preventing context-window overflows on large inputs. Default 16 000.
 
     Example::
 
-        chunker = ContextualChunking(llm=my_llm, base_chunker=StructuralChunking())
+        # No base chunker — shorthand kwargs configure the default one
+        chunker = ContextualChunking(llm=my_llm, max_tokens=256, overlap_sentences=1)
+
+        # Custom base chunker — configure it directly, pass no shorthand kwargs
+        chunker = ContextualChunking(llm=my_llm, base_chunker=StructuralChunking(max_tokens=512))
         result = await chunker.chunk_document(doc, ctx)
     """
+
+    _UNSET = object()  # sentinel for "caller did not pass this kwarg"
 
     def __init__(
         self,
         llm: LLMInterface,
         base_chunker: ChunkingStrategy | None = None,
-        max_tokens: int = 512,
-        overlap_sentences: int = 2,
-        encoding_name: str = "cl100k_base",
+        max_tokens: int | object = _UNSET,
+        overlap_sentences: int | object = _UNSET,
+        encoding_name: str | object = _UNSET,
         max_document_tokens: int = 16_000,
     ) -> None:
         super().__init__()
         self.llm = llm
 
-        if base_chunker is None:
+        if base_chunker is not None:
+            # Check that none of the shorthand kwargs were explicitly supplied
+            _conflicts = [
+                name
+                for name, val in (
+                    ("max_tokens", max_tokens),
+                    ("overlap_sentences", overlap_sentences),
+                    ("encoding_name", encoding_name),
+                )
+                if val is not ContextualChunking._UNSET
+            ]
+            if _conflicts:
+                raise TypeError(
+                    f"ContextualChunking: {', '.join(_conflicts)} "
+                    "cannot be used together with 'base_chunker'. "
+                    "Configure those parameters on the base_chunker directly."
+                )
+            self.base_chunker = base_chunker
+            # Use encoding_name solely for document-truncation token counting
+            _encoding_name = "cl100k_base"
+        else:
+            _max_tokens = max_tokens if max_tokens is not ContextualChunking._UNSET else 512
+            _overlap = overlap_sentences if overlap_sentences is not ContextualChunking._UNSET else 2
+            _encoding_name = encoding_name if encoding_name is not ContextualChunking._UNSET else "cl100k_base"
+
             from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
                 SentenceTokenCapChunking,
             )
 
             self.base_chunker = SentenceTokenCapChunking(
-                max_tokens=max_tokens,
-                overlap_sentences=overlap_sentences,
-                encoding_name=encoding_name,
+                max_tokens=_max_tokens,
+                overlap_sentences=_overlap,
+                encoding_name=_encoding_name,
             )
-        else:
-            self.base_chunker = base_chunker
 
-        self.encoding_name = encoding_name
+        self.encoding_name = _encoding_name
         self.max_document_tokens = max_document_tokens
 
     async def chunk(self, text: str, ctx: Context) -> TextChunks:
@@ -162,6 +191,8 @@ class ContextualChunking(ChunkingStrategy):
                     "original_chunk": chunk.text,
                     "token_count": len(enc.encode(enriched_text)),
                     "char_count": len(enriched_text),
+                    "strategy": "contextual_chunking",
+                    "base_strategy": chunk.metadata.get("strategy"),
                 }
             )
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
@@ -1,0 +1,147 @@
+# GraphRAG SDK — Ingestion: Structural Chunking
+#
+# A format-agnostic chunker that groups parsed DocumentElements.
+# Keeps paragraphs and their hierarchical context (headers) together.
+#
+# Delegates oversized blocks to a fallback chunker (e.g., SentenceTokenCapChunking).
+
+from __future__ import annotations
+
+import tiktoken
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import DocumentElement, DocumentOutput, TextChunk, TextChunks
+from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
+
+
+class StructuralChunking(ChunkingStrategy):
+    """Groups document elements based on structure, constrained by a token cap.
+
+    Reads ``document.elements`` (a tree/list of ``DocumentElement``).
+    Groups them into chunks up to ``max_tokens``.
+    If a single element exceeds ``max_tokens``, delegates it to ``fallback_chunker``.
+
+    Args:
+        fallback_chunker: Chunker to handle oversized elements. Default: SentenceTokenCapChunking.
+        max_tokens: Maximum tokens per structural chunk. Default: 512.
+        encoding_name: tiktoken encoding to use. Default ``cl100k_base``.
+    """
+
+    def __init__(
+        self,
+        fallback_chunker: ChunkingStrategy | None = None,
+        max_tokens: int = 512,
+        encoding_name: str = "cl100k_base",
+    ) -> None:
+        super().__init__()
+        if fallback_chunker is None:
+            from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
+                SentenceTokenCapChunking,
+            )
+
+            self.fallback_chunker = SentenceTokenCapChunking(
+                max_tokens=max_tokens,
+                encoding_name=encoding_name,
+            )
+        else:
+            self.fallback_chunker = fallback_chunker
+
+        self.max_tokens = max_tokens
+        self.encoding_name = encoding_name
+
+    async def chunk(self, text: str, ctx: Context) -> TextChunks:
+        ctx.log("StructuralChunking: No structural elements found. Delegating to fallback chunker.")
+        return await self.fallback_chunker.chunk(text, ctx)
+
+    async def chunk_document(self, document: DocumentOutput, ctx: Context) -> TextChunks:
+        if not document.elements:
+            return await self.chunk(document.text, ctx)
+
+        ctx.log(f"StructuralChunking: processing {len(document.elements)} root elements.")
+        enc = tiktoken.get_encoding(self.encoding_name)
+        chunks: list[TextChunk] = []
+        chunk_index = 0
+
+        # Flatten elements
+        flat_elements: list[DocumentElement] = []
+
+        def _flatten(elements: list[DocumentElement]) -> None:
+            for el in elements:
+                if el.content and el.content.strip():
+                    flat_elements.append(el)
+                if el.children:
+                    _flatten(el.children)
+
+        _flatten(document.elements)
+
+        if not flat_elements:
+            return await self.chunk(document.text, ctx)
+
+        buf: list[str] = []
+        buf_tokens = 0
+
+        def _flush_buffer() -> None:
+            nonlocal chunk_index, buf, buf_tokens
+            if not buf:
+                return
+            chunks.append(
+                TextChunk(
+                    text="\n\n".join(buf),
+                    index=chunk_index,
+                    metadata={
+                        "strategy": "structural_chunking",
+                        "token_count": buf_tokens,
+                    },
+                )
+            )
+            chunk_index += 1
+            buf = []
+            buf_tokens = 0
+
+        for el in flat_elements:
+            # Build element text with context prefix
+            prefix = " > ".join(el.breadcrumbs) if el.breadcrumbs else ""
+            # Don't duplicate the prefix if the element content already starts with it (e.g. headers)
+            if prefix and el.type != "header":
+                el_text = f"{prefix}\n{el.content}"
+            else:
+                el_text = el.content or ""
+
+            el_tokens = len(enc.encode(el_text))
+
+            if el_tokens > self.max_tokens:
+                # Emit current buffer first
+                _flush_buffer()
+
+                # Delegate the huge element
+                ctx.log(f"Delegating oversized element ({el_tokens} tokens) to fallback chunker")
+                sub_chunks = await self.fallback_chunker.chunk(el.content or "", ctx)
+                total_parts = len(sub_chunks.chunks)
+                for idx, sc in enumerate(sub_chunks.chunks, start=1):
+                    sc.index = chunk_index
+                    part_suffix = f" [Parte {idx}/{total_parts}]" if total_parts > 1 else ""
+                    
+                    if prefix and el.type != "header":
+                        sc.text = f"{prefix}{part_suffix}\n{sc.text}"
+                    elif total_parts > 1:
+                        sc.text = f"[Elemento Fragmentado - Parte {idx}/{total_parts}]\n{sc.text}"
+                        
+                    chunks.append(sc)
+                    chunk_index += 1
+                continue
+
+            if buf_tokens + el_tokens <= self.max_tokens:
+                buf.append(el_text)
+                buf_tokens += el_tokens
+            else:
+                # Emit current buffer
+                _flush_buffer()
+                buf = [el_text]
+                buf_tokens = el_tokens
+
+        # Emit any remaining buffer
+        _flush_buffer()
+
+        ctx.log(f"StructuralChunking produced {len(chunks)} chunks")
+        return TextChunks(chunks=chunks)
+

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
@@ -101,7 +101,8 @@ class StructuralChunking(ChunkingStrategy):
         for el in flat_elements:
             # Build element text with context prefix
             prefix = " > ".join(el.breadcrumbs) if el.breadcrumbs else ""
-            # Don't duplicate the prefix if the element content already starts with it (e.g. headers)
+            # Don't duplicate the prefix if the element
+            # content already starts with it (e.g. headers)
             if prefix and el.type != "header":
                 el_text = f"{prefix}\n{el.content}"
             else:
@@ -120,12 +121,12 @@ class StructuralChunking(ChunkingStrategy):
                 for idx, sc in enumerate(sub_chunks.chunks, start=1):
                     sc.index = chunk_index
                     part_suffix = f" [Parte {idx}/{total_parts}]" if total_parts > 1 else ""
-                    
+
                     if prefix and el.type != "header":
                         sc.text = f"{prefix}{part_suffix}\n{sc.text}"
                     elif total_parts > 1:
                         sc.text = f"[Elemento Fragmentado - Parte {idx}/{total_parts}]\n{sc.text}"
-                        
+
                     chunks.append(sc)
                     chunk_index += 1
                 continue

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
@@ -168,4 +168,3 @@ class StructuralChunking(ChunkingStrategy):
 
         ctx.log(f"StructuralChunking produced {len(chunks)} chunks")
         return TextChunks(chunks=chunks)
-

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
@@ -164,7 +164,7 @@ class StructuralChunking(ChunkingStrategy):
                 buf.append(el_text)
                 buf_tokens = candidate_tokens
                 # Merge this element's breadcrumbs into the buffer's breadcrumb list
-                for crumb in (el.breadcrumbs or []):
+                for crumb in el.breadcrumbs or []:
                     if crumb not in buf_breadcrumbs:
                         buf_breadcrumbs.append(crumb)
             else:

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
@@ -119,21 +119,44 @@ class StructuralChunking(ChunkingStrategy):
                 sub_chunks = await self.fallback_chunker.chunk(el.content or "", ctx)
                 total_parts = len(sub_chunks.chunks)
                 for idx, sc in enumerate(sub_chunks.chunks, start=1):
-                    sc.index = chunk_index
                     part_suffix = f" [Parte {idx}/{total_parts}]" if total_parts > 1 else ""
 
+                    prefix_str = ""
                     if prefix and el.type != "header":
-                        sc.text = f"{prefix}{part_suffix}\n{sc.text}"
+                        prefix_str = f"{prefix}{part_suffix}\n"
                     elif total_parts > 1:
-                        sc.text = f"[Elemento Fragmentado - Parte {idx}/{total_parts}]\n{sc.text}"
+                        prefix_str = f"[Elemento Fragmentado - Parte {idx}/{total_parts}]\n"
 
-                    chunks.append(sc)
+                    final_text = f"{prefix_str}{sc.text}"
+                    final_tokens = len(enc.encode(final_text))
+
+                    if final_tokens > self.max_tokens:
+                        ctx.log(
+                            f"StructuralChunking warning: Fallback chunk {idx}/{total_parts} "
+                            f"exceeds max_tokens after prefixing "
+                            f"({final_tokens} > {self.max_tokens})"
+                        )
+
+                    new_metadata = dict(sc.metadata)
+                    new_metadata["token_count"] = final_tokens
+
+                    chunks.append(
+                        TextChunk(
+                            text=final_text,
+                            index=chunk_index,
+                            uid=sc.uid,
+                            metadata=new_metadata,
+                        )
+                    )
                     chunk_index += 1
                 continue
 
-            if buf_tokens + el_tokens <= self.max_tokens:
+            candidate_text = "\n\n".join([*buf, el_text])
+            candidate_tokens = len(enc.encode(candidate_text))
+
+            if candidate_tokens <= self.max_tokens:
                 buf.append(el_text)
-                buf_tokens += el_tokens
+                buf_tokens = candidate_tokens
             else:
                 # Emit current buffer
                 _flush_buffer()

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
@@ -32,6 +32,7 @@ class StructuralChunking(ChunkingStrategy):
         fallback_chunker: ChunkingStrategy | None = None,
         max_tokens: int = 512,
         encoding_name: str = "cl100k_base",
+        overlap_sentences: int = 2,
     ) -> None:
         super().__init__()
         if fallback_chunker is None:
@@ -42,6 +43,7 @@ class StructuralChunking(ChunkingStrategy):
             self.fallback_chunker = SentenceTokenCapChunking(
                 max_tokens=max_tokens,
                 encoding_name=encoding_name,
+                overlap_sentences=overlap_sentences,
             )
         else:
             self.fallback_chunker = fallback_chunker
@@ -79,9 +81,10 @@ class StructuralChunking(ChunkingStrategy):
 
         buf: list[str] = []
         buf_tokens = 0
+        buf_breadcrumbs: list[str] = []  # union of breadcrumbs for elements in buf
 
         def _flush_buffer() -> None:
-            nonlocal chunk_index, buf, buf_tokens
+            nonlocal chunk_index, buf, buf_tokens, buf_breadcrumbs
             if not buf:
                 return
             chunks.append(
@@ -91,12 +94,14 @@ class StructuralChunking(ChunkingStrategy):
                     metadata={
                         "strategy": "structural_chunking",
                         "token_count": buf_tokens,
+                        "breadcrumbs": list(buf_breadcrumbs),
                     },
                 )
             )
             chunk_index += 1
             buf = []
             buf_tokens = 0
+            buf_breadcrumbs = []
 
         for el in flat_elements:
             # Build element text with context prefix
@@ -119,13 +124,13 @@ class StructuralChunking(ChunkingStrategy):
                 sub_chunks = await self.fallback_chunker.chunk(el.content or "", ctx)
                 total_parts = len(sub_chunks.chunks)
                 for idx, sc in enumerate(sub_chunks.chunks, start=1):
-                    part_suffix = f" [Parte {idx}/{total_parts}]" if total_parts > 1 else ""
+                    part_suffix = f" [Part {idx}/{total_parts}]" if total_parts > 1 else ""
 
                     prefix_str = ""
                     if prefix and el.type != "header":
                         prefix_str = f"{prefix}{part_suffix}\n"
                     elif total_parts > 1:
-                        prefix_str = f"[Elemento Fragmentado - Parte {idx}/{total_parts}]\n"
+                        prefix_str = f"[Fragmented Element - Part {idx}/{total_parts}]\n"
 
                     final_text = f"{prefix_str}{sc.text}"
                     final_tokens = len(enc.encode(final_text))
@@ -139,6 +144,7 @@ class StructuralChunking(ChunkingStrategy):
 
                     new_metadata = dict(sc.metadata)
                     new_metadata["token_count"] = final_tokens
+                    new_metadata["breadcrumbs"] = list(el.breadcrumbs) if el.breadcrumbs else []
 
                     chunks.append(
                         TextChunk(
@@ -157,11 +163,16 @@ class StructuralChunking(ChunkingStrategy):
             if candidate_tokens <= self.max_tokens:
                 buf.append(el_text)
                 buf_tokens = candidate_tokens
+                # Merge this element's breadcrumbs into the buffer's breadcrumb list
+                for crumb in (el.breadcrumbs or []):
+                    if crumb not in buf_breadcrumbs:
+                        buf_breadcrumbs.append(crumb)
             else:
                 # Emit current buffer
                 _flush_buffer()
                 buf = [el_text]
                 buf_tokens = el_tokens
+                buf_breadcrumbs = list(el.breadcrumbs) if el.breadcrumbs else []
 
         # Emit any remaining buffer
         _flush_buffer()

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
@@ -27,29 +27,54 @@ class StructuralChunking(ChunkingStrategy):
         encoding_name: tiktoken encoding to use. Default ``cl100k_base``.
     """
 
+    _UNSET = object()
+
     def __init__(
         self,
         fallback_chunker: ChunkingStrategy | None = None,
-        max_tokens: int = 512,
-        encoding_name: str = "cl100k_base",
-        overlap_sentences: int = 2,
+        max_tokens: int | object = _UNSET,
+        encoding_name: str | object = _UNSET,
+        overlap_sentences: int | object = _UNSET,
     ) -> None:
         super().__init__()
-        if fallback_chunker is None:
+
+        if fallback_chunker is not None:
+            _conflicts = [
+                name
+                for name, val in [
+                    ("max_tokens", max_tokens),
+                    ("encoding_name", encoding_name),
+                    ("overlap_sentences", overlap_sentences),
+                ]
+                if val is not StructuralChunking._UNSET
+            ]
+            if _conflicts:
+                raise TypeError(
+                    f"StructuralChunking: {', '.join(_conflicts)} cannot be used together "
+                    "with 'fallback_chunker'. Configure those parameters on the "
+                    "fallback chunker directly."
+                )
+            self.fallback_chunker = fallback_chunker
+            self.max_tokens = 512
+            self.encoding_name = "cl100k_base"
+        else:
+            self.max_tokens = max_tokens if max_tokens is not StructuralChunking._UNSET else 512
+            self.encoding_name = (
+                encoding_name if encoding_name is not StructuralChunking._UNSET else "cl100k_base"
+            )
+            _overlap = (
+                overlap_sentences if overlap_sentences is not StructuralChunking._UNSET else 2
+            )
+
             from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
                 SentenceTokenCapChunking,
             )
 
             self.fallback_chunker = SentenceTokenCapChunking(
-                max_tokens=max_tokens,
-                encoding_name=encoding_name,
-                overlap_sentences=overlap_sentences,
+                max_tokens=self.max_tokens,
+                encoding_name=self.encoding_name,
+                overlap_sentences=_overlap,
             )
-        else:
-            self.fallback_chunker = fallback_chunker
-
-        self.max_tokens = max_tokens
-        self.encoding_name = encoding_name
 
     async def chunk(self, text: str, ctx: Context) -> TextChunks:
         ctx.log("StructuralChunking: No structural elements found. Delegating to fallback chunker.")

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
@@ -130,6 +130,8 @@ class StructuralChunking(ChunkingStrategy):
             buf_tokens = 0
             buf_breadcrumbs = []
 
+        sep_tokens = len(enc.encode("\n\n"))
+
         for el in flat_elements:
             # Build element text with context prefix
             prefix = " > ".join(el.breadcrumbs) if el.breadcrumbs else ""
@@ -184,8 +186,7 @@ class StructuralChunking(ChunkingStrategy):
                     chunk_index += 1
                 continue
 
-            candidate_text = "\n\n".join([*buf, el_text])
-            candidate_tokens = len(enc.encode(candidate_text))
+            candidate_tokens = buf_tokens + (sep_tokens + el_tokens if buf else el_tokens)
 
             if candidate_tokens <= self.max_tokens:
                 buf.append(el_text)

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/structural_chunking.py
@@ -96,6 +96,8 @@ class StructuralChunking(ChunkingStrategy):
             for el in elements:
                 if el.content and el.content.strip():
                     flat_elements.append(el)
+                # Note: MarkdownLoader currently produces a flat list, but
+                # future loaders (e.g. HTML parsers) may emit nested elements.
                 if el.children:
                     _flatten(el.children)
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/__init__.py
@@ -6,4 +6,3 @@ from graphrag_sdk.ingestion.loaders.pdf_loader import PdfLoader
 from graphrag_sdk.ingestion.loaders.text_loader import TextLoader
 
 __all__ = ["LoaderStrategy", "MarkdownLoader", "PdfLoader", "TextLoader"]
-

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/__init__.py
@@ -1,5 +1,9 @@
 # GraphRAG SDK — Ingestion: Loaders
 
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
+from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+from graphrag_sdk.ingestion.loaders.pdf_loader import PdfLoader
+from graphrag_sdk.ingestion.loaders.text_loader import TextLoader
 
-__all__ = ["LoaderStrategy"]
+__all__ = ["LoaderStrategy", "MarkdownLoader", "PdfLoader", "TextLoader"]
+

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
@@ -104,7 +104,6 @@ class MarkdownLoader(LoaderStrategy):
             token = tokens[i]
 
             if token.type == "heading_open":
-                content = get_content(token)
                 level = int(token.tag[1:])
 
                 title = ""

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
@@ -68,7 +68,7 @@ class MarkdownLoader(LoaderStrategy):
             if not t.map:
                 return ""
             start, end = t.map
-            return "\n".join(lines[start:end]).strip()
+            return "\n".join(lines[start:end]).rstrip("\n")
 
         def skip_to_close(start_idx: int, open_type: str, close_type: str) -> int:
             nesting = 1

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
@@ -1,0 +1,150 @@
+# GraphRAG SDK — Ingestion: Markdown Loader
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from pathlib import Path
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.exceptions import LoaderError
+from graphrag_sdk.core.models import DocumentElement, DocumentInfo, DocumentOutput
+from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
+
+logger = logging.getLogger(__name__)
+
+
+class MarkdownLoader(LoaderStrategy):
+    """Load text and structural elements from a markdown file.
+
+    Parses the markdown structure (headers and paragraphs) to build
+    a flat list of ``DocumentElement``s. Each element contains ``breadcrumbs``
+    representing its header hierarchy, enabling precise structural chunking.
+    """
+
+    def __init__(self, encoding: str = "utf-8") -> None:
+        self.encoding = encoding
+
+    async def load(self, source: str, ctx: Context) -> DocumentOutput:
+        ctx.log(f"Loading markdown file: {source}")
+        return await asyncio.to_thread(self._load_sync, source)
+
+    def _load_sync(self, source: str) -> DocumentOutput:
+        path = Path(source)
+        if not path.exists():
+            raise LoaderError(f"File not found: {source}")
+
+        try:
+            text = path.read_text(encoding=self.encoding)
+            elements = self._parse_markdown(text)
+
+            return DocumentOutput(
+                text=text,
+                document_info=DocumentInfo(
+                    path=str(path),
+                    metadata={
+                        "size_bytes": path.stat().st_size,
+                        "loader": "markdown",
+                        "suffix": path.suffix,
+                    },
+                ),
+                elements=elements,
+            )
+        except Exception as exc:
+            raise LoaderError(f"Failed to read {source}: {exc}") from exc
+
+    def _parse_markdown(self, text: str) -> list[DocumentElement]:
+        """Parse raw markdown text into structural DocumentElements."""
+        from markdown_it import MarkdownIt
+
+        md = MarkdownIt("commonmark").enable("table")
+        tokens = md.parse(text)
+        lines = text.split("\n")
+
+        elements: list[DocumentElement] = []
+        current_breadcrumbs: list[tuple[int, str]] = []
+
+        def get_content(t) -> str:
+            if not t.map:
+                return ""
+            start, end = t.map
+            return "\n".join(lines[start:end]).strip()
+
+        def skip_to_close(start_idx: int, open_type: str, close_type: str) -> int:
+            nesting = 1
+            idx = start_idx + 1
+            while idx < len(tokens):
+                if tokens[idx].type == open_type:
+                    nesting += 1
+                elif tokens[idx].type == close_type:
+                    nesting -= 1
+                    if nesting == 0:
+                        return idx
+                idx += 1
+            return idx
+
+        def _emit(el_type: str, content: str) -> None:
+            if content:
+                elements.append(
+                    DocumentElement(
+                        type=el_type,
+                        content=content,
+                        breadcrumbs=[b[1] for b in current_breadcrumbs],
+                    )
+                )
+
+        i = 0
+        while i < len(tokens):
+            token = tokens[i]
+
+            if token.type == "heading_open":
+                content = get_content(token)
+                level = int(token.tag[1:])
+
+                title = ""
+                for j in range(i + 1, len(tokens)):
+                    if tokens[j].type == "inline":
+                        title = tokens[j].content
+                        break
+                    if tokens[j].type == "heading_close":
+                        break
+
+                while current_breadcrumbs and current_breadcrumbs[-1][0] >= level:
+                    current_breadcrumbs.pop()
+
+                current_breadcrumbs.append((level, title))
+
+                elements.append(
+                    DocumentElement(
+                        type="header",
+                        level=level,
+                        content=content,
+                        breadcrumbs=[b[1] for b in current_breadcrumbs],
+                    )
+                )
+                i = skip_to_close(i, "heading_open", "heading_close")
+
+            elif token.type == "paragraph_open":
+                _emit("paragraph", get_content(token))
+                i = skip_to_close(i, "paragraph_open", "paragraph_close")
+
+            elif token.type in ("bullet_list_open", "ordered_list_open"):
+                _emit("list", get_content(token))
+                close_type = token.type.replace("_open", "_close")
+                i = skip_to_close(i, token.type, close_type)
+
+            elif token.type == "table_open":
+                _emit("table", get_content(token))
+                i = skip_to_close(i, "table_open", "table_close")
+
+            elif token.type == "blockquote_open":
+                _emit("blockquote", get_content(token))
+                i = skip_to_close(i, "blockquote_open", "blockquote_close")
+
+            elif token.type in ("fence", "code_block"):
+                _emit("code", get_content(token))
+
+            i += 1
+
+        return elements

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from pathlib import Path
 
 from graphrag_sdk.core.context import Context

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
@@ -55,7 +55,13 @@ class MarkdownLoader(LoaderStrategy):
 
     def _parse_markdown(self, text: str) -> list[DocumentElement]:
         """Parse raw markdown text into structural DocumentElements."""
-        from markdown_it import MarkdownIt
+        try:
+            from markdown_it import MarkdownIt
+        except ImportError:
+            raise ImportError(
+                "Markdown parsing requires 'markdown-it-py'. Install with:"
+                "\n  pip install graphrag-sdk[markdown]"
+            )
 
         md = MarkdownIt("commonmark").enable("table")
         tokens = md.parse(text)
@@ -118,7 +124,7 @@ class MarkdownLoader(LoaderStrategy):
                     DocumentElement(
                         type="header",
                         level=level,
-                        content=content,
+                        content=title,
                         breadcrumbs=[b[1] for b in current_breadcrumbs],
                     )
                 )

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
@@ -36,22 +36,23 @@ class MarkdownLoader(LoaderStrategy):
 
         try:
             text = path.read_text(encoding=self.encoding)
-            elements = self._parse_markdown(text)
-
-            return DocumentOutput(
-                text=text,
-                document_info=DocumentInfo(
-                    path=str(path),
-                    metadata={
-                        "size_bytes": path.stat().st_size,
-                        "loader": "markdown",
-                        "suffix": path.suffix,
-                    },
-                ),
-                elements=elements,
-            )
-        except Exception as exc:
+        except OSError as exc:
             raise LoaderError(f"Failed to read {source}: {exc}") from exc
+
+        elements = self._parse_markdown(text)
+
+        return DocumentOutput(
+            text=text,
+            document_info=DocumentInfo(
+                path=str(path),
+                metadata={
+                    "size_bytes": path.stat().st_size,
+                    "loader": "markdown",
+                    "suffix": path.suffix,
+                },
+            ),
+            elements=elements,
+        )
 
     def _parse_markdown(self, text: str) -> list[DocumentElement]:
         """Parse raw markdown text into structural DocumentElements."""

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/markdown_loader.py
@@ -72,6 +72,11 @@ class MarkdownLoader(LoaderStrategy):
         current_breadcrumbs: list[tuple[int, str]] = []
 
         def get_content(t) -> str:
+            # Note: We intentionally return the raw markdown source lines here.
+            # While this includes syntax "noise" (like table pipes `|`, list dashes `-`,
+            # and code fences ```` `), it perfectly preserves structural cues like
+            # column alignment and list indentation that LLM extractors rely on
+            # to correctly understand relational and hierarchical data.
             if not t.map:
                 return ""
             start, end = t.map

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/pipeline.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/pipeline.py
@@ -138,7 +138,7 @@ class IngestionPipeline:
 
             # Step 2: Chunk
             ctx.log("Step 2/9: Chunking text")
-            chunks = await self.chunker.chunk(document.text, ctx)
+            chunks = await self.chunker.chunk_document(document, ctx)
 
             if not chunks.chunks:
                 ctx.log("No chunks produced, pipeline complete")

--- a/graphrag_sdk/tests/test_chunking_strategies.py
+++ b/graphrag_sdk/tests/test_chunking_strategies.py
@@ -5,6 +5,7 @@ Strategies under test:
   2. SentenceTokenCapChunking (tiktoken, no LLM)
   3. ContextualChunking       (tiktoken + LLM — mock LLM used)
   4. CallableChunking         (adapts any function — sync & async)
+  5. StructuralChunking       (Groups document elements based on structure, constrained by a token cap) 
 """
 from __future__ import annotations
 
@@ -16,6 +17,7 @@ from graphrag_sdk.ingestion.chunking_strategies.callable_chunking import Callabl
 from graphrag_sdk.ingestion.chunking_strategies.contextual_chunking import ContextualChunking
 from graphrag_sdk.ingestion.chunking_strategies.fixed_size import FixedSizeChunking
 from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import SentenceTokenCapChunking
+from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -165,6 +167,52 @@ class TestContextualChunking:
         assert "context_prefix" in result.chunks[0].metadata
         assert "original_chunk" in result.chunks[0].metadata
 
+    async def test_metadata_strategy_is_contextual_chunking(self, ctx):
+        """metadata['strategy'] must always equal 'contextual_chunking'.
+
+        Regression: a previous refactor silently overwrote the strategy key
+        without setting it to the contextual value, breaking any downstream
+        code that filters chunks by metadata['strategy'].
+        """
+        chunker = ContextualChunking(llm=_ContextualMockLLM(), max_tokens=512)
+        result = await chunker.chunk(SAMPLE_TEXT, ctx)
+        assert len(result.chunks) >= 1
+        for chunk in result.chunks:
+            assert chunk.metadata.get("strategy") == "contextual_chunking"
+
+
+    async def test_metadata_base_strategy_preserved(self, ctx):
+        """metadata['base_strategy'] must reflect the underlying chunker's strategy.
+
+        When a caller wraps e.g. StructuralChunking inside
+        ContextualChunking, the original strategy name must be kept so that
+        provenance information is not silently discarded.
+        """
+        chunker = ContextualChunking(
+            llm=_ContextualMockLLM(),
+            base_chunker=StructuralChunking(max_tokens=512, overlap_sentences=2),
+        )
+        result = await chunker.chunk(SAMPLE_TEXT, ctx)
+        assert len(result.chunks) >= 1
+        for chunk in result.chunks:
+            # base_strategy must be the value that StructuralChunking wrote
+            assert "base_strategy" in chunk.metadata
+            assert chunk.metadata["strategy"] == "contextual_chunking"
+
+    def test_raises_on_conflicting_kwargs(self):
+        """Passing shorthand kwargs alongside base_chunker must raise TypeError.
+
+        The parameters max_tokens, overlap_sentences, and encoding_name are
+        only meaningful when ContextualChunking builds the default base chunker.
+        Accepting them silently when base_chunker is supplied would mislead
+        callers into believing those values take effect.
+        """
+        with pytest.raises(TypeError, match="cannot be used together with 'base_chunker'"):
+            ContextualChunking(
+                llm=_ContextualMockLLM(),
+                base_chunker=StructuralChunking(max_tokens=256),
+                max_tokens=512,  # dead — should blow up
+            )
 
 # ---------------------------------------------------------------------------
 # 4. CallableChunking
@@ -230,7 +278,7 @@ class TestCallableChunking:
                 return text.split("\n\n")
 
         chunker = CallableChunking(ParagraphSplitter())
-        result = await chunker.chunk("Para one.\n\nPara two.", ctx)
+        result = await chunker.chunk("Part one.\n\nPart two.", ctx)
         assert len(result.chunks) == 2
 
 
@@ -284,7 +332,7 @@ class TestStructuralChunking:
         assert len(result.chunks) > 1
         total_parts = len(result.chunks)
         for i, chunk in enumerate(result.chunks, start=1):
-            assert f"H1 [Parte {i}/{total_parts}]" in chunk.text
+            assert f"H1 [Part {i}/{total_parts}]" in chunk.text
 
     async def test_no_elements_fallback(self, ctx):
         from graphrag_sdk.core.models import DocumentInfo, DocumentOutput
@@ -301,3 +349,62 @@ class TestStructuralChunking:
 
         assert len(result.chunks) == 1
         assert result.chunks[0].text == "Just some text. More text."
+
+    async def test_metadata_breadcrumbs_in_normal_chunk(self, ctx):
+        """Buffered chunks must carry the union of their elements' breadcrumbs.
+
+        The lexical-graph step spreads chunk.metadata onto Chunk node properties,
+        so breadcrumbs become graph-queryable without any extra pipeline work.
+        """
+        from graphrag_sdk.core.models import DocumentElement, DocumentInfo, DocumentOutput
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+
+        elements = [
+            DocumentElement(type="header",    content="Title",   breadcrumbs=["Title"]),
+            DocumentElement(type="paragraph", content="Intro.",  breadcrumbs=["Title"]),
+            DocumentElement(type="paragraph", content="Detail.", breadcrumbs=["Title", "Sub"]),
+        ]
+        doc = DocumentOutput(
+            text="Title\n\nIntro.\n\nDetail.",
+            document_info=DocumentInfo(path="test.md"),
+            elements=elements,
+        )
+
+        chunker = StructuralChunking(max_tokens=200)
+        result = await chunker.chunk_document(doc, ctx)
+
+        # All three elements fit in a single buffer → one chunk
+        assert len(result.chunks) == 1
+        meta = result.chunks[0].metadata
+        assert "breadcrumbs" in meta
+        # Must contain every unique breadcrumb seen across all elements in the chunk
+        assert "Title" in meta["breadcrumbs"]
+        assert "Sub" in meta["breadcrumbs"]
+
+    async def test_metadata_breadcrumbs_in_oversized_fallback(self, ctx):
+        """Fallback chunks (oversized elements) must also carry breadcrumbs."""
+        from graphrag_sdk.core.models import DocumentElement, DocumentInfo, DocumentOutput
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+
+        large_content = "Word. " * 50
+        elements = [
+            DocumentElement(
+                type="paragraph",
+                content=large_content,
+                breadcrumbs=["Chapter", "Section"],
+            )
+        ]
+        doc = DocumentOutput(
+            text=large_content,
+            document_info=DocumentInfo(path="test.md"),
+            elements=elements,
+        )
+
+        chunker = StructuralChunking(max_tokens=10)
+        result = await chunker.chunk_document(doc, ctx)
+
+        assert len(result.chunks) > 1
+        for chunk in result.chunks:
+            assert "breadcrumbs" in chunk.metadata
+            assert chunk.metadata["breadcrumbs"] == ["Chapter", "Section"]
+

--- a/graphrag_sdk/tests/test_chunking_strategies.py
+++ b/graphrag_sdk/tests/test_chunking_strategies.py
@@ -232,3 +232,72 @@ class TestCallableChunking:
         chunker = CallableChunking(ParagraphSplitter())
         result = await chunker.chunk("Para one.\n\nPara two.", ctx)
         assert len(result.chunks) == 2
+
+
+class TestStructuralChunking:
+    async def test_chunk_with_elements(self, ctx):
+        from graphrag_sdk.core.models import DocumentElement, DocumentInfo, DocumentOutput
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+
+        # Create elements
+        elements = [
+            DocumentElement(type="header", content="# Title", breadcrumbs=["Title"]),
+            DocumentElement(type="paragraph", content="Intro.", breadcrumbs=["Title"]),
+            DocumentElement(type="paragraph", content="P2.", breadcrumbs=["Title"]),
+        ]
+        doc = DocumentOutput(
+            text="# Title\n\nIntro.\n\nP2.",
+            document_info=DocumentInfo(path="test.md"),
+            elements=elements,
+        )
+
+        # max_tokens=100 ensures they group together
+        chunker = StructuralChunking(max_tokens=100)
+        result = await chunker.chunk_document(doc, ctx)
+
+        assert len(result.chunks) == 1
+        text = result.chunks[0].text
+        # Header text has prefix but since it's a header we avoided duplicating.
+        # Actually in our code, if prefix is present but it's not a header it gets added.
+        assert "Title\nIntro." in result.chunks[0].text
+        assert "Title\nP2." in result.chunks[0].text
+
+    async def test_fallback_when_oversized(self, ctx):
+        from graphrag_sdk.core.models import DocumentElement, DocumentInfo, DocumentOutput
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+
+        # A very large paragraph
+        large_content = "Word. " * 50
+        elements = [
+            DocumentElement(type="paragraph", content=large_content, breadcrumbs=["H1"])
+        ]
+        doc = DocumentOutput(
+            text=large_content,
+            document_info=DocumentInfo(path="test.md"),
+            elements=elements,
+        )
+
+        # Cap tokens to a very small number to force fallback
+        chunker = StructuralChunking(max_tokens=10)
+        result = await chunker.chunk_document(doc, ctx)
+
+        assert len(result.chunks) > 1
+        total_parts = len(result.chunks)
+        for i, chunk in enumerate(result.chunks, start=1):
+            assert f"H1 [Parte {i}/{total_parts}]" in chunk.text
+
+    async def test_no_elements_fallback(self, ctx):
+        from graphrag_sdk.core.models import DocumentInfo, DocumentOutput
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+
+        doc = DocumentOutput(
+            text="Just some text. More text.",
+            document_info=DocumentInfo(path="test.txt"),
+            elements=None,
+        )
+
+        chunker = StructuralChunking(max_tokens=50)
+        result = await chunker.chunk_document(doc, ctx)
+
+        assert len(result.chunks) == 1
+        assert result.chunks[0].text == "Just some text. More text."

--- a/graphrag_sdk/tests/test_chunking_strategies.py
+++ b/graphrag_sdk/tests/test_chunking_strategies.py
@@ -361,6 +361,55 @@ class TestStructuralChunking:
         assert len(result.chunks) == 1
         assert result.chunks[0].text == "Just some text. More text."
 
+    async def test_flatten_nested_elements(self, ctx):
+        from graphrag_sdk.core.models import DocumentElement, DocumentInfo, DocumentOutput
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+
+        nested_elements = [
+            DocumentElement(
+                type="header",
+                content="# Root",
+                breadcrumbs=["Root"],
+                children=[
+                    DocumentElement(
+                        type="paragraph",
+                        content="Child 1.",
+                        breadcrumbs=["Root", "Child 1"],
+                        children=[
+                            DocumentElement(
+                                type="paragraph",
+                                content="Grandchild.",
+                                breadcrumbs=["Root", "Child 1", "Grandchild"],
+                            )
+                        ]
+                    ),
+                    DocumentElement(
+                        type="paragraph",
+                        content="Child 2.",
+                        breadcrumbs=["Root", "Child 2"],
+                    )
+                ]
+            )
+        ]
+
+        doc = DocumentOutput(
+            text="ignored",
+            document_info=DocumentInfo(path="test.txt"),
+            elements=nested_elements,
+        )
+
+        chunker = StructuralChunking(max_tokens=100)
+        result = await chunker.chunk_document(doc, ctx)
+
+        assert len(result.chunks) == 1
+        # The flattened elements should be: Root, Child 1, Grandchild, Child 2
+        # And they should all be in the same chunk since max_tokens=100
+        text = result.chunks[0].text
+        assert "Root\n# Root" in text or "# Root" in text
+        assert "Root > Child 1\nChild 1." in text
+        assert "Root > Child 1 > Grandchild\nGrandchild." in text
+        assert "Root > Child 2\nChild 2." in text
+
     async def test_metadata_breadcrumbs_in_normal_chunk(self, ctx):
         """Buffered chunks must carry the union of their elements' breadcrumbs.
 

--- a/graphrag_sdk/tests/test_chunking_strategies.py
+++ b/graphrag_sdk/tests/test_chunking_strategies.py
@@ -325,14 +325,25 @@ class TestStructuralChunking:
             elements=elements,
         )
 
-        # Cap tokens to a very small number to force fallback
         chunker = StructuralChunking(max_tokens=10)
         result = await chunker.chunk_document(doc, ctx)
 
         assert len(result.chunks) > 1
+
         total_parts = len(result.chunks)
         for i, chunk in enumerate(result.chunks, start=1):
             assert f"H1 [Part {i}/{total_parts}]" in chunk.text
+
+    def test_raises_on_conflicting_kwargs(self):
+        """Passing shorthand kwargs alongside fallback_chunker must raise TypeError."""
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+        from graphrag_sdk.ingestion.chunking_strategies.fixed_size import FixedSizeChunking
+
+        with pytest.raises(TypeError, match="cannot be used together with 'fallback_chunker'"):
+            StructuralChunking(
+                fallback_chunker=FixedSizeChunking(chunk_size=200),
+                overlap_sentences=5,
+            )
 
     async def test_no_elements_fallback(self, ctx):
         from graphrag_sdk.core.models import DocumentInfo, DocumentOutput

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -149,6 +149,40 @@ class TestGraphRAGIngest:
             # Will fail because file doesn't exist, but would use PdfLoader
             await g.ingest("/fake/file.pdf")
 
+    async def test_ingest_auto_detects_md(self, mock_conn, embedder, llm, monkeypatch):
+        """Verifies Markdown extension triggers MarkdownLoader selection."""
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder, embedding_dimension=8)
+        
+        # Patch IngestionPipeline.run so we don't actually do anything,
+        # but we can inspect the loader that was built and passed to it.
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        
+        original_init = IngestionPipeline.__init__
+        captured_loader = None
+        
+        def fake_init(self_obj, loader, *args, **kwargs):
+            nonlocal captured_loader
+            captured_loader = loader
+            # Don't call original init, we just want to spy on the args
+        
+        from unittest.mock import AsyncMock
+        monkeypatch.setattr(IngestionPipeline, "__init__", fake_init)
+        
+        # Mock run to be awaitable
+        mock_run = AsyncMock()
+        from graphrag_sdk.core.models import IngestionResult
+        mock_run.return_value = IngestionResult(nodes_created=0, relationships_created=0, chunks_indexed=0, metadata={})
+        monkeypatch.setattr(IngestionPipeline, "run", mock_run)
+        
+        # We also need to skip the post-ingestion stuff
+        g._vector_store.ensure_indices = AsyncMock()
+        g._write_graph_config = AsyncMock()
+
+        await g.ingest("/fake/readme.md")
+        
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        assert isinstance(captured_loader, MarkdownLoader)
+
     async def test_ingest_calls_ensure_indices(self, graphrag):
         """Ingest should call ensure_indices after pipeline.run."""
         # Patch vector_store methods

--- a/graphrag_sdk/tests/test_ingestion_e2e.py
+++ b/graphrag_sdk/tests/test_ingestion_e2e.py
@@ -1,0 +1,291 @@
+"""End-to-end integration tests: MarkdownLoader → StructuralChunking → IngestionPipeline.
+
+Each component (loader, chunker, pipeline) is unit-tested in isolation.
+These tests verify the *wiring*: that real instances compose correctly and
+that metadata (breadcrumbs, strategy, chunk provenance) flows end-to-end
+without being lost at any hand-off point.
+
+External services (graph store, vector store) are provided by the shared
+mock_graph_store / mock_vector_store conftest fixtures.  Extraction and
+resolution are stubbed inline so each test controls only what it cares about.
+"""
+from __future__ import annotations
+
+import pytest
+
+_MARKDOWN = """\
+# Project Overview
+
+This document describes the GraphRAG SDK ingestion pipeline.
+
+## Installation
+
+Install the package with pip.
+
+### Prerequisites
+
+Python 3.10 or later is required.
+
+## Usage
+
+Import the pipeline and run it against your documents.
+"""
+
+
+class TestMarkdownLoaderStructuralChunkingPipeline:
+    """End-to-end wiring: real MarkdownLoader + real StructuralChunking."""
+
+    async def test_pipeline_runs_and_indexes_chunks(
+        self, ctx, tmp_path, mock_graph_store, mock_vector_store
+    ):
+        """Pipeline must complete without error and index at least one chunk."""
+        from graphrag_sdk.core.models import GraphData, GraphSchema, ResolutionResult
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+
+        class _NullExtractor(ExtractionStrategy):
+            async def extract(self, chunks, schema, ctx):
+                return GraphData(nodes=[], relationships=[])
+
+        class _NullResolver(ResolutionStrategy):
+            async def resolve(self, graph_data, ctx):
+                return ResolutionResult(nodes=[], relationships=[], merged_count=0)
+
+        md_file = tmp_path / "doc.md"
+        md_file.write_text(_MARKDOWN)
+
+        pipeline = IngestionPipeline(
+            loader=MarkdownLoader(),
+            chunker=StructuralChunking(max_tokens=512),
+            extractor=_NullExtractor(),
+            resolver=_NullResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            schema=GraphSchema(),
+        )
+        result = await pipeline.run(str(md_file), ctx)
+
+        assert result.chunks_indexed >= 1
+        assert mock_vector_store.index_chunks.called
+
+    async def test_structural_strategy_marker_set_on_chunks(
+        self, ctx, tmp_path, mock_graph_store, mock_vector_store
+    ):
+        """Chunks passed to the vector store must carry strategy='structural_chunking'.
+
+        Verifies chunk_document() is reached (not the plain chunk() fallback).
+        """
+        from graphrag_sdk.core.models import GraphData, GraphSchema, ResolutionResult
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+
+        class _NullExtractor(ExtractionStrategy):
+            async def extract(self, chunks, schema, ctx):
+                return GraphData(nodes=[], relationships=[])
+
+        class _NullResolver(ResolutionStrategy):
+            async def resolve(self, graph_data, ctx):
+                return ResolutionResult(nodes=[], relationships=[], merged_count=0)
+
+        md_file = tmp_path / "doc.md"
+        md_file.write_text(_MARKDOWN)
+
+        pipeline = IngestionPipeline(
+            loader=MarkdownLoader(),
+            chunker=StructuralChunking(max_tokens=512),
+            extractor=_NullExtractor(),
+            resolver=_NullResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            schema=GraphSchema(),
+        )
+        await pipeline.run(str(md_file), ctx)
+
+        chunks = mock_vector_store.index_chunks.call_args[0][0]
+        for chunk in chunks.chunks:
+            assert chunk.metadata.get("strategy") == "structural_chunking"
+
+    async def test_breadcrumbs_propagate_into_chunks(
+        self, ctx, tmp_path, mock_graph_store, mock_vector_store
+    ):
+        """Breadcrumbs produced by MarkdownLoader must survive into chunk metadata.
+
+        Validates the full hand-off:
+          MarkdownLoader (elements with breadcrumbs)
+          → StructuralChunking._flush_buffer (writes breadcrumbs to metadata)
+          → IngestionPipeline (passes chunks to vector store)
+        """
+        from graphrag_sdk.core.models import GraphData, GraphSchema, ResolutionResult
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+
+        class _NullExtractor(ExtractionStrategy):
+            async def extract(self, chunks, schema, ctx):
+                return GraphData(nodes=[], relationships=[])
+
+        class _NullResolver(ResolutionStrategy):
+            async def resolve(self, graph_data, ctx):
+                return ResolutionResult(nodes=[], relationships=[], merged_count=0)
+
+        md_file = tmp_path / "doc.md"
+        md_file.write_text(_MARKDOWN)
+
+        pipeline = IngestionPipeline(
+            loader=MarkdownLoader(),
+            chunker=StructuralChunking(max_tokens=512),
+            extractor=_NullExtractor(),
+            resolver=_NullResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            schema=GraphSchema(),
+        )
+        await pipeline.run(str(md_file), ctx)
+
+        chunks = mock_vector_store.index_chunks.call_args[0][0]
+        all_breadcrumbs = []
+        for chunk in chunks.chunks:
+            crumbs = chunk.metadata.get("breadcrumbs")
+            assert crumbs is not None, (
+                f"Chunk {chunk.index!r} missing 'breadcrumbs': {chunk.metadata}"
+            )
+            all_breadcrumbs.extend(crumbs)
+
+        assert "Project Overview" in all_breadcrumbs
+
+    async def test_chunk_nodes_in_graph_carry_breadcrumbs(
+        self, ctx, tmp_path, mock_graph_store, mock_vector_store
+    ):
+        """Chunk nodes written to the graph store must include breadcrumbs as a property.
+
+        _build_lexical_graph spreads chunk.metadata onto Chunk node properties,
+        so breadcrumbs become graph-queryable at zero extra cost.
+        """
+        from graphrag_sdk.core.models import GraphData, GraphSchema, ResolutionResult
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+
+        class _NullExtractor(ExtractionStrategy):
+            async def extract(self, chunks, schema, ctx):
+                return GraphData(nodes=[], relationships=[])
+
+        class _NullResolver(ResolutionStrategy):
+            async def resolve(self, graph_data, ctx):
+                return ResolutionResult(nodes=[], relationships=[], merged_count=0)
+
+        md_file = tmp_path / "doc.md"
+        md_file.write_text(_MARKDOWN)
+
+        pipeline = IngestionPipeline(
+            loader=MarkdownLoader(),
+            chunker=StructuralChunking(max_tokens=512),
+            extractor=_NullExtractor(),
+            resolver=_NullResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            schema=GraphSchema(),
+        )
+        await pipeline.run(str(md_file), ctx)
+
+        all_nodes = [
+            n
+            for call in mock_graph_store.upsert_nodes.call_args_list
+            for n in call[0][0]
+        ]
+        chunk_nodes = [n for n in all_nodes if n.label == "Chunk"]
+        assert chunk_nodes, "No Chunk nodes were written to the graph store"
+        for node in chunk_nodes:
+            assert "breadcrumbs" in node.properties, (
+                f"Chunk node {node.id!r} missing 'breadcrumbs': {node.properties}"
+            )
+
+    async def test_document_node_path_matches_source(
+        self, ctx, tmp_path, mock_graph_store, mock_vector_store
+    ):
+        """A Document node must be written with the source file path."""
+        from graphrag_sdk.core.models import GraphData, GraphSchema, ResolutionResult
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+
+        class _NullExtractor(ExtractionStrategy):
+            async def extract(self, chunks, schema, ctx):
+                return GraphData(nodes=[], relationships=[])
+
+        class _NullResolver(ResolutionStrategy):
+            async def resolve(self, graph_data, ctx):
+                return ResolutionResult(nodes=[], relationships=[], merged_count=0)
+
+        md_file = tmp_path / "readme.md"
+        md_file.write_text(_MARKDOWN)
+
+        pipeline = IngestionPipeline(
+            loader=MarkdownLoader(),
+            chunker=StructuralChunking(max_tokens=512),
+            extractor=_NullExtractor(),
+            resolver=_NullResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            schema=GraphSchema(),
+        )
+        await pipeline.run(str(md_file), ctx)
+
+        all_nodes = [
+            n
+            for call in mock_graph_store.upsert_nodes.call_args_list
+            for n in call[0][0]
+        ]
+        doc_nodes = [n for n in all_nodes if n.label == "Document"]
+        assert len(doc_nodes) == 1
+        assert doc_nodes[0].properties.get("path") == str(md_file)
+
+    async def test_header_markup_stripped_from_chunk_text(
+        self, ctx, tmp_path, mock_graph_store, mock_vector_store
+    ):
+        """Markdown '#' sigils must not appear in any indexed chunk text."""
+        from graphrag_sdk.core.models import GraphData, GraphSchema, ResolutionResult
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+
+        class _NullExtractor(ExtractionStrategy):
+            async def extract(self, chunks, schema, ctx):
+                return GraphData(nodes=[], relationships=[])
+
+        class _NullResolver(ResolutionStrategy):
+            async def resolve(self, graph_data, ctx):
+                return ResolutionResult(nodes=[], relationships=[], merged_count=0)
+
+        md_file = tmp_path / "doc.md"
+        md_file.write_text("# Main Title\n\nSome content here.\n")
+
+        pipeline = IngestionPipeline(
+            loader=MarkdownLoader(),
+            chunker=StructuralChunking(max_tokens=20),
+            extractor=_NullExtractor(),
+            resolver=_NullResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            schema=GraphSchema(),
+        )
+        await pipeline.run(str(md_file), ctx)
+
+        chunks = mock_vector_store.index_chunks.call_args[0][0]
+        full_text = " ".join(c.text for c in chunks.chunks)
+        assert "Main Title" in full_text
+        assert "# Main Title" not in full_text

--- a/graphrag_sdk/tests/test_ingestion_e2e.py
+++ b/graphrag_sdk/tests/test_ingestion_e2e.py
@@ -289,3 +289,149 @@ class TestMarkdownLoaderStructuralChunkingPipeline:
         full_text = " ".join(c.text for c in chunks.chunks)
         assert "Main Title" in full_text
         assert "# Main Title" not in full_text
+
+class TestPdfLoaderStructuralChunkingPipeline:
+    """Verifies that PdfLoader (which outputs no elements) falls back cleanly when used with StructuralChunking."""
+
+    async def test_pdf_loader_fallback(
+        self, ctx, tmp_path, mock_graph_store, mock_vector_store, monkeypatch
+    ):
+        from graphrag_sdk.core.models import DocumentInfo, DocumentOutput, GraphData, GraphSchema, ResolutionResult
+        from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import StructuralChunking
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+        from graphrag_sdk.ingestion.loaders.pdf_loader import PdfLoader
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+
+        class _NullExtractor(ExtractionStrategy):
+            async def extract(self, chunks, schema, ctx):
+                return GraphData(nodes=[], relationships=[])
+
+        class _NullResolver(ResolutionStrategy):
+            async def resolve(self, graph_data, ctx):
+                return ResolutionResult(nodes=[], relationships=[], merged_count=0)
+
+        # Mock PdfLoader so we don't require pypdf/pymupdf installed
+        async def mock_load(self_obj, source, ctx):
+            return DocumentOutput(
+                text="This is a PDF document. It has no structural elements, just flat text.",
+                document_info=DocumentInfo(path=source),
+                elements=None,  # Key behavior: PdfLoader returns None for elements
+            )
+        monkeypatch.setattr(PdfLoader, "load", mock_load)
+
+        pdf_file = tmp_path / "doc.pdf"
+        pdf_file.write_text("fake pdf bytes")
+
+        pipeline = IngestionPipeline(
+            loader=PdfLoader(),
+            chunker=StructuralChunking(max_tokens=50),
+            extractor=_NullExtractor(),
+            resolver=_NullResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            schema=GraphSchema(),
+        )
+        
+        result = await pipeline.run(str(pdf_file), ctx)
+
+        assert result.chunks_indexed >= 1
+        assert mock_vector_store.index_chunks.called
+        
+        # Verify chunks don't have breadcrumbs but have the base strategy marker
+        chunks = mock_vector_store.index_chunks.call_args[0][0]
+        for chunk in chunks.chunks:
+            # StructuralChunking fallback retains its marker or sentence_token_cap marker
+            # The exact metadata isn't strictly defined, but breadcrumbs should be empty/missing
+            assert not chunk.metadata.get("breadcrumbs")
+
+class TestMarkdownLoaderFallbackStrategies:
+    """Verifies that MarkdownLoader composes safely with standard non-structural chunking strategies."""
+
+    async def test_markdown_with_fixed_size_chunking(
+        self, ctx, tmp_path, mock_graph_store, mock_vector_store
+    ):
+        """Markdown loader text is correctly chunked by FixedSizeChunking."""
+        from graphrag_sdk.core.models import GraphData, GraphSchema, ResolutionResult
+        from graphrag_sdk.ingestion.chunking_strategies.fixed_size import FixedSizeChunking
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+
+        class _NullExtractor(ExtractionStrategy):
+            async def extract(self, chunks, schema, ctx):
+                return GraphData(nodes=[], relationships=[])
+
+        class _NullResolver(ResolutionStrategy):
+            async def resolve(self, graph_data, ctx):
+                return ResolutionResult(nodes=[], relationships=[], merged_count=0)
+
+        md_file = tmp_path / "doc.md"
+        # 120 chars total
+        md_file.write_text("# Title\n\nSentence one. Sentence two. Sentence three. Sentence four.")
+
+        pipeline = IngestionPipeline(
+            loader=MarkdownLoader(),
+            chunker=FixedSizeChunking(chunk_size=50, chunk_overlap=10),
+            extractor=_NullExtractor(),
+            resolver=_NullResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            schema=GraphSchema(),
+        )
+        
+        result = await pipeline.run(str(md_file), ctx)
+
+        assert result.chunks_indexed > 1
+        
+        chunks = mock_vector_store.index_chunks.call_args[0][0]
+        # Verify text was cleaned of sigils (handled by Loader) and chunked (handled by Chunker)
+        full_text = " ".join(c.text for c in chunks.chunks)
+        assert "Title" in full_text
+        assert "# Title" not in full_text
+        for chunk in chunks.chunks:
+            assert chunk.metadata.get("strategy") == "fixed_size"
+            # Since FixedSize ignores elements, breadcrumbs won't be explicitly mapped to chunks
+            assert "breadcrumbs" not in chunk.metadata
+
+    async def test_markdown_with_sentence_token_cap_chunking(
+        self, ctx, tmp_path, mock_graph_store, mock_vector_store
+    ):
+        """Markdown loader text is correctly chunked by SentenceTokenCapChunking."""
+        from graphrag_sdk.core.models import GraphData, GraphSchema, ResolutionResult
+        from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import SentenceTokenCapChunking
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        from graphrag_sdk.ingestion.pipeline import IngestionPipeline
+        from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+
+        class _NullExtractor(ExtractionStrategy):
+            async def extract(self, chunks, schema, ctx):
+                return GraphData(nodes=[], relationships=[])
+
+        class _NullResolver(ResolutionStrategy):
+            async def resolve(self, graph_data, ctx):
+                return ResolutionResult(nodes=[], relationships=[], merged_count=0)
+
+        md_file = tmp_path / "doc.md"
+        md_file.write_text("Sentence one. Sentence two. Sentence three. Sentence four.")
+
+        pipeline = IngestionPipeline(
+            loader=MarkdownLoader(),
+            # Cap tokens so it splits the document
+            chunker=SentenceTokenCapChunking(max_tokens=10, overlap_sentences=1),
+            extractor=_NullExtractor(),
+            resolver=_NullResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            schema=GraphSchema(),
+        )
+        
+        result = await pipeline.run(str(md_file), ctx)
+
+        assert result.chunks_indexed > 1
+        
+        chunks = mock_vector_store.index_chunks.call_args[0][0]
+        for chunk in chunks.chunks:
+            assert chunk.metadata.get("strategy") == "sentence_token_cap"

--- a/graphrag_sdk/tests/test_ingestion_e2e.py
+++ b/graphrag_sdk/tests/test_ingestion_e2e.py
@@ -386,12 +386,12 @@ class TestMarkdownLoaderFallbackStrategies:
         assert result.chunks_indexed > 1
         
         chunks = mock_vector_store.index_chunks.call_args[0][0]
-        # Verify text was cleaned of sigils (handled by Loader) and chunked (handled by Chunker)
+        # Verify chunks contain the original text (handled by Loader) and chunked (handled by Chunker)
         full_text = " ".join(c.text for c in chunks.chunks)
-        assert "Title" in full_text
-        assert "# Title" not in full_text
+        assert "# Title" in full_text
         for chunk in chunks.chunks:
-            assert chunk.metadata.get("strategy") == "fixed_size"
+            assert "start_char" in chunk.metadata
+            assert "end_char" in chunk.metadata
             # Since FixedSize ignores elements, breadcrumbs won't be explicitly mapped to chunks
             assert "breadcrumbs" not in chunk.metadata
 

--- a/graphrag_sdk/tests/test_loaders.py
+++ b/graphrag_sdk/tests/test_loaders.py
@@ -151,3 +151,97 @@ class TestPdfLoader:
 
         with pytest.raises(ImportError, match=r"graphrag-sdk\[pdf"):
             await pdf_mod.PdfLoader().load(str(file), ctx)
+
+
+class TestMarkdownLoader:
+    async def test_load_markdown_structure(self, ctx, tmp_path):
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+
+        file = tmp_path / "struct.md"
+        content = (
+            "# Main Title\n"
+            "Intro paragraph.\n\n"
+            "## Section 1\n"
+            "Section 1 details.\n\n"
+            "### Subsection 1.1\n"
+            "Deep details."
+        )
+        file.write_text(content)
+        loader = MarkdownLoader()
+        result = await loader.load(str(file), ctx)
+        
+        elements = result.elements
+        assert elements is not None
+        assert len(elements) == 6  # 3 headers, 3 paragraphs
+        
+        # Verify first header
+        assert elements[0].type == "header"
+        assert elements[0].level == 1
+        assert elements[0].content == "# Main Title"
+        assert elements[0].breadcrumbs == ["Main Title"]
+        
+        # Verify first paragraph
+        assert elements[1].type == "paragraph"
+        assert elements[1].content == "Intro paragraph."
+        assert elements[1].breadcrumbs == ["Main Title"]
+        
+        # Verify H2
+        assert elements[2].type == "header"
+        assert elements[2].level == 2
+        assert elements[2].content == "## Section 1"
+        assert elements[2].breadcrumbs == ["Main Title", "Section 1"]
+        
+        # Verify deeply nested paragraph
+        assert elements[5].type == "paragraph"
+        assert elements[5].content == "Deep details."
+        assert elements[5].breadcrumbs == ["Main Title", "Section 1", "Subsection 1.1"]
+
+    async def test_file_not_found(self, ctx):
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        loader = MarkdownLoader()
+        with pytest.raises(LoaderError, match="File not found"):
+            await loader.load("/nonexistent.md", ctx)
+
+    async def test_markdown_complex_structures(self, ctx, tmp_path):
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+
+        file = tmp_path / "complex.md"
+        content = (
+            "# Data\n\n"
+            "| ID | Name |\n"
+            "|---|---|\n"
+            "| 1 | Alice |\n\n"
+            "Some list:\n"
+            "- Item 1\n"
+            "  - Subitem\n"
+            "\n"
+            "- Item 2\n\n"
+            "Code:\n"
+            "```python\n"
+            "def foo():\n"
+            "    return 42\n"
+            "```\n"
+        )
+        file.write_text(content)
+        loader = MarkdownLoader()
+        result = await loader.load(str(file), ctx)
+        
+        elements = result.elements
+        assert elements is not None
+        
+        # Verify table
+        assert elements[1].type == "table"
+        assert "| 1 | Alice |" in elements[1].content
+        
+        # Verify paragraph
+        assert elements[2].type == "paragraph"
+        assert elements[2].content == "Some list:"
+        
+        # Verify list
+        assert elements[3].type == "list"
+        assert "- Item 1" in elements[3].content
+        assert "- Item 2" in elements[3].content
+        
+        # Verify code block
+        assert elements[5].type == "code"
+        assert "def foo():" in elements[5].content

--- a/graphrag_sdk/tests/test_loaders.py
+++ b/graphrag_sdk/tests/test_loaders.py
@@ -177,7 +177,7 @@ class TestMarkdownLoader:
         # Verify first header
         assert elements[0].type == "header"
         assert elements[0].level == 1
-        assert elements[0].content == "# Main Title"
+        assert elements[0].content == "Main Title"
         assert elements[0].breadcrumbs == ["Main Title"]
         
         # Verify first paragraph
@@ -188,7 +188,7 @@ class TestMarkdownLoader:
         # Verify H2
         assert elements[2].type == "header"
         assert elements[2].level == 2
-        assert elements[2].content == "## Section 1"
+        assert elements[2].content == "Section 1"
         assert elements[2].breadcrumbs == ["Main Title", "Section 1"]
         
         # Verify deeply nested paragraph

--- a/graphrag_sdk/tests/test_loaders.py
+++ b/graphrag_sdk/tests/test_loaders.py
@@ -202,6 +202,24 @@ class TestMarkdownLoader:
         with pytest.raises(LoaderError, match="File not found"):
             await loader.load("/nonexistent.md", ctx)
 
+    async def test_raises_when_markdown_it_missing(self, ctx, tmp_path, monkeypatch):
+        """When markdown-it-py is not installed, a clear install message is raised and not hidden by LoaderError."""
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+        
+        file = tmp_path / "struct.md"
+        file.write_text("# Main Title\nIntro.")
+        
+        loader = MarkdownLoader()
+        
+        def fake_parse_markdown(self, text):
+            raise ImportError("Markdown parsing requires 'markdown-it-py'. Install with:\n  pip install graphrag-sdk[markdown]")
+            
+        monkeypatch.setattr(MarkdownLoader, "_parse_markdown", fake_parse_markdown)
+        
+        with pytest.raises(ImportError, match=r"graphrag-sdk\[markdown\]"):
+            await loader.load(str(file), ctx)
+
+
     async def test_markdown_complex_structures(self, ctx, tmp_path):
         from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
 

--- a/graphrag_sdk/tests/test_pipeline_10step.py
+++ b/graphrag_sdk/tests/test_pipeline_10step.py
@@ -39,7 +39,7 @@ def pipeline_components(mock_graph_store, mock_vector_store):
     )
 
     chunker = MagicMock()
-    chunker.chunk = AsyncMock(
+    chunker.chunk_document = AsyncMock(
         return_value=TextChunks(
             chunks=[
                 TextChunk(text="Alice works at Acme Corp.", index=0, uid="chunk-0"),
@@ -134,7 +134,7 @@ class TestPipeline10StepExecution:
         # Step 1: Loader called
         pipeline_components["loader"].load.assert_called_once()
         # Step 2: Chunker called
-        pipeline_components["chunker"].chunk.assert_called_once()
+        pipeline_components["chunker"].chunk_document.assert_called_once()
         # Step 3: Lexical graph written (upsert_nodes called for doc + chunks)
         # Step 4: Extractor called
         pipeline_components["extractor"].extract.assert_called_once()
@@ -187,7 +187,7 @@ class TestPipelineWithTextInput:
         )
 
         pipeline_components["loader"].load.assert_not_called()
-        pipeline_components["chunker"].chunk.assert_called_once()
+        pipeline_components["chunker"].chunk_document.assert_called_once()
 
 
 class TestPipelineEmptyChunks:
@@ -201,7 +201,7 @@ class TestPipelineEmptyChunks:
             )
         )
         chunker = MagicMock()
-        chunker.chunk = AsyncMock(return_value=TextChunks(chunks=[]))
+        chunker.chunk_document = AsyncMock(return_value=TextChunks(chunks=[]))
 
         pipeline = IngestionPipeline(
             loader=loader,


### PR DESCRIPTION
#241 Feature: Document-Aware Structural Chunking & Refactored Ingestion Pipeline

Hi guys, I would like to share some ideas about document loaders and structural chunking. 

## Summary

This Pull Request introduces a structural-aware document ingestion pipeline designed to significantly improve retrieval precision in RAG scenarios. It transitions the chunking architecture from being purely text-based to operating on complex document structures (such as tables, lists, and hierarchical headers) are never broken arbitrarily.

## Changes

- **ChunkingStrategy Interface**: Added a new method chunk_document(document: DocumentOutput, ctx: Context).
- **Pipeline Update**: The ingestion pipeline now passes the full DocumentOutput object to the chunker rather than just the raw text.
- **Backward Compatibility**: By default, chunk_document delegates to the legacy chunk(document.text) method. Format-agnostic text chunkers continue to work exactly as before, while advanced strategies can tap into document.elements.

## Test Plan

- [x] All existing tests pass (`pytest tests/ -q`)
- [x] New tests added for new functionality (if applicable)
- [x] Lint passes (`ruff check src/`)

## Notes

1. Generic Document Model (DocumentElement)
Introduced a new hierarchical data model in core/models.py. Loaders now parse documents into a list of DocumentElements. Each node retains its original content, structural type (paragraph, table, code, etc.), and spatial breadcrumbs (e.g., ["Chapter 1", "Section 1.2"]).

2. Robust Markdown Parsing (markdown-it-py)
Replaced the brittle Regex/State-Machine parsing in MarkdownLoader with markdown-it-py (fully CommonMark compliant).

The loader now deterministically loops through Semantic Tokens (table_open, bullet_list_open, etc.) to perfectly map markdown lines to DocumentElements, completely eliminating the risk of malformed tables or nested lists.

3. StructuralChunking Strategy
Introduced a powerful, format-agnostic chunker that groups DocumentElements dynamically up to a max_tokens cap:

- Smart Fallback: If a single element (e.g., a massive 400-line table) exceeds the token cap, it delegates the splitting to a fallback_chunker (like SentenceTokenCapChunking).

- Fragment Indexing (Anti-Amnesia): When oversized elements are sliced, the chunker actively prepends the contextual breadcrumb and a sequential index to each sub-chunk (e.g., Header 1 > Header 2 [Part 1/3]). This ensures the LLM and the Vector Store retain perfect spatial awareness during Retrieval.

4. ContextualChunking as a Decorator
Refactored ContextualChunking to act as a wrapper/decorator over a base_chunker. It receives the pre-chunked list and focuses entirely on executing high-performance batch LLM calls to enrich the chunks with global context.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown loader with structural parsing (headers, paragraphs, lists, tables, code) and breadcrumb context.
  * Structural chunking that groups element hierarchy into token-capped chunks, preserves breadcrumbs, and falls back for oversized pieces.
  * Chunkers updated to accept full parsed documents; contextual chunking now composes with base chunkers.

* **Tests**
  * Expanded unit and e2e tests for markdown parsing, structural chunking, contextual behavior, and pipeline integration.

* **Documentation**
  * Docs and example demonstrating MarkdownLoader and StructuralChunking usage.

* **Chores**
  * Added markdown-it-py>=3.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->