### PR TITLE
fix(retrieval): rank MENTIONED_IN chunks by cosine in MultiPath Path C

### DIFF
--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/chunk_retrieval.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/chunk_retrieval.py
@@ -51,17 +51,25 @@ async def retrieve_chunks(
     except Exception as exc:
         logger.debug("Chunk vector search failed: %s", exc)
 
-    # Path C: MENTIONED_IN — 3 chunks per entity (batched UNWIND)
+    # Path C: MENTIONED_IN — top-3 chunks per entity, ranked by cosine
+    # distance to the query embedding. Hub entities (e.g. the main
+    # product name) can be MENTIONED_IN hundreds of chunks; the previous
+    # COLLECT(c)[..3] picked an arbitrary 3, almost never including the
+    # chunks most relevant to the current query. Ranking by cosine here
+    # surfaces the chunks closest to the query intent.
     eids_mention = [eid for eid, _ in entity_list[:15]]
     if eids_mention:
         try:
             result = await graph_store.query_raw(
                 "UNWIND $eids AS eid "
                 "MATCH (e:__Entity__ {id: eid})-[:MENTIONED_IN]->(c:Chunk) "
+                "WHERE c.embedding IS NOT NULL "
+                "WITH eid, c, vec.cosineDistance(c.embedding, vecf32($qv)) AS dist "
+                "ORDER BY eid, dist ASC "
                 "WITH eid, COLLECT(c)[..3] AS chunks "
                 "UNWIND chunks AS c "
                 "RETURN eid, c.id AS id, c.text AS text",
-                {"eids": eids_mention},
+                {"eids": eids_mention, "qv": query_vector},
             )
             for row in result.result_set:
                 cid = row[1]

--- a/graphrag_sdk/tests/test_multi_path_retrieval.py
+++ b/graphrag_sdk/tests/test_multi_path_retrieval.py
@@ -233,6 +233,55 @@ class TestMultiPathRetrieval:
         ]
         assert len(twohop_chunk_queries) >= 1
 
