### PR TITLE
docs(retrieval): recommend SentenceTokenCapChunking for CypherFirst

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/cypher_first.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/cypher_first.py
@@ -927,6 +927,39 @@ class CypherFirstAggregationStrategy(RetrievalStrategy):
     extraction-quality issues — not strategy bugs — and should be
     addressed in the ingestion pipeline (resolver, coref, dedup).
 
+    Recommended ingestion config
+    ----------------------------
+    For aggregation accuracy, ingest with a **sentence- or paragraph-aware
+    chunker**, not the default :class:`FixedSizeChunking`. Character-window
+    chunking can split entity names mid-token at chunk boundaries
+    (``"Wayne Enterprises"`` → ``"Wayne En"``), and the resulting stub
+    entities never merge with their full forms during resolution. On the
+    internal 7-question aggregation benchmark, switching from
+    ``FixedSizeChunking(chunk_size=1000)`` to
+    ``SentenceTokenCapChunking(max_tokens=512, overlap_sentences=2)``
+    moved the score from 6/7 (intermittent) to 7/7 (stable across runs)
+    by eliminating every truncation stub and almost every short-form
+    duplicate (the latter benefit because per-chunk FastCoref binds
+    references to antecedents that now reliably land in the same chunk)::
+
+        from graphrag_sdk import (
+            CypherFirstAggregationStrategy,
+            FastCorefResolver,
+            GraphExtraction,
+            LLMVerifiedResolution,
+            SentenceTokenCapChunking,
+        )
+
+        chunker = SentenceTokenCapChunking(max_tokens=512, overlap_sentences=2)
+        extractor = GraphExtraction(llm=llm, coref_resolver=FastCorefResolver())
+        resolver = LLMVerifiedResolution(llm=llm, embedder=embedder)
+
+        await rag.ingest(text=doc, chunker=chunker,
+                         extractor=extractor, resolver=resolver)
+
+    ``StructuralChunking`` is a reasonable alternative when the source
+    text has explicit paragraph/header structure (e.g. Markdown).
+
     Args:
         graph_store: Required for Cypher execution.
         vector_store: Required for the RAG fallback.


### PR DESCRIPTION
## Summary

Adds a "Recommended ingestion config" section to `CypherFirstAggregationStrategy`'s docstring pointing users at `SentenceTokenCapChunking`. Cosmetic / discoverability — the strategy itself works the same.

## Why

The default chunker (`FixedSizeChunking`) splits on a character window with no awareness of sentence or word boundaries, so entity names get truncated at chunk boundaries (`"Wayne Enterprises"` → `"Wayne En"`). The stub entities never merge with their full forms during resolution, so cypher counts come back inflated.

On the internal 7-question aggregation benchmark, switching the benchmark's ingestion config from `FixedSizeChunking(chunk_size=1000)` to `SentenceTokenCapChunking(max_tokens=512, overlap_sentences=2)` moved the score from **6/7** (intermittent) to **7/7** (stable across three runs).

## Stacking

This PR is stacked on **#255** (`feat/cypher-aggregation-accuracy`). After #255 merges, GitHub will auto-retarget this to `main` and the diff stays a 33-line docstring change.

Related: **#254** makes `SentenceTokenCapChunking` the SDK's default chunker — that's a behavior change for all callers, kept separate from this docs-only PR.

## Test plan

- [x] All existing tests pass on the parent branch
- [ ] No new tests needed (docstring only)