### PR TITLE
chore(release): v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-05-04
+
+Patch release. One retrieval correctness fix and one default-value
+change carried over from the post-1.0.1 README onboarding work.
+
+### Fixed
+
+- **Chunk citations preserve the full `Document.path`.** The chunk
+  retrieval strategy was reducing the path returned from the graph
+  to a basename via `path.rsplit("/", 1)[-1]` before handing it off
+  to the citation pipeline. That dropped real information: files
+  sharing a basename across directories — e.g. `operations/index.md`
+  vs `commands/index.md` — collapsed to the same identifier
+  downstream, and consumers building source links from the citation
+  could no longer reconstruct the original location. `Document.path`
+  already stored the full path passed to `rag.ingest()`, so this is
+  a read-side fix only; existing graphs start emitting full paths in
+  the next query with no migration required.
+
 ### Changed
 
 - **Default `embedding_dimension` lowered from 1536 to 256.** Aligns

--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphrag-sdk"
-version = "1.0.1"
+version = "1.0.2"
 description = "The most accurate Graph RAG framework. Build knowledge graphs and query them with natural language. Built on FalkorDB."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -11,7 +11,7 @@
 #   Adaptability — Optimization-ready core, strategies are swappable.
 #   Velocity — Production-grade throughput.
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 # ── API Surface (Facade) ────────────────────────────────────────
 from graphrag_sdk.api.main import GraphRAG


### PR DESCRIPTION
## Summary

Release prep for **v1.0.2**. Patch bundle of one retrieval correctness fix and one default-value change that had been sitting in `Unreleased` since the post-1.0.1 README polish.

- Bumps version `1.0.1` → `1.0.2` in `graphrag_sdk/pyproject.toml` and `graphrag_sdk/src/graphrag_sdk/__init__.py` (pypi-publish workflow checks both line up with the git tag)
- Finalizes `CHANGELOG.md`: new `[1.0.2] - 2026-05-04` section
  - **Fixed**: chunk citations preserve full `Document.path` (#245) — files sharing a basename across directories no longer collapse to the same identifier downstream
  - **Changed**: default `embedding_dimension` lowered from 1536 to 256 to match the `text-embedding-3-large` Matryoshka 256-dim benchmark configuration (carried over from `Unreleased`; existing graphs unaffected)

No code changes in this PR — the underlying fix already landed via #245. This is the version-bump + CHANGELOG commit needed to cut the tag.

## Release steps after merge

- [ ] Merge to `main`
- [ ] Tag `v1.0.2` on the merge commit and create a GitHub release — the `pypi-publish.yaml` workflow auto-publishes to PyPI on release, and verifies `pyproject.toml` matches the tag

## Test plan

- [x] `pyproject.toml` version matches `__version__` in `graphrag_sdk/__init__.py`
- [x] CHANGELOG `[Unreleased]` is empty; `[1.0.2]` summarizes both shipping changes
- [x] No code changes (pure release-prep diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chunk citation retrieval to ensure full document paths are preserved, preventing potential citation collisions in systems with similarly named documents

* **Changes**
  * Updated default embedding dimension to 256 (from 1536) for improved performance and reduced memory requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->