+    async def test_mentioned_in_ranks_chunks_by_cosine(self, mp_graph_store, mp_vector_store, mp_embedder, mp_llm):
+        """The MENTIONED_IN path must rank chunks per entity by cosine
+        distance to the query embedding — not pick an arbitrary 3.
+
+        Hub entities can be MENTIONED_IN hundreds of chunks; arbitrary
+        selection almost never surfaces the chunks relevant to the
+        current query (regression: see PR referencing issue #258).
+        """
+        # Seed entity discovery so Path C runs (mirrors the setup in
+        # ``test_mentioned_in_and_2hop_chunk_paths``).
+        mp_vector_store.search_relationships = AsyncMock(return_value=[
+            {"src_name": "Alice", "type": "WORKS_AT", "tgt_name": "Acme", "fact": "engineer", "score": 0.9},
+        ])
+
+        captured: list[tuple[str, dict]] = []
+
+        async def capture_query(cypher, params=None):
+            captured.append((cypher, params or {}))
+            result = MagicMock()
+            result.result_set = []
+            return result
+
+        mp_graph_store.query_raw = AsyncMock(side_effect=capture_query)
+
+        s = MultiPathRetrieval(
+            graph_store=mp_graph_store,
+            vector_store=mp_vector_store,
+            embedder=mp_embedder,
+            llm=mp_llm,
+        )
+        await s.search("Who is Alice?")
+
+        # Find the direct MENTIONED_IN query (entity -> chunk, not 2-hop)
+        direct_mention = [
+            (q, p) for q, p in captured
+            if "MENTIONED_IN" in q and "Chunk" in q and "neighbor" not in q.lower()
+        ]
+        assert direct_mention, "expected at least one direct MENTIONED_IN chunk query"
+
+        cypher, params = direct_mention[0]
+        # The fix: rank by cosine distance to the query vector before
+        # COLLECT, so per-entity chunk selection is query-relevant.
+        assert "vec.cosineDistance" in cypher, (
+            "MENTIONED_IN chunk query must rank by cosine distance to the "
+            "query vector (regression of issue #258)"
+        )
+        assert "ORDER BY" in cypher, "expected ORDER BY to make COLLECT[..3] meaningful"
+        assert "qv" in params, "query vector must be passed as a parameter"
+
     async def test_format_produces_sections(self, mp_graph_store, mp_vector_store, mp_embedder, mp_llm):
         """Output should include structured sections when data is available."""
         mp_vector_store.search_relationships = AsyncMock(return_value=[


### PR DESCRIPTION
## Summary

`retrieve_chunks` Path C uses `COLLECT(c)[..3]` with no `ORDER BY`. For hub entities — the main product name, generic verbs like "install", high-frequency Cypher keywords — this picks **an arbitrary 3 out of hundreds**, almost never the chunks relevant to the current query.

This PR adds an `ORDER BY vec.cosineDistance(c.embedding, query_vector)` before the `COLLECT` so per-entity chunk selection is query-aware. Closes the retrieval half of #258.

## Repro / Evidence

Tested against the FalkorDB docs knowledge graph (1,356 chunks, 2,945 entities). The `FalkorDB` entity has **486 chunks** linked via `MENTIONED_IN`. Six of those are install-relevant (chunks 0, 1, 2, 3, 6, 7 of `getting-started/index.md`).

P(an unordered 3 of 486 contains an install chunk) ≈ 4% per slot → ~12% chance overall. Measured behavior matches: standalone `How do I install FalkorDB?` reliably failed.

**Before** (arbitrary 3):
> "This isn't covered in the FalkorDB docs. Related setup topics include Docker, Kubernetes, and the Python client installation."

**After** (cosine-ranked 3):
> "FalkorDB can be deployed with Docker, including the `falkordb/falkordb-server` image, and there's also a Helm chart installation path for Kubernetes. For Python, `pip install falkordb` installs the FalkorDB client."

Same query, same graph, same retrieval strategy — only `chunk_retrieval.py:Path C` changed.

## The change

```diff
- MATCH (e:__Entity__ {id: eid})-[:MENTIONED_IN]->(c:Chunk)
- WITH eid, COLLECT(c)[..3] AS chunks
+ MATCH (e:__Entity__ {id: eid})-[:MENTIONED_IN]->(c:Chunk)
+ WHERE c.embedding IS NOT NULL
+ WITH eid, c, vec.cosineDistance(c.embedding, vecf32($qv)) AS dist
+ ORDER BY eid, dist ASC
+ WITH eid, COLLECT(c)[..3] AS chunks
```

`query_vector` is already passed into `retrieve_chunks` — used by Path B (raw vector search) — so it's a parameter-add, not a new signature. Chunks without stored embeddings are excluded (rare; `c.embedding IS NOT NULL` guard).

## Tests

Added `test_mentioned_in_ranks_chunks_by_cosine` to `tests/test_multi_path_retrieval.py`, asserting the emitted Cypher contains `vec.cosineDistance`, `ORDER BY`, and passes the query vector as a parameter. Full retrieval test suite passes (161/161, 1 skip).

## Test plan

- [x] Unit tests pass (`pytest tests/test_multi_path_retrieval.py` — 45/45)
- [x] Broader retrieval suite passes (`pytest -k 'retrieval or multi_path or chunk'` — 161/161 + 1 skip)
- [x] Live end-to-end repro on FalkorDB docs widget: failing query now answers correctly with cited install commands
- [ ] Reviewer to sanity-check perf on graphs with very large MENTIONED_IN fan-out (per-entity ordering is O(N log N) per entity, but N is bounded per entity by ingestion characteristics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chunk retrieval now intelligently ranks results by relevance instead of arbitrary selection, ensuring more pertinent results are prioritized.

* **Tests**
  * Added regression test to verify chunk ranking behavior functions correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/GraphRAG-SDK/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->