### PR TITLE
fix(retrieval): preserve full Document.path in chunk citations

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/chunk_retrieval.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/chunk_retrieval.py
@@ -114,10 +114,17 @@ async def fetch_chunk_documents(
     graph_store: Any,
     chunk_ids: list[str],
 ) -> dict[str, str]:
-    """Batch-fetch source document name for each chunk via PART_OF.
+    """Batch-fetch the source document path for each chunk via PART_OF.
+
+    Returns the value of ``Document.path`` exactly as it was stored at
+    ingestion time — typically a path relative to the ingestion root
+    (e.g. ``"operations/falkordblite/falkordblite-py.md"``). Downstream
+    consumers (citation rendering, source-link builders) need the full
+    relative path; basenames alone are ambiguous when the same filename
+    appears in multiple directories (e.g. ``index.md``).
 
     Returns:
-        Mapping of chunk_id -> document filename.
+        Mapping of chunk_id -> document path.
     """
     if not chunk_ids:
         return {}
@@ -133,8 +140,7 @@ async def fetch_chunk_documents(
             cid = row[0] or ""
             path = row[1] if len(row) > 1 else ""
             if cid and path:
-                name = path.rsplit("/", 1)[-1] if "/" in path else path
-                mapping[cid] = name
+                mapping[cid] = path
         return mapping
     except Exception as exc:
         logger.debug("Document name fetch failed: %s", exc)

--- a/graphrag_sdk/tests/test_chunk_retrieval.py
+++ b/graphrag_sdk/tests/test_chunk_retrieval.py
@@ -1,0 +1,92 @@
+"""Tests for retrieval/strategies/chunk_retrieval.py utilities."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphrag_sdk.retrieval.strategies.chunk_retrieval import fetch_chunk_documents
+
+
+def _graph_with_rows(rows: list[list]) -> MagicMock:
+    """Build a graph_store mock whose query_raw returns the given rows."""
+    result = MagicMock()
+    result.result_set = rows
+    graph = MagicMock()
+    graph.query_raw = AsyncMock(return_value=result)
+    return graph
+
+
+class TestFetchChunkDocuments:
+    """fetch_chunk_documents returns the full Document.path verbatim.
+
+    The path is the value passed to ``rag.ingest()`` as the source id
+    (typically a path relative to the ingestion root). Downstream
+    consumers — citation rendering, source-link builders — rely on the
+    full relative path to disambiguate files that share a basename
+    (e.g. ``operations/index.md`` vs ``commands/index.md``).
+    """
+
+    async def test_returns_full_relative_path_unchanged(self):
+        graph = _graph_with_rows(
+            [
+                ["chunk-1", "operations/falkordblite/falkordblite-py.md"],
+                ["chunk-2", "cypher/functions.md"],
+                ["chunk-3", "genai-tools/graphrag-toolkit.md"],
+            ]
+        )
+        mapping = await fetch_chunk_documents(graph, ["chunk-1", "chunk-2", "chunk-3"])
+
+        assert mapping == {
+            "chunk-1": "operations/falkordblite/falkordblite-py.md",
+            "chunk-2": "cypher/functions.md",
+            "chunk-3": "genai-tools/graphrag-toolkit.md",
+        }
+
+    async def test_preserves_paths_that_share_a_basename(self):
+        # Three different files with the same basename — we must not
+        # collapse them to identical mappings.
+        graph = _graph_with_rows(
+            [
+                ["c-root", "index.md"],
+                ["c-ops", "operations/index.md"],
+                ["c-cmd", "commands/index.md"],
+            ]
+        )
+        mapping = await fetch_chunk_documents(graph, ["c-root", "c-ops", "c-cmd"])
+
+        assert mapping == {
+            "c-root": "index.md",
+            "c-ops": "operations/index.md",
+            "c-cmd": "commands/index.md",
+        }
+
+    async def test_returns_basename_when_path_has_no_directory(self):
+        graph = _graph_with_rows([["chunk-1", "configuration.md"]])
+        mapping = await fetch_chunk_documents(graph, ["chunk-1"])
+        assert mapping == {"chunk-1": "configuration.md"}
+
+    async def test_skips_rows_with_empty_path(self):
+        # Older ingests may have left Document.path blank — skip those.
+        graph = _graph_with_rows(
+            [
+                ["chunk-1", ""],
+                ["chunk-2", None],
+                ["chunk-3", "cypher/match.md"],
+            ]
+        )
+        mapping = await fetch_chunk_documents(graph, ["chunk-1", "chunk-2", "chunk-3"])
+        assert mapping == {"chunk-3": "cypher/match.md"}
+
+    async def test_empty_chunk_ids_short_circuits(self):
+        graph = MagicMock()
+        graph.query_raw = AsyncMock()
+        mapping = await fetch_chunk_documents(graph, [])
+        assert mapping == {}
+        graph.query_raw.assert_not_awaited()
+
+    async def test_query_failure_returns_empty_mapping(self):
+        graph = MagicMock()
+        graph.query_raw = AsyncMock(side_effect=RuntimeError("graph down"))
+        mapping = await fetch_chunk_documents(graph, ["chunk-1"])
+        assert mapping == {}

