### PR TITLE
chore(release): bump to v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-13
+
+Closes a usability gap in v1.1.0's `apply_changes` convenience wrapper:
+per-call strategy overrides (`loader` / `chunker` / `extractor` /
+`resolver`) now reach the inner `ingest()` and `update()` dispatches.
+Previously callers who passed strategies to `apply_changes` got SDK
+defaults silently — the only escape was to bypass the wrapper and loop
+over the primitives directly. Default behaviour is unchanged.
+
+### Added
+
+- **`GraphRAG.apply_changes(*, loader=, chunker=, extractor=, resolver=, ...)`**
+  and `apply_changes_sync()` — strategy overrides are now forwarded to
+  the inner `ingest()` (for `added`) and `update()` (for `modified`)
+  calls. `delete_document` does not take strategies and is unaffected.
+  All four kwargs default to `None`, preserving v1.1.0 behaviour for
+  callers that don't pass them.
+
 ## [1.1.0] - 2026-05-05
 
 Adds incremental ingestion primitives and a CI-friendly batch wrapper.

--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphrag-sdk"
-version = "1.1.0"
+version = "1.1.1"
 description = "The most accurate Graph RAG framework. Build knowledge graphs and query them with natural language. Built on FalkorDB."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -11,7 +11,7 @@
 #   Adaptability — Optimization-ready core, strategies are swappable.
 #   Velocity — Production-grade throughput.
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # ── API Surface (Facade) ────────────────────────────────────────
 from graphrag_sdk.api.main import GraphRAG


### PR DESCRIPTION
## Summary
Cuts v1.1.1 to ship the `apply_changes` strategy-forwarding fix from #250.

v1.1.0 silently dropped per-call `loader` / `chunker` / `extractor` / `resolver` overrides at the `apply_changes` boundary; downstream CI orchestrators using `apply_changes` as their single entrypoint were getting SDK defaults regardless of what they passed. #250 closes the gap by forwarding the four kwargs through to the inner `ingest()` and `update()` calls; this PR releases that fix.

Default behaviour is unchanged — `apply_changes` callers that don't pass strategies still get SDK defaults.

## Changes
- `pyproject.toml`: `version = "1.1.0"` → `"1.1.1"`
- `__init__.py`: `__version__ = "1.1.0"` → `"1.1.1"`
- `CHANGELOG.md`: new `[1.1.1] - 2026-05-13` section documenting the forwarded kwargs

## After merge
- Tag `v1.1.1` from `main`
- Build + publish wheel to PyPI
- Downstream (e.g. FalkorDB/GraphRAG-UI) bumps pin from `==1.1.0` → `==1.1.1` to start using the new kwargs

## Test plan
- [x] PR #250's tests pass (`test_facade.py` — 114 passed)
- [ ] Smoke-import the published wheel: `pip install graphrag-sdk==1.1.1 && python -c "import graphrag_sdk; assert graphrag_sdk.__version__ == '1.1.1'"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed per-call strategy overrides in `apply_changes` convenience wrappers to properly forward configuration parameters into inner operations. Default behavior remains unchanged when overrides are not specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/GraphRAG-SDK/pull/251)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->