--- a/graphrag_sdk/tests/test_multi_path_retrieval.py
+++ b/graphrag_sdk/tests/test_multi_path_retrieval.py
@@ -286,7 +286,12 @@ class TestMultiPathRetrieval:
         assert call_count["two_hop_rel"] >= 1
 
     async def test_source_document_tags(self, mp_graph_store, mp_vector_store, mp_embedder, mp_llm):
-        """Passages should include [Source: filename] when document info is available."""
+        """Passages should include [Source: <path>] with the full Document.path verbatim.
+
+        Citation consumers (link builders, source-attribution UIs) need
+        the full relative path to disambiguate files that share a
+        basename — e.g. `operations/index.md` vs `commands/index.md`.
+        """
         mp_vector_store.fulltext_search_chunks = AsyncMock(return_value=[
             {"id": "c1", "text": "Alice is an engineer at Acme Corp.", "score": 0.8},
         ])
@@ -294,7 +299,7 @@ class TestMultiPathRetrieval:
         async def mock_query_raw(cypher, params=None):
             if "PART_OF" in cypher:
                 result = MagicMock()
-                result.result_set = [["c1", "/docs/novel.txt"]]
+                result.result_set = [["c1", "docs/fiction/novel.txt"]]
                 return result
             result = MagicMock()
             result.result_set = []
@@ -311,7 +316,7 @@ class TestMultiPathRetrieval:
         result = await s.search("Who is Alice?")
         for item in result.items:
             if item.metadata.get("section") == "passages":
-                assert "[Source: novel.txt]" in item.content
+                assert "[Source: docs/fiction/novel.txt]" in item.content
                 break
 
     async def test_question_type_yesno(self):


### PR DESCRIPTION
## Summary
- \`fetch_chunk_documents\` was truncating \`Document.path\` to a basename before returning, throwing away the directory part of the path.
- That lost information downstream: files sharing a basename across directories (e.g. \`operations/index.md\` vs \`commands/index.md\`) became indistinguishable in the \`[Source: …]\` citation tag, and any consumer building source links from the citation couldn't reconstruct the real location.
- \`Document.path\` already stores the full path passed to \`rag.ingest()\` (see \`pipeline.py:132\`). Fix is read-side only — return the path verbatim. No data migration; existing graphs start emitting full paths on the next query.

## Concrete impact
A consumer (the GraphRAG-UI chat widget) is using \`source_doc\` to render clickable links to the deployed docs site. Today it builds URLs like \`https://docs.falkordb.com/falkordblite-py.html\` — a 404 — instead of \`https://docs.falkordb.com/operations/falkordblite/falkordblite-py.html\`, because the directory was dropped before it ever reached the consumer. After this fix the consumer gets enough information to build the correct URL.

## Test plan
- [x] New \`tests/test_chunk_retrieval.py\` module: full-path passthrough, shared-basename disambiguation (3 \`index.md\` files), bare basename when there's no directory, empty/null path skipping, empty input short-circuit, query-failure → empty mapping.
- [x] Updated \`test_source_document_tags\` in \`test_multi_path_retrieval.py\` (which previously locked in the basename behavior) to assert the full path appears in the \`[Source: …]\` marker.
- [x] Full SDK suite: \`pytest graphrag_sdk/tests/ → 664 passed, 2 skipped\`.

## Notes
- Behavior change is observable: \`[Source: …]\` markers in the LLM context now contain the full relative path. Slightly longer, more informative — no semantic loss.
- Docstring updated to make the contract explicit ("path verbatim, typically relative to the ingestion root").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document retrieval now preserves complete file paths (including directory structure) instead of stripping directory components. This improves document identification and disambiguation in citation results.

* **Tests**
  * Added comprehensive test coverage for chunk retrieval behavior with various path scenarios.
  * Updated existing retrieval tests to validate full-path handling in document citations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->