### PR TITLE
feat(ontology): mutating evolution API — add/drop/rename + atomic attribute backfill

### DIFF
--- a/docs/graph-schema.md
+++ b/docs/graph-schema.md
@@ -4,6 +4,8 @@ When you ingest documents into GraphRAG SDK, the system builds a property graph 
 
 Understanding the graph structure helps you write custom Cypher queries, debug ingestion quality, and tune retrieval.
 
+Looking to *change* an existing ontology — add/drop attributes, rename labels, retype fields? See [Ontology Evolution](ontology-evolution.md) for the atomic-evolve API and the alignment invariant it enforces.
+
 ---
 
 ## The Big Picture

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,5 +43,6 @@ asyncio.run(main())
 - [Getting Started](getting-started.md) -- Full tutorial from install to first query
 - [Architecture](architecture.md) -- How the 9-step pipeline works
 - [Strategies](strategies.md) -- All swappable strategy ABCs and built-in options
+- [Ontology Evolution](ontology-evolution.md) -- Safely change schema on a populated graph
 - [Benchmark](benchmark.md) -- Methodology and reproduction instructions
 - [API Reference](api-reference.md) -- Full API documentation

--- a/docs/ontology-evolution.md
+++ b/docs/ontology-evolution.md
@@ -8,9 +8,9 @@ If you're new to the ontology, start with [Graph Schema](graph-schema.md). This 
 
 ## The Invariant
 
-GraphRAG SDK treats the ontology as a **contract**: a declared attribute exists on every instance of its owner entity type. There is no API that can declare schema your data doesn't match.
+GraphRAG SDK treats the ontology as a **contract**: every instance of a declared attribute's owner entity type is queryable for that attribute. Values the LLM didn't determine read as `null` — Cypher treats absent and explicit-null identically under `WHERE n.attr IS NULL`, so callers get a consistent view regardless of which one underlies a given entity. There is no API that can declare schema your data doesn't match.
 
-This means one thing in practice: when you add an attribute, the SDK runs an LLM backfill across your existing chunks **as part of the same call** and only commits the schema change once the data is aligned. Adding an attribute is therefore expensive — pay attention to corpus size.
+This means one thing in practice: when you add an attribute, the SDK runs an LLM backfill across your existing chunks **as part of the same call** and only commits the schema change once the data is aligned. Adding an attribute is therefore expensive — pay attention to corpus size and use `dry_run=True` to preview before running for real.
 
 The invariant covers attributes only. Declaring a new entity type or relation pattern is cheap (no data implication — "this is allowed" is not "this exists"). For those, there are opt-in discovery tools that re-scan the corpus.
 
@@ -50,10 +50,11 @@ rag.drop_relation_pattern(rel_label, source, target)
 Return: `EvolutionResult`. The ontology graph write is the **commit point** — backfill runs first, schema change last.
 
 ```python
-rag.add_attribute(owner_label, attribute, *, concurrency=4)
+rag.add_attribute(owner_label, attribute, *, concurrency=4, dry_run=False)
 # Atomic: LLM extracts values from every chunk mentioning the owner
 # type, sets them on matching entities (null where the LLM doesn't
 # know), then commits the new :Property to the ontology graph.
+# Pass dry_run=True to preview cost without invoking the LLM.
 
 rag.drop_attribute(owner_label, name)
 # Atomic: REMOVE n.<name> on every instance, then delete the :Property
@@ -67,14 +68,16 @@ Entity owners only in v1. Relation-attribute mutation raises `NotImplementedErro
 Return: `BackfillResult`. Use after `add_entity` / `add_relation_pattern` if you want to populate instances from the existing corpus.
 
 ```python
-rag.backfill_entity(label, *, scope="all" | list[chunk_id])
+rag.backfill_entity(label, *, scope="all" | list[chunk_id], dry_run=False)
 # "Re-scan chunks for any entities of this type I might have missed."
 
-rag.backfill_relation_pattern(rel_label, source, target)
+rag.backfill_relation_pattern(rel_label, source, target, *, dry_run=False)
 # "Re-scan candidate co-mention chunks for any edges of this pattern."
 ```
 
 These don't enforce anything. Declaring an entity type or relation pattern just says *the schema allows this* — zero instances is a valid state.
+
+> **Provenance:** `backfill_relation_pattern` does NOT write `source_chunk_ids` on the new edges. `GraphStore.upsert_relationships` only unions provenance for `:RELATES` edges; writing it on arbitrary-typed edges would be silently overwritten by future MERGE writes. If you need chunk-level traceability on these backfilled edges, query the underlying co-mentioned chunks via the source/target entities' `MENTIONED_IN` edges instead.
 
 ---
 
@@ -145,15 +148,36 @@ This is the only honest move when the source of truth is the corpus. A mechanica
 
 ---
 
-## Concurrency Rule
+## Concurrency
 
-**Do not run `ingest()` concurrently with `add_attribute()` or `drop_attribute()`.**
+**Evolution calls are not safe to run concurrently with `ingest()` or with each other on the same graph.** Coordinate at the application level — treat evolution as a maintenance operation: pause new ingestion, run the evolution, resume.
 
-The extractor reads the persisted ontology to decide what to extract from new chunks. While `add_attribute` is mid-flight, the ontology hasn't been committed yet — the extractor doesn't know about the new attribute — and any concurrent `ingest()` would produce entities without it. The invariant would silently break the moment the schema commits.
+The constraint has two sources:
 
-Coordinate at the application level. Treat attribute evolution as a maintenance operation: pause new ingestion, run the evolution, resume.
+- **`add_attribute` / `drop_attribute`** — the extractor reads the persisted ontology to decide what to extract from new chunks. While `add_attribute` is mid-flight, the ontology hasn't been committed yet, and any concurrent `ingest()` would produce entities without the new attribute. The invariant would silently break the moment the schema commits.
+- **Mechanical Group 2 calls and `backfill_*`** — internally use a count-then-mutate pattern across two Cypher statements. Concurrent writes can change the count between the two queries.
 
-The other Group 1 / Group 2 / Group 4 calls don't have this constraint.
+For multi-process deployments where this matters, gate evolution behind an application-level lock (Redis, etc.) that also blocks `ingest()`.
+
+---
+
+## Cost Preview (`dry_run=True`)
+
+`add_attribute`, `backfill_entity`, and `backfill_relation_pattern` accept a `dry_run` keyword. When `True`, the scope query runs but the LLM is not invoked and no writes happen. The returned result carries `chunks_in_scope` — the number of chunks this run *would* scan.
+
+```python
+preview = await rag.add_attribute(
+    "Person", Attribute(name="role", type="STRING"),
+    dry_run=True,
+)
+print(f"Would scan {preview.chunks_in_scope} chunks "
+      f"(~{preview.chunks_in_scope} LLM calls)")
+# Decide whether to proceed.
+if preview.chunks_in_scope < 1000:
+    result = await rag.add_attribute("Person", Attribute(name="role", type="STRING"))
+```
+
+The count reflects what *this run* would scan: chunks already marked from a prior partial run are already filtered out, so the preview is accurate for the work that remains, not a hypothetical clean slate.
 
 ---
 
@@ -231,11 +255,12 @@ A more comprehensive walkthrough lives in `examples/09_ontology_evolution.py`.
 
 ## EvolutionResult Reference
 
-Returned by `add_attribute`. All counters are populated; `failed_chunks` is empty on a successful return because hard failures raise instead.
+Returned by `add_attribute`. On a successful (non-dry-run) return, all counters are populated; hard failures raise `OntologyEvolutionError` instead of returning.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `ontology` | `Ontology` | Refreshed ontology after the schema commit |
+| `chunks_in_scope` | `int` | Total chunks matching the scope query — equal to `chunks_scanned + chunks_skipped` on success; the only meaningful field under `dry_run=True` |
 | `chunks_scanned` | `int` | Chunks processed by the LLM this run |
 | `chunks_skipped` | `int` | Chunks already marked from a prior run (idempotent re-runs) |
 | `llm_calls` | `int` | Total LLM invocations |

--- a/docs/ontology-evolution.md
+++ b/docs/ontology-evolution.md
@@ -1,0 +1,267 @@
+# Ontology Evolution
+
+How to safely evolve the ontology (schema) of an already-populated knowledge graph — adding attributes, renaming labels, dropping types — without drifting away from the data graph.
+
+If you're new to the ontology, start with [Graph Schema](graph-schema.md). This page is about *changing* an existing ontology.
+
+---
+
+## The Invariant
+
+GraphRAG SDK treats the ontology as a **contract**: a declared attribute exists on every instance of its owner entity type. There is no API that can declare schema your data doesn't match.
+
+This means one thing in practice: when you add an attribute, the SDK runs an LLM backfill across your existing chunks **as part of the same call** and only commits the schema change once the data is aligned. Adding an attribute is therefore expensive — pay attention to corpus size.
+
+The invariant covers attributes only. Declaring a new entity type or relation pattern is cheap (no data implication — "this is allowed" is not "this exists"). For those, there are opt-in discovery tools that re-scan the corpus.
+
+---
+
+## The API at a Glance
+
+15 methods on `GraphRAG`, grouped by what they touch.
+
+### Group 1 — Pure declarations (cheap, no LLM)
+
+Return: `Ontology`.
+
+```python
+rag.set_entity_description(label, description)
+rag.set_relation_description(label, description)
+rag.set_attribute_description(owner_label, attribute_name, description)
+rag.add_entity(entity: Entity)                    # declaration only
+rag.add_relation_pattern(rel_label, source, target)  # declaration only
+```
+
+### Group 2 — Mechanical data migration (Cypher, no LLM)
+
+Return: `Ontology`. Data migration runs first; the ontology graph is updated second. A crash between the two leaves the data graph ahead, and re-running the same call is idempotent.
+
+```python
+rag.rename_entity(old, new)
+rag.rename_attribute(owner_label, old_name, new_name)
+rag.rename_relation(old, new)
+rag.drop_entity(label)                            # cascades to relation patterns
+rag.drop_relation(label)
+rag.drop_relation_pattern(rel_label, source, target)
+```
+
+### Group 3 — Atomic attribute evolution (LLM, invariant-enforcing)
+
+Return: `EvolutionResult`. The ontology graph write is the **commit point** — backfill runs first, schema change last.
+
+```python
+rag.add_attribute(owner_label, attribute, *, concurrency=4)
+# Atomic: LLM extracts values from every chunk mentioning the owner
+# type, sets them on matching entities (null where the LLM doesn't
+# know), then commits the new :Property to the ontology graph.
+
+rag.drop_attribute(owner_label, name)
+# Atomic: REMOVE n.<name> on every instance, then delete the :Property
+# declaration. Cheap, no LLM.
+```
+
+Entity owners only in v1. Relation-attribute mutation raises `NotImplementedError`.
+
+### Group 4 — Opportunistic discovery (opt-in, not invariant-enforcing)
+
+Return: `BackfillResult`. Use after `add_entity` / `add_relation_pattern` if you want to populate instances from the existing corpus.
+
+```python
+rag.backfill_entity(label, *, scope="all" | list[chunk_id])
+# "Re-scan chunks for any entities of this type I might have missed."
+
+rag.backfill_relation_pattern(rel_label, source, target)
+# "Re-scan candidate co-mention chunks for any edges of this pattern."
+```
+
+These don't enforce anything. Declaring an entity type or relation pattern just says *the schema allows this* — zero instances is a valid state.
+
+---
+
+## Why `add_attribute` is Atomic
+
+Two reasons.
+
+**The invariant.** If `add_attribute` were "declare cheap, fill later," the schema would say "Person has `role`" while many Person nodes lacked the property. Querying `MATCH (p:Person) WHERE p.role = "engineer"` would silently miss data. The atomic shape guarantees consistency.
+
+**Honest commit ordering.** The data graph is mutated first. The ontology graph is updated **last**, as the commit point. If anything fails during backfill, the schema stays at its pre-call state — readers see a consistent (old) view of the world. There is no window in which the schema promises an attribute that isn't there.
+
+```
+add_attribute("Person", Attribute(name="role", type="STRING"))
+        │
+        ▼
+  ┌─────────────────────────────┐
+  │ 1. LLM-extract role from    │
+  │    every chunk mentioning   │
+  │    a Person.                │
+  │                             │
+  │ 2. SET p.role on matching   │
+  │    entities (null where     │
+  │    the LLM doesn't know).   │
+  │                             │
+  │ 3. Commit :Property node    │
+  │    to ontology graph.       │   ← commit point
+  └─────────────────────────────┘
+        │
+        ▼
+   EvolutionResult
+```
+
+---
+
+## Failure & Retry
+
+If a chunk hard-fails (LLM error / parse error beyond retries), the call raises `OntologyEvolutionError` and the ontology graph is **not** updated. The data graph may be partially mutated — some entities have the new property, some don't. That's safe because the schema doesn't yet promise the property exists.
+
+To recover: fix the underlying cause (rate limits, malformed chunks, etc.), then **call `add_attribute` again with the same arguments**. The call is idempotent:
+
+- Already-processed chunks carry an `extracted_ops` marker; the LLM is not re-invoked for them.
+- Already-set entity values are not overwritten.
+
+```python
+from graphrag_sdk import OntologyEvolutionError
+
+try:
+    result = await rag.add_attribute("Person", Attribute(name="role"))
+except OntologyEvolutionError as e:
+    print(f"Failed on {len(e.failed_chunks)} chunks: {e.failed_chunks[:5]}")
+    # ...investigate and fix...
+    result = await rag.add_attribute("Person", Attribute(name="role"))  # idempotent retry
+```
+
+---
+
+## Type Changes
+
+There is no `retype_attribute`. To change a type, drop the attribute and add it with the new type — the LLM re-derives values from the chunks.
+
+```python
+# Person.age is STRING. We want INTEGER.
+await rag.drop_attribute("Person", "age")
+result = await rag.add_attribute("Person", Attribute(name="age", type="INTEGER"))
+```
+
+This is the only honest move when the source of truth is the corpus. A mechanical `toInteger` coercion of `"around thirty"` would either drop the value or fabricate one; the LLM can re-extract `30` from the surrounding text.
+
+---
+
+## Concurrency Rule
+
+**Do not run `ingest()` concurrently with `add_attribute()` or `drop_attribute()`.**
+
+The extractor reads the persisted ontology to decide what to extract from new chunks. While `add_attribute` is mid-flight, the ontology hasn't been committed yet — the extractor doesn't know about the new attribute — and any concurrent `ingest()` would produce entities without it. The invariant would silently break the moment the schema commits.
+
+Coordinate at the application level. Treat attribute evolution as a maintenance operation: pause new ingestion, run the evolution, resume.
+
+The other Group 1 / Group 2 / Group 4 calls don't have this constraint.
+
+---
+
+## End-to-End Example
+
+```python
+import asyncio
+from graphrag_sdk import (
+    Attribute, ConnectionConfig, Entity, EvolutionResult, GraphRAG,
+    LiteLLM, LiteLLMEmbedder, Ontology, Relation,
+)
+
+
+async def main():
+    starter = Ontology(
+        entities=[
+            Entity(label="Person", description="A human"),
+            Entity(label="Company", description="A business"),
+        ],
+        relations=[
+            Relation(
+                label="WORKS_AT",
+                patterns=[("Person", "Company")],
+            ),
+        ],
+    )
+
+    async with GraphRAG(
+        connection=ConnectionConfig(host="localhost", graph_name="evolve_demo"),
+        llm=LiteLLM(model="openai/gpt-4o-mini"),
+        embedder=LiteLLMEmbedder(model="openai/text-embedding-3-small"),
+        ontology=starter,
+    ) as rag:
+        # 1. Ingest with the starter ontology.
+        await rag.ingest(
+            text="Alice Liddell is a software engineer at Acme Corp.",
+            document_id="doc1",
+        )
+
+        # 2. Atomic attribute add: declare + LLM backfill + commit.
+        result: EvolutionResult = await rag.add_attribute(
+            "Person", Attribute(name="role", type="STRING"),
+        )
+        print(f"role filled on {result.values_filled} entities, "
+              f"{result.chunks_scanned} chunks scanned, "
+              f"{result.llm_calls} LLM calls")
+
+        # 3. Type change via drop + add.
+        await rag.drop_attribute("Person", "role")
+        result = await rag.add_attribute(
+            "Person", Attribute(name="role", type="STRING",
+                                description="Their job title"),
+        )
+
+        # 4. Declare a new entity type — cheap, no LLM.
+        await rag.add_entity(Entity(label="City"))
+
+        # 5. Opportunistic: scan corpus for any Cities we missed.
+        discovery = await rag.backfill_entity("City", scope="all")
+        print(f"discovered {discovery.values_filled} City instances")
+
+        # 6. Inspect the final ontology.
+        ontology = await rag.get_ontology()
+        for e in ontology.entities:
+            attrs = ", ".join(f"{p.name}:{p.type}" for p in e.properties) or "—"
+            print(f"  {e.label:<10} {attrs}")
+
+
+asyncio.run(main())
+```
+
+A more comprehensive walkthrough lives in `examples/09_ontology_evolution.py`.
+
+---
+
+## EvolutionResult Reference
+
+Returned by `add_attribute`. All counters are populated; `failed_chunks` is empty on a successful return because hard failures raise instead.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ontology` | `Ontology` | Refreshed ontology after the schema commit |
+| `chunks_scanned` | `int` | Chunks processed by the LLM this run |
+| `chunks_skipped` | `int` | Chunks already marked from a prior run (idempotent re-runs) |
+| `llm_calls` | `int` | Total LLM invocations |
+| `values_filled` | `int` | Entities for which the LLM returned a value |
+| `values_skipped` | `int` | Entities for which the LLM returned `null` |
+| `elapsed_s` | `float` | Wall-clock time |
+
+## OntologyEvolutionError Reference
+
+Raised by `add_attribute` when one or more chunks hard-fail. The ontology graph is **not** updated.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `failed_chunks` | `list[str]` | Chunk ids that raised after retries — investigate and retry |
+| `chunks_scanned` | `int` | Chunks that did succeed before the failure |
+
+The exception subclasses `RuntimeError` so it propagates through `await` paths cleanly.
+
+---
+
+## What's Not in the API (and Why)
+
+| Removed | Why |
+|---------|-----|
+| `retype_attribute` | Type changes go through `drop_attribute` + `add_attribute`. The LLM re-derives values from chunks — the only honest move when text is the source of truth. |
+| `backfill_attribute` (public) | Folded into `add_attribute`. Exposing it as a separate call would re-introduce the drift it's designed to prevent. |
+| `backfill_attribute_semantic` | Supported `retype_attribute`. Gone with it. |
+
+Relation-attribute mutation (`add_attribute("WORKS_AT", ...)` etc.) raises `NotImplementedError` in v1. The workaround is `delete_all()` followed by a fresh `ingest()` with the updated ontology — that's a heavy hammer, but it's the only way to keep edge properties aligned without an edge-property migration primitive. A follow-up PR can lift this.

--- a/graphrag_sdk/examples/09_ontology_evolution.py
+++ b/graphrag_sdk/examples/09_ontology_evolution.py
@@ -125,11 +125,12 @@ async def main() -> None:
         # mentioned Person has been LLM-asked for their role (null where
         # the LLM honestly doesn't know).
 
-        # ── 3. Re-running is idempotent ────────────────────────────
+        # ── 3. Add another attribute (independent atomic backfill) ─
         # Re-issuing the same add_attribute would raise ValueError now
-        # because role is declared. Instead, observe idempotency by
-        # adding a DIFFERENT attribute that hits the same chunks.
-        banner("3. Add another attribute — re-uses chunk markers if applicable")
+        # because `role` is already declared. This is a fresh, independent
+        # backfill operation — different op_id (Person.join_year), so it
+        # gets its own chunk markers and runs its own LLM scan.
+        banner("3. Add another attribute — independent atomic backfill")
         result = await rag.add_attribute("Person", Attribute(name="join_year", type="INTEGER"))
         print_evolution("Person.join_year", result)
 

--- a/graphrag_sdk/examples/09_ontology_evolution.py
+++ b/graphrag_sdk/examples/09_ontology_evolution.py
@@ -1,0 +1,171 @@
+"""
+GraphRAG SDK — Ontology evolution walkthrough
+==============================================
+Companion to ``08_ontology_lifecycle.py`` (which demonstrates strict
+additive evolution). This script shows the *mutating* evolution API:
+
+1. Ingest a small corpus with a starter ontology.
+2. **Group 1** — pure ontology changes: ``add_attribute``, ``add_relation_pattern``.
+3. **Group 2** — mechanical data migration: ``rename_entity``,
+   ``drop_attribute``, ``retype_attribute``.
+4. **Group 3** — LLM-driven backfill: ``backfill_attribute``,
+   ``backfill_entity``, ``backfill_relation_pattern``.
+5. Idempotency demo — re-run a backfill and observe ``llm_calls == 0``.
+
+Prereqs::
+
+    pip install graphrag-sdk[litellm]
+    docker run -p 6379:6379 falkordb/falkordb
+    export OPENAI_API_KEY=...
+
+Run::
+
+    python 09_ontology_evolution.py
+
+The focused backfill prompts are intentionally narrower than the
+production ``VERIFY_EXTRACT_RELS_PROMPT``. They have not been A/B-tested
+on a representative corpus yet — expect to refine wording per your
+domain.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from uuid import uuid4
+
+from graphrag_sdk import (
+    Attribute,
+    ConnectionConfig,
+    Entity,
+    GraphRAG,
+    LiteLLM,
+    LiteLLMEmbedder,
+    Ontology,
+    Relation,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)-8s %(name)s | %(message)s")
+
+
+SAMPLE_TEXT = """\
+Alice Liddell is a software engineer at Acme Corporation. She joined in 2020.
+Bob Carroll works at Acme Corporation as a product manager.
+Acme Corporation is based in Boston.
+"""
+
+
+def starter_ontology() -> Ontology:
+    return Ontology(
+        entities=[
+            Entity(label="Person", description="A human"),
+            Entity(label="Company", description="A business"),
+        ],
+        relations=[
+            Relation(
+                label="WORKS_AT",
+                description="Employment",
+                patterns=[("Person", "Company")],
+            ),
+        ],
+    )
+
+
+def banner(title: str) -> None:
+    print()
+    print("=" * 70)
+    print(f" {title}")
+    print("=" * 70)
+
+
+async def main() -> None:
+    if not os.getenv("OPENAI_API_KEY"):
+        raise SystemExit("Set OPENAI_API_KEY before running this example.")
+
+    graph_name = f"evolve_{uuid4().hex[:8]}"
+    print(f"Using ephemeral graph: {graph_name}")
+
+    rag = GraphRAG(
+        connection=ConnectionConfig(host="localhost", port=6379, graph_name=graph_name),
+        llm=LiteLLM(model="gpt-4o-mini"),
+        embedder=LiteLLMEmbedder(model="text-embedding-3-large"),
+        embedding_dimension=256,
+        ontology=starter_ontology(),
+    )
+
+    try:
+        # ── 1. Ingest the corpus with the starter ontology ─────────
+        banner("1. Ingest")
+        await rag.ingest(text=SAMPLE_TEXT, document_id="evolution-demo")
+
+        # ── 2. Group 1: declare new structure (no data change) ─────
+        banner("2. Declare a new attribute on Person (no values yet)")
+        await rag.add_attribute("Person", Attribute(name="role", type="STRING"))
+        await rag.add_attribute("Person", Attribute(name="join_year", type="INTEGER"))
+        ontology = await rag.get_ontology()
+        person = next(e for e in ontology.entities if e.label == "Person")
+        print("  Person attrs:", [(a.name, a.type) for a in person.properties])
+
+        # ── 3. Group 2: mechanical data migration ─────────────────
+        banner("3. Mechanical migration: rename Person → Employee, drop join_year")
+        await rag.rename_entity("Person", "Employee")
+        await rag.drop_attribute("Employee", "join_year")
+        ontology = await rag.get_ontology()
+        labels = [e.label for e in ontology.entities]
+        print(f"  Entity labels after rename: {labels}")
+
+        # ── 4. Group 3: LLM-driven backfill ───────────────────────
+        banner("4. Backfill Employee.role from the existing chunks")
+        result = await rag.backfill_attribute("Employee", "role")
+        print(f"  op_id={result.operation_id}")
+        print(f"  chunks_scanned={result.chunks_scanned} values_filled={result.values_filled}")
+        print(f"  llm_calls={result.llm_calls} elapsed={result.elapsed_s:.2f}s")
+
+        # ── 5. Idempotency ────────────────────────────────────────
+        banner("5. Re-run the same backfill — should be a no-op (markers hit)")
+        result2 = await rag.backfill_attribute("Employee", "role")
+        print(f"  llm_calls={result2.llm_calls} (expected 0)")
+        print(f"  chunks_skipped={result2.chunks_skipped}")
+
+        # ── 6. Add a new entity type and backfill its instances ───
+        banner("6. Declare a new entity type (City) and backfill instances")
+        await rag.add_entity(Entity(label="City", description="A geographic place"))
+        entity_result = await rag.backfill_entity("City", scope="all")
+        print(
+            f"  City entities found: {entity_result.values_filled} "
+            f"across {entity_result.chunks_scanned} chunks"
+        )
+
+        # ── 7. Add a new relation pattern and backfill edges ──────
+        banner("7. Declare a new relation pattern (BASED_IN) and backfill edges")
+        await rag.add_relation_pattern("BASED_IN", "Company", "City")
+        pattern_result = await rag.backfill_relation_pattern(
+            "BASED_IN", "Company", "City"
+        )
+        print(
+            f"  BASED_IN edges added: {pattern_result.values_filled} "
+            f"across {pattern_result.chunks_scanned} chunks"
+        )
+
+        # ── 8. Inspect final ontology ─────────────────────────────
+        banner("8. Final ontology")
+        ontology = await rag.get_ontology()
+        for e in ontology.entities:
+            props = ", ".join(f"{p.name}:{p.type}" for p in e.properties) or "—"
+            print(f"  Entity   {e.label:<14} props: {props}")
+        for r in ontology.relations:
+            pats = ", ".join(f"{s}->{t}" for s, t in r.patterns) or "(open)"
+            print(f"  Relation {r.label:<18} patterns: {pats}")
+
+        print()
+        print("All scenarios passed.")
+    finally:
+        try:
+            await rag.delete_all()
+        finally:
+            await rag.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/graphrag_sdk/examples/09_ontology_evolution.py
+++ b/graphrag_sdk/examples/09_ontology_evolution.py
@@ -4,13 +4,19 @@ GraphRAG SDK — Ontology evolution walkthrough
 Companion to ``08_ontology_lifecycle.py`` (which demonstrates strict
 additive evolution). This script shows the *mutating* evolution API:
 
+The design enforces a strict alignment invariant: **a declared attribute
+exists on every instance of its owner entity type**. To honor this,
+``add_attribute`` is atomic — it LLM-extracts values from existing
+chunks before committing the schema change.
+
 1. Ingest a small corpus with a starter ontology.
-2. **Group 1** — pure ontology changes: ``add_attribute``, ``add_relation_pattern``.
-3. **Group 2** — mechanical data migration: ``rename_entity``,
-   ``drop_attribute``, ``retype_attribute``.
-4. **Group 3** — LLM-driven backfill: ``backfill_attribute``,
-   ``backfill_entity``, ``backfill_relation_pattern``.
-5. Idempotency demo — re-run a backfill and observe ``llm_calls == 0``.
+2. Group 1 — pure declarations: ``add_entity``, ``add_relation_pattern``.
+3. Group 2 — mechanical migration: ``rename_entity``, ``rename_attribute``.
+4. Atomic attribute evolution: ``add_attribute`` (LLM backfill + commit
+   in one call), ``drop_attribute`` (cheap data + ontology removal).
+5. Type changes: ``drop_attribute`` + ``add_attribute`` with the new
+   type — the LLM re-derives values from the chunks.
+6. Opportunistic discovery: ``backfill_entity``, ``backfill_relation_pattern``.
 
 Prereqs::
 
@@ -22,10 +28,11 @@ Run::
 
     python 09_ontology_evolution.py
 
-The focused backfill prompts are intentionally narrower than the
-production ``VERIFY_EXTRACT_RELS_PROMPT``. They have not been A/B-tested
-on a representative corpus yet — expect to refine wording per your
-domain.
+Important: do NOT run ``ingest()`` concurrently with ``add_attribute()``
+or ``drop_attribute()``. The extractor reads the persisted ontology to
+decide what to extract; concurrent ingest during attribute evolution
+would create entities without the new attribute. Coordinate at the
+application level.
 """
 
 from __future__ import annotations
@@ -39,6 +46,7 @@ from graphrag_sdk import (
     Attribute,
     ConnectionConfig,
     Entity,
+    EvolutionResult,
     GraphRAG,
     LiteLLM,
     LiteLLMEmbedder,
@@ -79,6 +87,16 @@ def banner(title: str) -> None:
     print("=" * 70)
 
 
+def print_evolution(label: str, result: EvolutionResult) -> None:
+    print(
+        f"  {label}: filled={result.values_filled} "
+        f"chunks_scanned={result.chunks_scanned} "
+        f"chunks_skipped={result.chunks_skipped} "
+        f"llm_calls={result.llm_calls} "
+        f"elapsed={result.elapsed_s:.2f}s"
+    )
+
+
 async def main() -> None:
     if not os.getenv("OPENAI_API_KEY"):
         raise SystemExit("Set OPENAI_API_KEY before running this example.")
@@ -95,58 +113,52 @@ async def main() -> None:
     )
 
     try:
-        # ── 1. Ingest the corpus with the starter ontology ─────────
+        # ── 1. Ingest with the starter ontology ────────────────────
         banner("1. Ingest")
         await rag.ingest(text=SAMPLE_TEXT, document_id="evolution-demo")
 
-        # ── 2. Group 1: declare new structure (no data change) ─────
-        banner("2. Declare a new attribute on Person (no values yet)")
-        await rag.add_attribute("Person", Attribute(name="role", type="STRING"))
-        await rag.add_attribute("Person", Attribute(name="join_year", type="INTEGER"))
-        ontology = await rag.get_ontology()
-        person = next(e for e in ontology.entities if e.label == "Person")
-        print("  Person attrs:", [(a.name, a.type) for a in person.properties])
+        # ── 2. Atomic add_attribute (declare + LLM backfill + commit) ─
+        banner("2. add_attribute('Person', 'role') — atomic evolve+backfill")
+        result = await rag.add_attribute("Person", Attribute(name="role", type="STRING"))
+        print_evolution("Person.role", result)
+        # On return, the ontology graph has the new property AND every
+        # mentioned Person has been LLM-asked for their role (null where
+        # the LLM honestly doesn't know).
 
-        # ── 3. Group 2: mechanical data migration ─────────────────
-        banner("3. Mechanical migration: rename Person → Employee, drop join_year")
+        # ── 3. Re-running is idempotent ────────────────────────────
+        # Re-issuing the same add_attribute would raise ValueError now
+        # because role is declared. Instead, observe idempotency by
+        # adding a DIFFERENT attribute that hits the same chunks.
+        banner("3. Add another attribute — re-uses chunk markers if applicable")
+        result = await rag.add_attribute("Person", Attribute(name="join_year", type="INTEGER"))
+        print_evolution("Person.join_year", result)
+
+        # ── 4. Type change: drop + add (LLM re-derives) ────────────
+        banner("4. Change Person.join_year STRING via drop + add")
+        await rag.drop_attribute("Person", "join_year")
+        result = await rag.add_attribute("Person", Attribute(name="join_year", type="STRING"))
+        print_evolution("Person.join_year retyped", result)
+
+        # ── 5. Group 1 / 2 operations (cheap, no LLM) ──────────────
+        banner("5. Cheap structural changes")
         await rag.rename_entity("Person", "Employee")
-        await rag.drop_attribute("Employee", "join_year")
+        await rag.rename_attribute("Employee", "role", "title")
         ontology = await rag.get_ontology()
         labels = [e.label for e in ontology.entities]
-        print(f"  Entity labels after rename: {labels}")
+        print(f"  Entity labels: {labels}")
+        emp = next(e for e in ontology.entities if e.label == "Employee")
+        print(f"  Employee attrs: {[(a.name, a.type) for a in emp.properties]}")
 
-        # ── 4. Group 3: LLM-driven backfill ───────────────────────
-        banner("4. Backfill Employee.role from the existing chunks")
-        result = await rag.backfill_attribute("Employee", "role")
-        print(f"  op_id={result.operation_id}")
-        print(f"  chunks_scanned={result.chunks_scanned} values_filled={result.values_filled}")
-        print(f"  llm_calls={result.llm_calls} elapsed={result.elapsed_s:.2f}s")
-
-        # ── 5. Idempotency ────────────────────────────────────────
-        banner("5. Re-run the same backfill — should be a no-op (markers hit)")
-        result2 = await rag.backfill_attribute("Employee", "role")
-        print(f"  llm_calls={result2.llm_calls} (expected 0)")
-        print(f"  chunks_skipped={result2.chunks_skipped}")
-
-        # ── 6. Add a new entity type and backfill its instances ───
-        banner("6. Declare a new entity type (City) and backfill instances")
+        # ── 6. Opportunistic discovery (opt-in, not invariant-enforcing) ─
+        banner("6. backfill_entity — opportunistic: scan corpus for missed Cities")
         await rag.add_entity(Entity(label="City", description="A geographic place"))
-        entity_result = await rag.backfill_entity("City", scope="all")
-        print(
-            f"  City entities found: {entity_result.values_filled} "
-            f"across {entity_result.chunks_scanned} chunks"
-        )
+        bf = await rag.backfill_entity("City", scope="all")
+        print(f"  City entities found via opportunistic scan: {bf.values_filled}")
 
-        # ── 7. Add a new relation pattern and backfill edges ──────
-        banner("7. Declare a new relation pattern (BASED_IN) and backfill edges")
+        banner("7. backfill_relation_pattern — opportunistic edge discovery")
         await rag.add_relation_pattern("BASED_IN", "Company", "City")
-        pattern_result = await rag.backfill_relation_pattern(
-            "BASED_IN", "Company", "City"
-        )
-        print(
-            f"  BASED_IN edges added: {pattern_result.values_filled} "
-            f"across {pattern_result.chunks_scanned} chunks"
-        )
+        bf = await rag.backfill_relation_pattern("BASED_IN", "Company", "City")
+        print(f"  BASED_IN edges added: {bf.values_filled}")
 
         # ── 8. Inspect final ontology ─────────────────────────────
         banner("8. Final ontology")

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -67,6 +67,8 @@ from graphrag_sdk.ingestion.backfill import (
     BackfillMergeStats,
     BackfillResult,
     ChunkContext,
+    EvolutionResult,
+    OntologyEvolutionError,
 )
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
 from graphrag_sdk.ingestion.chunking_strategies.callable_chunking import (
@@ -173,6 +175,8 @@ __all__ = [
     "BackfillResult",
     "ChunkContext",
     "ChunkingStrategy",
+    "EvolutionResult",
+    "OntologyEvolutionError",
     "CallableChunking",
     "ContextualChunking",
     "FixedSizeChunking",

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -62,6 +62,12 @@ from graphrag_sdk.core.providers import (
 )
 
 # ── Ingestion Strategies ────────────────────────────────────────
+from graphrag_sdk.ingestion.backfill import (
+    BackfillExecutor,
+    BackfillMergeStats,
+    BackfillResult,
+    ChunkContext,
+)
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
 from graphrag_sdk.ingestion.chunking_strategies.callable_chunking import (
     CallableChunking,
@@ -162,6 +168,10 @@ __all__ = [
     "TextChunks",
     "UpdateResult",
     # Ingestion
+    "BackfillExecutor",
+    "BackfillMergeStats",
+    "BackfillResult",
+    "ChunkContext",
     "ChunkingStrategy",
     "CallableChunking",
     "ContextualChunking",

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -145,14 +145,12 @@ def _neutralize_context_close_tag(text: str) -> str:
 def _strip_and_load_json(text: str) -> Any:
     """Parse LLM-emitted JSON, tolerating optional markdown fences.
 
-    Used by the ontology-evolution backfill methods to consume their
-    focused-prompt responses. Returns ``{}`` on malformed JSON so a single
-    bad response degrades to a no-op merge rather than poisoning the run.
+    Raises ``ValueError`` on malformed JSON so the calling
+    :py:class:`BackfillExecutor` lands the chunk in
+    ``BackfillResult.failed_chunks`` instead of marking it done — otherwise
+    a parser-corrupted chunk would be permanently skipped on every rerun.
     """
-    try:
-        return json.loads(_strip_markdown_fences(text))
-    except (ValueError, TypeError):
-        return {}
+    return json.loads(_strip_markdown_fences(text))
 
 
 _QUESTION_REWRITE_PROMPT = (
@@ -461,9 +459,12 @@ class GraphRAG:
         """Reload the persisted ontology and re-propagate to retrieval.
 
         Internal helper shared by every evolution method so the refresh
-        path lives in one place.
+        path lives in one place. Updates ``self.ontology`` in lockstep so
+        a follow-up ``ingest()`` (which reads ``self.ontology.entities``
+        in ``_default_extractor``) sees the post-mutation label set.
         """
         self._global_ontology = await self._ontology_store.load()
+        self.ontology = self._global_ontology
         if hasattr(self._retrieval_strategy, "_ontology"):
             self._retrieval_strategy._ontology = self._global_ontology
         return self._global_ontology
@@ -488,6 +489,17 @@ class GraphRAG:
         if is_relation:
             return "relation"
         raise ValueError(f"Unknown ontology label: {owner_label!r}")
+
+    def _owner_for_kind(self, owner_label: str, kind: Literal["entity", "relation"]) -> Any:
+        """Return the :py:class:`Entity` or :py:class:`Relation` for a known label.
+
+        Companion to :py:meth:`_resolve_owner_kind`; only intended to be
+        called after the kind has been resolved. ``KeyError`` here would
+        indicate a programming error (the kind was wrong).
+        """
+        if kind == "entity":
+            return next(e for e in self._global_ontology.entities if e.label == owner_label)
+        return next(r for r in self._global_ontology.relations if r.label == owner_label)
 
     # ── Group 1: pure ontology (no data, no LLM) ─────────────────
 
@@ -532,15 +544,21 @@ class GraphRAG:
         await self._ontology_store.register(Ontology(entities=[entity]))
         return await self._refresh_global_ontology()
 
-    async def add_attribute(self, entity_label: str, attribute: Attribute) -> Ontology:
-        """Declare a new attribute on an existing entity type. Adds no
-        data — call ``backfill_attribute`` afterwards to populate values
-        from already-ingested chunks.
+    async def add_attribute(self, owner_label: str, attribute: Attribute) -> Ontology:
+        """Declare a new attribute on an existing entity OR relation type.
+
+        Adds no data — call ``backfill_attribute`` afterwards to populate
+        values from already-ingested chunks (entities only; relation
+        attributes are ontology-only in v1, see ``rename_attribute``).
+        Resolves entity-vs-relation dynamically, like the other attribute
+        evolution methods.
         """
         await self._ensure_ontology_initialized()
-        if not any(e.label == entity_label for e in self._global_ontology.entities):
-            raise ValueError(f"Unknown entity label: {entity_label!r}")
-        await self._ontology_store.add_entity_property(entity_label, attribute)
+        kind = self._resolve_owner_kind(owner_label)
+        if kind == "entity":
+            await self._ontology_store.add_entity_property(owner_label, attribute)
+        else:
+            await self._ontology_store.add_relation_property(owner_label, attribute)
         return await self._refresh_global_ontology()
 
     async def add_relation_pattern(self, rel_label: str, source: str, target: str) -> Ontology:
@@ -587,11 +605,28 @@ class GraphRAG:
         """Rename an attribute on an entity (data + ontology) or on a
         relation (ontology only — relation-property data migration is
         not implemented in this version; a warning is logged).
+
+        Validates that ``old_name`` exists and ``new_name`` does not before
+        touching either graph — without this guard a typo silently no-ops
+        the rename, and a collision with an existing attribute would
+        overwrite values on the data graph.
         """
         await self._ensure_ontology_initialized()
         kind = self._resolve_owner_kind(owner_label)
         if old_name == new_name:
             return self._global_ontology
+        owner = self._owner_for_kind(owner_label, kind)
+        attr_names = {p.name for p in owner.properties}
+        if old_name not in attr_names:
+            raise ValueError(
+                f"Unknown attribute {owner_label}.{old_name!r}; declared "
+                f"attributes are {sorted(attr_names)}."
+            )
+        if new_name in attr_names:
+            raise ValueError(
+                f"Attribute {owner_label}.{new_name!r} already exists; "
+                f"merging attributes is not supported by rename_attribute."
+            )
         nodes_touched = 0
         if kind == "entity":
             nodes_touched = await self._graph_store.rename_node_property(
@@ -821,9 +856,19 @@ class GraphRAG:
 
         async def _merge(parsed: dict[str, Any], ctx: ChunkContext) -> BackfillMergeStats:
             filled = skipped = dropped = 0
-            by_name = {(ent.get("name") or "").strip(): ent for ent in ctx.payload["entities"]}
+            # Key by BOTH name and id so the merge tolerates LLM responses
+            # that echo either the human name or the entity id (the prompt
+            # falls back to id when name is missing).
+            by_key: dict[str, dict[str, Any]] = {}
+            for ent in ctx.payload["entities"]:
+                name_key = (ent.get("name") or "").strip()
+                id_key = (ent.get("id") or "").strip()
+                if name_key:
+                    by_key[name_key] = ent
+                if id_key:
+                    by_key[id_key] = ent
             for ent_name, raw_value in parsed.items():
-                ent = by_name.get((ent_name or "").strip())
+                ent = by_key.get((ent_name or "").strip())
                 if ent is None:
                     continue
                 if raw_value is None or raw_value == "":
@@ -852,6 +897,10 @@ class GraphRAG:
             merge_fn=_merge,
         )
         result.target_nodes = sum(len(r["entities"]) for r in chunk_rows)
+        result.chunks_skipped = await self._graph_store.count_chunks_marked_with_op(op_id) - (
+            result.chunks_scanned + len(result.failed_chunks)
+        )
+        result.chunks_skipped = max(0, result.chunks_skipped)
         return result
 
     async def backfill_entity(
@@ -970,6 +1019,11 @@ class GraphRAG:
             merge_fn=_merge,
         )
         result.target_nodes = len(chunk_rows)
+        result.chunks_skipped = max(
+            0,
+            await self._graph_store.count_chunks_marked_with_op(op_id)
+            - (result.chunks_scanned + len(result.failed_chunks)),
+        )
         return result
 
     async def backfill_relation_pattern(
@@ -1041,25 +1095,37 @@ class GraphRAG:
 
         async def _merge(parsed: list[dict[str, Any]], ctx: ChunkContext) -> BackfillMergeStats:
             filled = skipped = 0
-            by_src = {(p.get("src_name") or "").strip(): p for p in ctx.payload["pairs"]}
-            by_tgt = {(p.get("tgt_name") or "").strip(): p for p in ctx.payload["pairs"]}
+            # Key by the (src, tgt) tuple so we never combine src_id from
+            # one candidate pair with tgt_id from another when the chunk
+            # has multiple candidates sharing a name.
+            by_pair = {
+                (
+                    (p.get("src_name") or "").strip(),
+                    (p.get("tgt_name") or "").strip(),
+                ): p
+                for p in ctx.payload["pairs"]
+            }
             new_edges: list[GraphRelationship] = []
             for link in parsed:
                 src_name = (link.get("src") or "").strip()
                 tgt_name = (link.get("tgt") or "").strip()
-                src_pair = by_src.get(src_name)
-                tgt_pair = by_tgt.get(tgt_name)
-                if src_pair is None or tgt_pair is None:
+                pair = by_pair.get((src_name, tgt_name))
+                if pair is None:
                     skipped += 1
                     continue
+                # NB: ``source_chunk_ids`` provenance is intentionally NOT
+                # written here. ``GraphStore.upsert_relationships`` only
+                # unions provenance for RELATES edges; arbitrary typed
+                # backfill edges would have their lists overwritten on
+                # subsequent MERGE, so we skip the field rather than
+                # appear to track provenance that we'd silently lose.
                 new_edges.append(
                     GraphRelationship(
-                        start_node_id=src_pair["src_id"],
-                        end_node_id=tgt_pair["tgt_id"],
+                        start_node_id=pair["src_id"],
+                        end_node_id=pair["tgt_id"],
                         type=rel_label,
                         properties={
                             "description": link.get("description", ""),
-                            "source_chunk_ids": [ctx.chunk_id],
                         },
                     )
                 )
@@ -1077,6 +1143,11 @@ class GraphRAG:
             merge_fn=_merge,
         )
         result.target_nodes = sum(len(r["pairs"]) for r in chunk_rows)
+        result.chunks_skipped = max(
+            0,
+            await self._graph_store.count_chunks_marked_with_op(op_id)
+            - (result.chunks_scanned + len(result.failed_chunks)),
+        )
         return result
 
     async def backfill_attribute_semantic(
@@ -1150,7 +1221,7 @@ class GraphRAG:
                         node_id,
                         exc,
                     )
-                    result.failed_chunks.append(node_id)
+                    result.failed_node_ids.append(node_id)
 
         await asyncio.gather(*[_coerce_one(nid, val) for nid, val in rows])
         # After coercion, update the ontology graph's declared type.

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -45,6 +45,8 @@ from graphrag_sdk.ingestion.backfill import (
     BackfillMergeStats,
     BackfillResult,
     ChunkContext,
+    EvolutionResult,
+    OntologyEvolutionError,
 )
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
 from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
@@ -59,7 +61,6 @@ from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
     BACKFILL_ATTRIBUTE_PROMPT,
     BACKFILL_ENTITY_PROMPT,
     BACKFILL_RELATION_PATTERN_PROMPT,
-    BACKFILL_SEMANTIC_COERCION_PROMPT,
     GraphExtraction,
     _coerce_attribute_value,
 )
@@ -544,22 +545,81 @@ class GraphRAG:
         await self._ontology_store.register(Ontology(entities=[entity]))
         return await self._refresh_global_ontology()
 
-    async def add_attribute(self, owner_label: str, attribute: Attribute) -> Ontology:
-        """Declare a new attribute on an existing entity OR relation type.
+    async def add_attribute(
+        self,
+        owner_label: str,
+        attribute: Attribute,
+        *,
+        concurrency: int = 4,
+    ) -> EvolutionResult:
+        """Atomically declare an attribute and populate it from existing chunks.
 
-        Adds no data — call ``backfill_attribute`` afterwards to populate
-        values from already-ingested chunks (entities only; relation
-        attributes are ontology-only in v1, see ``rename_attribute``).
-        Resolves entity-vs-relation dynamically, like the other attribute
-        evolution methods.
+        Workflow:
+          1. Validate (owner is a known entity, attribute not already declared).
+          2. LLM-extract the attribute value from every chunk mentioning an
+             entity of ``owner_label``. Per-chunk idempotency via
+             ``extracted_ops`` markers — re-runs skip completed chunks.
+          3. SET the value on matching entities (null where the LLM doesn't
+             know, which is honest absence; querying with
+             ``WHERE n.<attr> IS NULL`` finds these).
+          4. Commit the ontology graph (write the ``:Property`` node) as the
+             final step.
+
+        Atomicity: the ontology graph write happens LAST. If any chunk
+        hard-fails (LLM error / parse error beyond retries),
+        :py:class:`OntologyEvolutionError` is raised and the ontology stays
+        at its pre-call state. The data graph has been partially mutated
+        but the schema doesn't yet promise the attribute exists, so callers
+        see a consistent (old) view of the world. Retrying is safe and
+        idempotent.
+
+        Cost: ~one LLM call per chunk that mentions an ``owner_label``
+        entity. Use sparingly on large corpora.
+
+        **Concurrency rule:** do NOT run ``ingest()`` concurrently with
+        ``add_attribute()``. The extractor reads the persisted ontology to
+        decide what to extract; while ``add_attribute`` is mid-flight, new
+        ingests would produce entities without the new attribute and leave
+        the data graph misaligned. Coordinate at the application level.
+
+        v1: entity owners only. Relation-attribute evolution raises
+        ``NotImplementedError`` — workaround is ``delete_all()`` followed by
+        a fresh ``ingest()`` against the new ontology.
         """
         await self._ensure_ontology_initialized()
         kind = self._resolve_owner_kind(owner_label)
-        if kind == "entity":
-            await self._ontology_store.add_entity_property(owner_label, attribute)
-        else:
-            await self._ontology_store.add_relation_property(owner_label, attribute)
-        return await self._refresh_global_ontology()
+        if kind != "entity":
+            raise NotImplementedError(
+                f"add_attribute on relation owners is not implemented "
+                f"(label={owner_label!r}). Relation-attribute evolution would "
+                f"require re-scanning edges; for now, delete_all() and re-ingest "
+                f"with the updated ontology."
+            )
+        owner = self._owner_for_kind(owner_label, kind)
+        if any(a.name == attribute.name for a in owner.properties):
+            raise ValueError(
+                f"Attribute {owner_label}.{attribute.name!r} is already declared. "
+                f"To change its type, call drop_attribute() first, then "
+                f"add_attribute() with the new type — the LLM will re-derive "
+                f"values from the chunks."
+            )
+
+        backfill = await self._run_atomic_attribute_backfill(
+            owner_label, attribute, concurrency=concurrency
+        )
+        # Commit the ontology graph as the LAST step. Reaching here means
+        # every chunk in scope was processed or skipped successfully.
+        await self._ontology_store.add_entity_property(owner_label, attribute)
+        refreshed = await self._refresh_global_ontology()
+        return EvolutionResult(
+            ontology=refreshed,
+            chunks_scanned=backfill.chunks_scanned,
+            chunks_skipped=backfill.chunks_skipped,
+            llm_calls=backfill.llm_calls,
+            values_filled=backfill.values_filled,
+            values_skipped=backfill.values_skipped,
+            elapsed_s=backfill.elapsed_s,
+        )
 
     async def add_relation_pattern(self, rel_label: str, source: str, target: str) -> Ontology:
         """Declare a new ``(source, target)`` pattern for a relation. Adds
@@ -674,22 +734,29 @@ class GraphRAG:
         return await self._refresh_global_ontology()
 
     async def drop_attribute(self, owner_label: str, name: str) -> Ontology:
-        """Drop an attribute from data + ontology (for entities) or
-        ontology only (for relations — see ``rename_attribute``'s note).
+        """Atomically remove an attribute from data and ontology.
+
+        For entity owners: ``REMOVE n.<name>`` on every instance of
+        ``owner_label``, then delete the ``:Property`` declaration. Cheap,
+        no LLM, idempotent. Data migration runs first so a crash between
+        the two steps leaves the data graph already cleaned and a retry
+        completes the ontology side.
+
+        v1: entity owners only. Relation-attribute evolution raises
+        ``NotImplementedError`` — workaround is ``delete_all()`` followed by
+        a fresh ``ingest()`` against the updated ontology.
         """
         await self._ensure_ontology_initialized()
         kind = self._resolve_owner_kind(owner_label)
-        nodes_touched = 0
-        if kind == "entity":
-            nodes_touched = await self._graph_store.drop_node_property(owner_label, name)
-            await self._ontology_store.drop_entity_property(owner_label, name)
-        else:
-            logger.warning(
-                "drop_attribute on relation %s: skipping data-graph property "
-                "drop (edge-property drop is out of scope for v1).",
-                owner_label,
+        if kind != "entity":
+            raise NotImplementedError(
+                f"drop_attribute on relation owners is not implemented "
+                f"(label={owner_label!r}). Relation-attribute evolution would "
+                f"require iterating edges; for now, delete_all() and re-ingest "
+                f"with the updated ontology."
             )
-            await self._ontology_store.drop_relation_property(owner_label, name)
+        nodes_touched = await self._graph_store.drop_node_property(owner_label, name)
+        await self._ontology_store.drop_entity_property(owner_label, name)
         logger.info("drop_attribute %s.%s: %d nodes touched", owner_label, name, nodes_touched)
         return await self._refresh_global_ontology()
 
@@ -742,83 +809,32 @@ class GraphRAG:
         )
         return await self._refresh_global_ontology()
 
-    async def retype_attribute(self, owner_label: str, name: str, new_type: str) -> Ontology:
-        """Mechanically coerce an attribute's data-graph values to a new
-        Cypher type and update the ontology graph.
+    # ── Group 3 internals: atomic-backfill engine ───────────────
+    #
+    # The previous PR exposed ``backfill_attribute`` /
+    # ``backfill_attribute_semantic`` / ``retype_attribute`` as public
+    # methods. Under the strict alignment design (atomic add_attribute,
+    # no retype, drop+add for type changes) those are gone — the
+    # backfill engine below is internal to ``add_attribute``.
 
-        Mechanical coercion handles ``INTEGER``, ``FLOAT``, ``STRING``,
-        ``BOOLEAN``. ``DATE`` and ``LIST`` require LLM-assisted
-        coercion — use ``backfill_attribute_semantic`` for those.
-
-        Values that don't convert (e.g. ``"twelve"`` → INTEGER) are
-        DROPPED from the affected nodes; the count is logged. Re-running
-        is idempotent because converted values stay converted.
-        """
-        await self._ensure_ontology_initialized()
-        kind = self._resolve_owner_kind(owner_label)
-        coerced = dropped = 0
-        if kind == "entity":
-            coerced, dropped = await self._graph_store.coerce_node_property(
-                owner_label, name, new_type
-            )
-        else:
-            logger.warning(
-                "retype_attribute on relation %s: skipping data-graph coercion "
-                "(edge-property coercion is out of scope for v1).",
-                owner_label,
-            )
-        await self._ontology_store.retype_property(kind, owner_label, name, new_type)
-        logger.info(
-            "retype_attribute %s.%s → %s: %d coerced, %d dropped",
-            owner_label,
-            name,
-            new_type,
-            coerced,
-            dropped,
-        )
-        return await self._refresh_global_ontology()
-
-    # ── Group 3: LLM-driven backfill ─────────────────────────────
-
-    async def backfill_attribute(
+    async def _run_atomic_attribute_backfill(
         self,
         owner_label: str,
-        name: str,
+        attribute: Attribute,
         *,
-        scope: str = "missing",
-        concurrency: int = 4,
+        concurrency: int,
     ) -> BackfillResult:
-        """Fill a newly-declared attribute on an existing entity type by
-        re-scanning chunks that mention entities of ``owner_label``
-        currently missing this attribute.
+        """LLM-extract ``attribute`` for every entity of ``owner_label``
+        from existing chunks. Internal helper of :py:meth:`add_attribute`.
 
-        ``scope="missing"`` is the only mode in v1 — entities already
-        carrying a value are left alone. Idempotent: chunks already
-        processed are skipped via the ``extracted_ops`` marker.
-
-        Cost: roughly one LLM call per chunk that has at least one
-        missing-attribute entity. Use sparingly on large corpora.
+        Raises :py:class:`OntologyEvolutionError` if any chunk hard-fails
+        after retries — callers must NOT commit the ontology graph in
+        that case. Re-running is safe (chunk markers skip done work).
         """
-        if scope != "missing":
-            raise ValueError(
-                f"backfill_attribute: unsupported scope {scope!r}; only 'missing' is implemented."
-            )
-        await self._ensure_ontology_initialized()
-        entity = next(
-            (e for e in self._global_ontology.entities if e.label == owner_label),
-            None,
-        )
-        if entity is None:
-            raise ValueError(f"Unknown entity label: {owner_label!r}")
-        attribute = next((a for a in entity.properties if a.name == name), None)
-        if attribute is None:
-            raise ValueError(
-                f"Unknown attribute {owner_label}.{name!r} — declare it first via add_attribute()."
-            )
-
-        op_id = f"backfill_attribute:{owner_label}:{name}"
+        op_id = f"add_attribute:{owner_label}:{attribute.name}"
+        attr_name = attribute.name
         chunk_rows = await self._graph_store.list_chunks_for_attribute_backfill(
-            owner_label, name, op_id=op_id
+            owner_label, attr_name, op_id=op_id
         )
 
         async def _iter() -> Any:
@@ -843,7 +859,7 @@ class GraphRAG:
             )
             return BACKFILL_ATTRIBUTE_PROMPT.format(
                 owner_label=owner_label,
-                attr_name=name,
+                attr_name=attr_name,
                 attr_type=attribute.type,
                 attr_description=attr_desc_line,
                 entities_block=entity_lines,
@@ -879,7 +895,7 @@ class GraphRAG:
                     dropped += 1
                     continue
                 await self._graph_store.set_node_property_by_id(
-                    owner_label, ent["id"], name, coerced
+                    owner_label, ent["id"], attr_name, coerced
                 )
                 filled += 1
             return BackfillMergeStats(
@@ -897,10 +913,23 @@ class GraphRAG:
             merge_fn=_merge,
         )
         result.target_nodes = sum(len(r["entities"]) for r in chunk_rows)
-        result.chunks_skipped = await self._graph_store.count_chunks_marked_with_op(op_id) - (
-            result.chunks_scanned + len(result.failed_chunks)
+        result.chunks_skipped = max(
+            0,
+            await self._graph_store.count_chunks_marked_with_op(op_id)
+            - (result.chunks_scanned + len(result.failed_chunks)),
         )
-        result.chunks_skipped = max(0, result.chunks_skipped)
+        # Hard-failure → caller must NOT commit the ontology. The data
+        # graph may be partially mutated, but chunk markers make a retry
+        # of add_attribute idempotent.
+        if result.failed_chunks:
+            raise OntologyEvolutionError(
+                f"add_attribute({owner_label}, {attr_name!r}) hard-failed on "
+                f"{len(result.failed_chunks)} chunk(s); ontology NOT committed. "
+                f"First few: {result.failed_chunks[:5]}. "
+                f"Resolve and retry — the call is idempotent.",
+                failed_chunks=result.failed_chunks,
+                chunks_scanned=result.chunks_scanned,
+            )
         return result
 
     async def backfill_entity(
@@ -1148,102 +1177,6 @@ class GraphRAG:
             await self._graph_store.count_chunks_marked_with_op(op_id)
             - (result.chunks_scanned + len(result.failed_chunks)),
         )
-        return result
-
-    async def backfill_attribute_semantic(
-        self,
-        owner_label: str,
-        name: str,
-        target_type: str,
-        *,
-        concurrency: int = 4,
-    ) -> BackfillResult:
-        """LLM-assisted coercion of an attribute's existing string values
-        to ``target_type``. Use when mechanical Cypher coercion would
-        drop too many values (e.g. ``"twelve"`` → 12, free-form dates
-        → ISO 8601).
-
-        Operates on existing node values directly — no chunk re-scan.
-        Updates the ontology graph's declared type once values land;
-        nodes whose value couldn't be coerced have the property
-        dropped.
-        """
-        await self._ensure_ontology_initialized()
-        kind = self._resolve_owner_kind(owner_label)
-        if kind != "entity":
-            raise ValueError(
-                "backfill_attribute_semantic on relation owners is not "
-                "implemented in v1 (relation-property coercion would require "
-                "iterating edges)."
-            )
-        rows = await self._graph_store.list_node_values_for_semantic_coerce(owner_label, name)
-        op_id = f"backfill_attribute_semantic:{owner_label}:{name}:{target_type}"
-
-        result = BackfillResult(operation_id=op_id, target_nodes=len(rows))
-        import time as _time
-
-        start = _time.monotonic()
-        # Worker-pool pattern: live task count stays O(concurrency)
-        # regardless of len(rows). With a plain asyncio.gather + per-row
-        # task, a 100k-node coercion would create 100k pending tasks up
-        # front, holding their captured state in memory until completion.
-        queue: asyncio.Queue[tuple[str, Any] | None] = asyncio.Queue(maxsize=concurrency * 2)
-
-        async def _worker() -> None:
-            while True:
-                item = await queue.get()
-                try:
-                    if item is None:
-                        return
-                    node_id, current = item
-                    try:
-                        prompt = BACKFILL_SEMANTIC_COERCION_PROMPT.format(
-                            owner_label=owner_label,
-                            attr_name=name,
-                            target_type=target_type,
-                            current_value=current,
-                        )
-                        response = await self.llm.ainvoke(prompt)
-                        result.llm_calls += 1
-                        payload = _strip_and_load_json(response.content)
-                        new_value = payload.get("value") if isinstance(payload, dict) else None
-                        if new_value is None:
-                            await self._graph_store.set_node_property_by_id(
-                                owner_label, node_id, name, None
-                            )
-                            result.dropped_for_coercion += 1
-                            continue
-                        ok, coerced = _coerce_attribute_value(new_value, target_type)
-                        if not ok:
-                            await self._graph_store.set_node_property_by_id(
-                                owner_label, node_id, name, None
-                            )
-                            result.dropped_for_coercion += 1
-                            continue
-                        await self._graph_store.set_node_property_by_id(
-                            owner_label, node_id, name, coerced
-                        )
-                        result.values_filled += 1
-                    except Exception as exc:
-                        logger.warning(
-                            "backfill_attribute_semantic: node %s failed: %s",
-                            node_id,
-                            exc,
-                        )
-                        result.failed_node_ids.append(node_id)
-                finally:
-                    queue.task_done()
-
-        workers = [asyncio.create_task(_worker()) for _ in range(concurrency)]
-        for node_id, value in rows:
-            await queue.put((node_id, value))
-        for _ in workers:
-            await queue.put(None)
-        await asyncio.gather(*workers)
-        # After coercion, update the ontology graph's declared type.
-        await self._ontology_store.retype_property("entity", owner_label, name, target_type)
-        result.elapsed_s = _time.monotonic() - start
-        await self._refresh_global_ontology()
         return result
 
     # ── Graph admin ──────────────────────────────────────────────

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -831,7 +831,10 @@ class GraphRAG:
         after retries — callers must NOT commit the ontology graph in
         that case. Re-running is safe (chunk markers skip done work).
         """
-        op_id = f"add_attribute:{owner_label}:{attribute.name}"
+        # op_id includes the type — drop+add with a new type must trigger
+        # a fresh LLM rescan, not be filtered out by chunk markers from
+        # the previous (different-type) backfill of the same name.
+        op_id = f"add_attribute:{owner_label}:{attribute.name}:{attribute.type}"
         attr_name = attribute.name
         chunk_rows = await self._graph_store.list_chunks_for_attribute_backfill(
             owner_label, attr_name, op_id=op_id

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -36,11 +36,16 @@ from graphrag_sdk.core.models import (
     IngestionResult,
     Ontology,
     RagResult,
-    Relation,
     RetrieverResult,
     UpdateResult,
 )
 from graphrag_sdk.core.providers import Embedder, LLMInterface
+from graphrag_sdk.ingestion.backfill import (
+    BackfillExecutor,
+    BackfillMergeStats,
+    BackfillResult,
+    ChunkContext,
+)
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
 from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
     SentenceTokenCapChunking,
@@ -48,14 +53,6 @@ from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
 from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
 from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
     DEFAULT_ENTITY_TYPES,
-)
-from graphrag_sdk.ingestion.backfill import (
-    BackfillExecutor,
-    BackfillMergeStats,
-    BackfillResult,
-    ChunkContext,
-)
-from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
     _strip_markdown_fences,
 )
 from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
@@ -494,9 +491,7 @@ class GraphRAG:
 
     # ── Group 1: pure ontology (no data, no LLM) ─────────────────
 
-    async def set_entity_description(
-        self, label: str, description: str | None
-    ) -> Ontology:
+    async def set_entity_description(self, label: str, description: str | None) -> Ontology:
         """Set or clear the description on an existing entity type."""
         await self._ensure_ontology_initialized()
         if not any(e.label == label for e in self._global_ontology.entities):
@@ -504,9 +499,7 @@ class GraphRAG:
         await self._ontology_store.set_description("entity", label, description)
         return await self._refresh_global_ontology()
 
-    async def set_relation_description(
-        self, label: str, description: str | None
-    ) -> Ontology:
+    async def set_relation_description(self, label: str, description: str | None) -> Ontology:
         """Set or clear the description on an existing relation type."""
         await self._ensure_ontology_initialized()
         if not any(r.label == label for r in self._global_ontology.relations):
@@ -550,9 +543,7 @@ class GraphRAG:
         await self._ontology_store.add_entity_property(entity_label, attribute)
         return await self._refresh_global_ontology()
 
-    async def add_relation_pattern(
-        self, rel_label: str, source: str, target: str
-    ) -> Ontology:
+    async def add_relation_pattern(self, rel_label: str, source: str, target: str) -> Ontology:
         """Declare a new ``(source, target)`` pattern for a relation. Adds
         no data — call ``backfill_relation_pattern`` afterwards.
 
@@ -589,14 +580,10 @@ class GraphRAG:
             )
         nodes_moved = await self._graph_store.rename_label(old, new)
         await self._ontology_store.rename_entity_label(old, new)
-        logger.info(
-            "rename_entity %s → %s: %d data nodes relabelled", old, new, nodes_moved
-        )
+        logger.info("rename_entity %s → %s: %d data nodes relabelled", old, new, nodes_moved)
         return await self._refresh_global_ontology()
 
-    async def rename_attribute(
-        self, owner_label: str, old_name: str, new_name: str
-    ) -> Ontology:
+    async def rename_attribute(self, owner_label: str, old_name: str, new_name: str) -> Ontology:
         """Rename an attribute on an entity (data + ontology) or on a
         relation (ontology only — relation-property data migration is
         not implemented in this version; a warning is logged).
@@ -616,12 +603,13 @@ class GraphRAG:
                 "rename (edge-property rename is out of scope for v1).",
                 owner_label,
             )
-        await self._ontology_store.rename_property_label(
-            kind, owner_label, old_name, new_name
-        )
+        await self._ontology_store.rename_property_label(kind, owner_label, old_name, new_name)
         logger.info(
             "rename_attribute %s.%s → %s: %d nodes touched",
-            owner_label, old_name, new_name, nodes_touched,
+            owner_label,
+            old_name,
+            new_name,
+            nodes_touched,
         )
         return await self._refresh_global_ontology()
 
@@ -644,7 +632,9 @@ class GraphRAG:
         await self._ontology_store.rename_relation_label(old, new)
         logger.info(
             "rename_relation %s → %s: %d data edges recreated",
-            old, new, edges_moved,
+            old,
+            new,
+            edges_moved,
         )
         return await self._refresh_global_ontology()
 
@@ -656,9 +646,7 @@ class GraphRAG:
         kind = self._resolve_owner_kind(owner_label)
         nodes_touched = 0
         if kind == "entity":
-            nodes_touched = await self._graph_store.drop_node_property(
-                owner_label, name
-            )
+            nodes_touched = await self._graph_store.drop_node_property(owner_label, name)
             await self._ontology_store.drop_entity_property(owner_label, name)
         else:
             logger.warning(
@@ -667,9 +655,7 @@ class GraphRAG:
                 owner_label,
             )
             await self._ontology_store.drop_relation_property(owner_label, name)
-        logger.info(
-            "drop_attribute %s.%s: %d nodes touched", owner_label, name, nodes_touched
-        )
+        logger.info("drop_attribute %s.%s: %d nodes touched", owner_label, name, nodes_touched)
         return await self._refresh_global_ontology()
 
     async def drop_entity(self, label: str) -> Ontology:
@@ -699,9 +685,7 @@ class GraphRAG:
         logger.info("drop_relation %s: %d data edges deleted", label, edges_deleted)
         return await self._refresh_global_ontology()
 
-    async def drop_relation_pattern(
-        self, rel_label: str, source: str, target: str
-    ) -> Ontology:
+    async def drop_relation_pattern(self, rel_label: str, source: str, target: str) -> Ontology:
         """Drop a single ``(source, target)`` pattern of a relation.
 
         Sibling patterns of the same relation (with different endpoint
@@ -716,13 +700,14 @@ class GraphRAG:
         await self._ontology_store.drop_relation_pattern_node(rel_label, source, target)
         logger.info(
             "drop_relation_pattern %s (%s→%s): %d data edges deleted",
-            rel_label, source, target, edges_deleted,
+            rel_label,
+            source,
+            target,
+            edges_deleted,
         )
         return await self._refresh_global_ontology()
 
-    async def retype_attribute(
-        self, owner_label: str, name: str, new_type: str
-    ) -> Ontology:
+    async def retype_attribute(self, owner_label: str, name: str, new_type: str) -> Ontology:
         """Mechanically coerce an attribute's data-graph values to a new
         Cypher type and update the ontology graph.
 
@@ -750,7 +735,11 @@ class GraphRAG:
         await self._ontology_store.retype_property(kind, owner_label, name, new_type)
         logger.info(
             "retype_attribute %s.%s → %s: %d coerced, %d dropped",
-            owner_label, name, new_type, coerced, dropped,
+            owner_label,
+            name,
+            new_type,
+            coerced,
+            dropped,
         )
         return await self._refresh_global_ontology()
 
@@ -789,8 +778,7 @@ class GraphRAG:
         attribute = next((a for a in entity.properties if a.name == name), None)
         if attribute is None:
             raise ValueError(
-                f"Unknown attribute {owner_label}.{name!r} — declare it first "
-                f"via add_attribute()."
+                f"Unknown attribute {owner_label}.{name!r} — declare it first via add_attribute()."
             )
 
         op_id = f"backfill_attribute:{owner_label}:{name}"
@@ -807,13 +795,17 @@ class GraphRAG:
                     ontology=self._global_ontology,
                 )
 
-        attr_desc_line = f"- description: {attribute.description}\n" if attribute.description else ""
+        attr_desc_line = (
+            f"- description: {attribute.description}\n" if attribute.description else ""
+        )
 
         def _prompt(ctx: ChunkContext) -> str:
-            entity_lines = "\n".join(
-                f"- {ent.get('name') or ent.get('id')}"
-                for ent in ctx.payload["entities"]
-            ) or "(none)"
+            entity_lines = (
+                "\n".join(
+                    f"- {ent.get('name') or ent.get('id')}" for ent in ctx.payload["entities"]
+                )
+                or "(none)"
+            )
             return BACKFILL_ATTRIBUTE_PROMPT.format(
                 owner_label=owner_label,
                 attr_name=name,
@@ -827,14 +819,9 @@ class GraphRAG:
             payload = _strip_and_load_json(text)
             return payload.get("results", {}) if isinstance(payload, dict) else {}
 
-        async def _merge(
-            parsed: dict[str, Any], ctx: ChunkContext
-        ) -> BackfillMergeStats:
+        async def _merge(parsed: dict[str, Any], ctx: ChunkContext) -> BackfillMergeStats:
             filled = skipped = dropped = 0
-            by_name = {
-                (ent.get("name") or "").strip(): ent
-                for ent in ctx.payload["entities"]
-            }
+            by_name = {(ent.get("name") or "").strip(): ent for ent in ctx.payload["entities"]}
             for ent_name, raw_value in parsed.items():
                 ent = by_name.get((ent_name or "").strip())
                 if ent is None:
@@ -933,9 +920,7 @@ class GraphRAG:
             payload = _strip_and_load_json(text)
             return payload.get("entities", []) if isinstance(payload, dict) else []
 
-        async def _merge(
-            parsed: list[dict[str, Any]], ctx: ChunkContext
-        ) -> BackfillMergeStats:
+        async def _merge(parsed: list[dict[str, Any]], ctx: ChunkContext) -> BackfillMergeStats:
             filled = skipped = 0
             from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
                 compute_entity_id,
@@ -1035,10 +1020,12 @@ class GraphRAG:
         rel_desc_line = f"- description: {relation.description}\n" if relation.description else ""
 
         def _prompt(ctx: ChunkContext) -> str:
-            pair_lines = "\n".join(
-                f"- {p.get('src_name') or p.get('src_id')} → {p.get('tgt_name') or p.get('tgt_id')}"
-                for p in ctx.payload["pairs"]
-            ) or "(none)"
+            def _pair_line(p: dict[str, Any]) -> str:
+                src = p.get("src_name") or p.get("src_id")
+                tgt = p.get("tgt_name") or p.get("tgt_id")
+                return f"- {src} → {tgt}"
+
+            pair_lines = "\n".join(_pair_line(p) for p in ctx.payload["pairs"]) or "(none)"
             return BACKFILL_RELATION_PATTERN_PROMPT.format(
                 rel_label=rel_label,
                 src_label=source,
@@ -1052,16 +1039,10 @@ class GraphRAG:
             payload = _strip_and_load_json(text)
             return payload.get("links", []) if isinstance(payload, dict) else []
 
-        async def _merge(
-            parsed: list[dict[str, Any]], ctx: ChunkContext
-        ) -> BackfillMergeStats:
+        async def _merge(parsed: list[dict[str, Any]], ctx: ChunkContext) -> BackfillMergeStats:
             filled = skipped = 0
-            by_src = {
-                (p.get("src_name") or "").strip(): p for p in ctx.payload["pairs"]
-            }
-            by_tgt = {
-                (p.get("tgt_name") or "").strip(): p for p in ctx.payload["pairs"]
-            }
+            by_src = {(p.get("src_name") or "").strip(): p for p in ctx.payload["pairs"]}
+            by_tgt = {(p.get("tgt_name") or "").strip(): p for p in ctx.payload["pairs"]}
             new_edges: list[GraphRelationship] = []
             for link in parsed:
                 src_name = (link.get("src") or "").strip()
@@ -1124,9 +1105,7 @@ class GraphRAG:
                 "implemented in v1 (relation-property coercion would require "
                 "iterating edges)."
             )
-        rows = await self._graph_store.list_node_values_for_semantic_coerce(
-            owner_label, name
-        )
+        rows = await self._graph_store.list_node_values_for_semantic_coerce(owner_label, name)
         op_id = f"backfill_attribute_semantic:{owner_label}:{name}:{target_type}"
 
         result = BackfillResult(operation_id=op_id, target_nodes=len(rows))
@@ -1168,15 +1147,14 @@ class GraphRAG:
                 except Exception as exc:
                     logger.warning(
                         "backfill_attribute_semantic: node %s failed: %s",
-                        node_id, exc,
+                        node_id,
+                        exc,
                     )
                     result.failed_chunks.append(node_id)
 
         await asyncio.gather(*[_coerce_one(nid, val) for nid, val in rows])
         # After coercion, update the ontology graph's declared type.
-        await self._ontology_store.retype_property(
-            "entity", owner_label, name, target_type
-        )
+        await self._ontology_store.retype_property("entity", owner_label, name, target_type)
         result.elapsed_s = _time.monotonic() - start
         await self._refresh_global_ontology()
         return result

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
 import os
 import re
@@ -23,15 +24,19 @@ from graphrag_sdk.core.exceptions import (
 )
 from graphrag_sdk.core.models import (
     ApplyChangesResult,
+    Attribute,
     BatchEntry,
     ChatMessage,
     DeleteDocumentResult,
     DocumentInfo,
     Entity,
     FinalizeResult,
+    GraphNode,
+    GraphRelationship,
     IngestionResult,
     Ontology,
     RagResult,
+    Relation,
     RetrieverResult,
     UpdateResult,
 )
@@ -44,7 +49,23 @@ from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
 from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
     DEFAULT_ENTITY_TYPES,
 )
-from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import GraphExtraction
+from graphrag_sdk.ingestion.backfill import (
+    BackfillExecutor,
+    BackfillMergeStats,
+    BackfillResult,
+    ChunkContext,
+)
+from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
+    _strip_markdown_fences,
+)
+from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
+    BACKFILL_ATTRIBUTE_PROMPT,
+    BACKFILL_ENTITY_PROMPT,
+    BACKFILL_RELATION_PATTERN_PROMPT,
+    BACKFILL_SEMANTIC_COERCION_PROMPT,
+    GraphExtraction,
+    _coerce_attribute_value,
+)
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
 from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
 from graphrag_sdk.ingestion.loaders.pdf_loader import PdfLoader
@@ -122,6 +143,19 @@ _CONTEXT_CLOSE_RE = re.compile(r"</\s*context\s*>", re.IGNORECASE)
 def _neutralize_context_close_tag(text: str) -> str:
     """Disarm any literal ``</context>`` that appears inside untrusted text."""
     return _CONTEXT_CLOSE_RE.sub("</ context>", text)
+
+
+def _strip_and_load_json(text: str) -> Any:
+    """Parse LLM-emitted JSON, tolerating optional markdown fences.
+
+    Used by the ontology-evolution backfill methods to consume their
+    focused-prompt responses. Returns ``{}`` on malformed JSON so a single
+    bad response degrades to a no-op merge rather than poisoning the run.
+    """
+    try:
+        return json.loads(_strip_markdown_fences(text))
+    except (ValueError, TypeError):
+        return {}
 
 
 _QUESTION_REWRITE_PROMPT = (
@@ -410,6 +444,742 @@ class GraphRAG:
         """
         ontology = await self.get_ontology()
         ontology.save_to_file(path, indent=indent)
+
+    # ── Ontology evolution ──────────────────────────────────────
+    #
+    # Three tiers (see plan & module docstring of ingestion/backfill.py):
+    #
+    # - **Group 1** — pure ontology changes (descriptions, declarations).
+    # - **Group 2** — mechanical data migration via Cypher (renames,
+    #   drops, mechanical retypes).
+    # - **Group 3** — LLM-driven re-scan over stored chunks.
+    #
+    # Each method is a thin orchestrator: it validates input against the
+    # current ontology, runs the data migration first (so a crash leaves
+    # the data graph ahead of the ontology — re-running is then idempotent),
+    # updates the ontology graph, and refreshes the cached
+    # ``_global_ontology`` + retrieval strategy.
+
+    async def _refresh_global_ontology(self) -> Ontology:
+        """Reload the persisted ontology and re-propagate to retrieval.
+
+        Internal helper shared by every evolution method so the refresh
+        path lives in one place.
+        """
+        self._global_ontology = await self._ontology_store.load()
+        if hasattr(self._retrieval_strategy, "_ontology"):
+            self._retrieval_strategy._ontology = self._global_ontology
+        return self._global_ontology
+
+    def _resolve_owner_kind(self, owner_label: str) -> Literal["entity", "relation"]:
+        """Decide whether ``owner_label`` names an entity or a relation.
+
+        Resolved against the current ``_global_ontology``. Raises
+        ``ValueError`` when the label is unknown, or when it is shared by
+        an entity and a relation (ambiguous; the caller must split).
+        """
+        is_entity = any(e.label == owner_label for e in self._global_ontology.entities)
+        is_relation = any(r.label == owner_label for r in self._global_ontology.relations)
+        if is_entity and is_relation:
+            raise ValueError(
+                f"Label '{owner_label}' is declared as both an entity and a "
+                f"relation in the current ontology; disambiguate by calling "
+                f"the entity- or relation-specific evolution method directly."
+            )
+        if is_entity:
+            return "entity"
+        if is_relation:
+            return "relation"
+        raise ValueError(f"Unknown ontology label: {owner_label!r}")
+
+    # ── Group 1: pure ontology (no data, no LLM) ─────────────────
+
+    async def set_entity_description(
+        self, label: str, description: str | None
+    ) -> Ontology:
+        """Set or clear the description on an existing entity type."""
+        await self._ensure_ontology_initialized()
+        if not any(e.label == label for e in self._global_ontology.entities):
+            raise ValueError(f"Unknown entity label: {label!r}")
+        await self._ontology_store.set_description("entity", label, description)
+        return await self._refresh_global_ontology()
+
+    async def set_relation_description(
+        self, label: str, description: str | None
+    ) -> Ontology:
+        """Set or clear the description on an existing relation type."""
+        await self._ensure_ontology_initialized()
+        if not any(r.label == label for r in self._global_ontology.relations):
+            raise ValueError(f"Unknown relation label: {label!r}")
+        await self._ontology_store.set_description("relation", label, description)
+        return await self._refresh_global_ontology()
+
+    async def set_attribute_description(
+        self,
+        owner_label: str,
+        attribute_name: str,
+        description: str | None,
+    ) -> Ontology:
+        """Set or clear the description on an attribute of an entity or relation."""
+        await self._ensure_ontology_initialized()
+        kind = self._resolve_owner_kind(owner_label)
+        await self._ontology_store.set_description(
+            f"{kind}_property", attribute_name, description, owner_label=owner_label
+        )
+        return await self._refresh_global_ontology()
+
+    async def add_entity(self, entity: Entity) -> Ontology:
+        """Declare a new entity type. Adds no data — call ``backfill_entity``
+        afterwards to populate instances from already-ingested chunks.
+        """
+        await self._ensure_ontology_initialized()
+        if any(e.label == entity.label for e in self._global_ontology.entities):
+            raise ValueError(f"Entity label {entity.label!r} already exists")
+        # Re-use register()'s additive path — it accepts brand-new labels.
+        await self._ontology_store.register(Ontology(entities=[entity]))
+        return await self._refresh_global_ontology()
+
+    async def add_attribute(self, entity_label: str, attribute: Attribute) -> Ontology:
+        """Declare a new attribute on an existing entity type. Adds no
+        data — call ``backfill_attribute`` afterwards to populate values
+        from already-ingested chunks.
+        """
+        await self._ensure_ontology_initialized()
+        if not any(e.label == entity_label for e in self._global_ontology.entities):
+            raise ValueError(f"Unknown entity label: {entity_label!r}")
+        await self._ontology_store.add_entity_property(entity_label, attribute)
+        return await self._refresh_global_ontology()
+
+    async def add_relation_pattern(
+        self, rel_label: str, source: str, target: str
+    ) -> Ontology:
+        """Declare a new ``(source, target)`` pattern for a relation. Adds
+        no data — call ``backfill_relation_pattern`` afterwards.
+
+        The relation may be new (in which case the call is equivalent to a
+        single-pattern ``register()``) or existing (a fresh pattern is
+        added alongside any sibling patterns).
+        """
+        await self._ensure_ontology_initialized()
+        if not any(e.label == source for e in self._global_ontology.entities):
+            raise ValueError(f"Unknown source entity label: {source!r}")
+        if not any(e.label == target for e in self._global_ontology.entities):
+            raise ValueError(f"Unknown target entity label: {target!r}")
+        await self._ontology_store.add_relation_pattern_node(rel_label, source, target)
+        return await self._refresh_global_ontology()
+
+    # ── Group 2: mechanical data migration ───────────────────────
+
+    async def rename_entity(self, old: str, new: str) -> Ontology:
+        """Rename an entity label across both data and ontology graphs.
+
+        Data migration runs first (relabels every ``:old`` node to
+        ``:new``) so a crash between the two leaves the data graph
+        already migrated; re-running is idempotent.
+        """
+        await self._ensure_ontology_initialized()
+        if not any(e.label == old for e in self._global_ontology.entities):
+            raise ValueError(f"Unknown entity label: {old!r}")
+        if old == new:
+            return self._global_ontology
+        if any(e.label == new for e in self._global_ontology.entities):
+            raise ValueError(
+                f"Entity {new!r} already exists; merging entity types is not "
+                f"supported by rename_entity — drop one or use a fresh label."
+            )
+        nodes_moved = await self._graph_store.rename_label(old, new)
+        await self._ontology_store.rename_entity_label(old, new)
+        logger.info(
+            "rename_entity %s → %s: %d data nodes relabelled", old, new, nodes_moved
+        )
+        return await self._refresh_global_ontology()
+
+    async def rename_attribute(
+        self, owner_label: str, old_name: str, new_name: str
+    ) -> Ontology:
+        """Rename an attribute on an entity (data + ontology) or on a
+        relation (ontology only — relation-property data migration is
+        not implemented in this version; a warning is logged).
+        """
+        await self._ensure_ontology_initialized()
+        kind = self._resolve_owner_kind(owner_label)
+        if old_name == new_name:
+            return self._global_ontology
+        nodes_touched = 0
+        if kind == "entity":
+            nodes_touched = await self._graph_store.rename_node_property(
+                owner_label, old_name, new_name
+            )
+        else:
+            logger.warning(
+                "rename_attribute on relation %s: skipping data-graph property "
+                "rename (edge-property rename is out of scope for v1).",
+                owner_label,
+            )
+        await self._ontology_store.rename_property_label(
+            kind, owner_label, old_name, new_name
+        )
+        logger.info(
+            "rename_attribute %s.%s → %s: %d nodes touched",
+            owner_label, old_name, new_name, nodes_touched,
+        )
+        return await self._refresh_global_ontology()
+
+    async def rename_relation(self, old: str, new: str) -> Ontology:
+        """Rename a relation type. Recreates every ``[:old]`` edge as
+        ``[:new]`` in the data graph (expensive — logs a warning when
+        edge count > 10k), then updates the ontology graph.
+        """
+        await self._ensure_ontology_initialized()
+        if not any(r.label == old for r in self._global_ontology.relations):
+            raise ValueError(f"Unknown relation label: {old!r}")
+        if old == new:
+            return self._global_ontology
+        if any(r.label == new for r in self._global_ontology.relations):
+            raise ValueError(
+                f"Relation {new!r} already exists; merging relations is not "
+                f"supported by rename_relation."
+            )
+        edges_moved = await self._graph_store.rename_relation_type(old, new)
+        await self._ontology_store.rename_relation_label(old, new)
+        logger.info(
+            "rename_relation %s → %s: %d data edges recreated",
+            old, new, edges_moved,
+        )
+        return await self._refresh_global_ontology()
+
+    async def drop_attribute(self, owner_label: str, name: str) -> Ontology:
+        """Drop an attribute from data + ontology (for entities) or
+        ontology only (for relations — see ``rename_attribute``'s note).
+        """
+        await self._ensure_ontology_initialized()
+        kind = self._resolve_owner_kind(owner_label)
+        nodes_touched = 0
+        if kind == "entity":
+            nodes_touched = await self._graph_store.drop_node_property(
+                owner_label, name
+            )
+            await self._ontology_store.drop_entity_property(owner_label, name)
+        else:
+            logger.warning(
+                "drop_attribute on relation %s: skipping data-graph property "
+                "drop (edge-property drop is out of scope for v1).",
+                owner_label,
+            )
+            await self._ontology_store.drop_relation_property(owner_label, name)
+        logger.info(
+            "drop_attribute %s.%s: %d nodes touched", owner_label, name, nodes_touched
+        )
+        return await self._refresh_global_ontology()
+
+    async def drop_entity(self, label: str) -> Ontology:
+        """Drop an entity type. ``DETACH DELETE``s every node with that
+        label (cascading their incident RELATES edges) and removes the
+        entity (and any relation patterns referencing it) from the
+        ontology graph.
+        """
+        await self._ensure_ontology_initialized()
+        if not any(e.label == label for e in self._global_ontology.entities):
+            raise ValueError(f"Unknown entity label: {label!r}")
+        nodes_deleted = await self._graph_store.delete_nodes_by_label(label)
+        await self._ontology_store.drop_entity_label(label)
+        logger.info("drop_entity %s: %d data nodes deleted", label, nodes_deleted)
+        return await self._refresh_global_ontology()
+
+    async def drop_relation(self, label: str) -> Ontology:
+        """Drop a relation type. Deletes every edge with that type from
+        the data graph and the corresponding Relation nodes from the
+        ontology graph.
+        """
+        await self._ensure_ontology_initialized()
+        if not any(r.label == label for r in self._global_ontology.relations):
+            raise ValueError(f"Unknown relation label: {label!r}")
+        edges_deleted = await self._graph_store.delete_relations_by_type(label)
+        await self._ontology_store.drop_relation_label(label)
+        logger.info("drop_relation %s: %d data edges deleted", label, edges_deleted)
+        return await self._refresh_global_ontology()
+
+    async def drop_relation_pattern(
+        self, rel_label: str, source: str, target: str
+    ) -> Ontology:
+        """Drop a single ``(source, target)`` pattern of a relation.
+
+        Sibling patterns of the same relation (with different endpoint
+        labels) are preserved.
+        """
+        await self._ensure_ontology_initialized()
+        if not any(r.label == rel_label for r in self._global_ontology.relations):
+            raise ValueError(f"Unknown relation label: {rel_label!r}")
+        edges_deleted = await self._graph_store.delete_relations_by_pattern(
+            rel_label, source, target
+        )
+        await self._ontology_store.drop_relation_pattern_node(rel_label, source, target)
+        logger.info(
+            "drop_relation_pattern %s (%s→%s): %d data edges deleted",
+            rel_label, source, target, edges_deleted,
+        )
+        return await self._refresh_global_ontology()
+
+    async def retype_attribute(
+        self, owner_label: str, name: str, new_type: str
+    ) -> Ontology:
+        """Mechanically coerce an attribute's data-graph values to a new
+        Cypher type and update the ontology graph.
+
+        Mechanical coercion handles ``INTEGER``, ``FLOAT``, ``STRING``,
+        ``BOOLEAN``. ``DATE`` and ``LIST`` require LLM-assisted
+        coercion — use ``backfill_attribute_semantic`` for those.
+
+        Values that don't convert (e.g. ``"twelve"`` → INTEGER) are
+        DROPPED from the affected nodes; the count is logged. Re-running
+        is idempotent because converted values stay converted.
+        """
+        await self._ensure_ontology_initialized()
+        kind = self._resolve_owner_kind(owner_label)
+        coerced = dropped = 0
+        if kind == "entity":
+            coerced, dropped = await self._graph_store.coerce_node_property(
+                owner_label, name, new_type
+            )
+        else:
+            logger.warning(
+                "retype_attribute on relation %s: skipping data-graph coercion "
+                "(edge-property coercion is out of scope for v1).",
+                owner_label,
+            )
+        await self._ontology_store.retype_property(kind, owner_label, name, new_type)
+        logger.info(
+            "retype_attribute %s.%s → %s: %d coerced, %d dropped",
+            owner_label, name, new_type, coerced, dropped,
+        )
+        return await self._refresh_global_ontology()
+
+    # ── Group 3: LLM-driven backfill ─────────────────────────────
+
+    async def backfill_attribute(
+        self,
+        owner_label: str,
+        name: str,
+        *,
+        scope: str = "missing",
+        concurrency: int = 4,
+    ) -> BackfillResult:
+        """Fill a newly-declared attribute on an existing entity type by
+        re-scanning chunks that mention entities of ``owner_label``
+        currently missing this attribute.
+
+        ``scope="missing"`` is the only mode in v1 — entities already
+        carrying a value are left alone. Idempotent: chunks already
+        processed are skipped via the ``extracted_ops`` marker.
+
+        Cost: roughly one LLM call per chunk that has at least one
+        missing-attribute entity. Use sparingly on large corpora.
+        """
+        if scope != "missing":
+            raise ValueError(
+                f"backfill_attribute: unsupported scope {scope!r}; only 'missing' is implemented."
+            )
+        await self._ensure_ontology_initialized()
+        entity = next(
+            (e for e in self._global_ontology.entities if e.label == owner_label),
+            None,
+        )
+        if entity is None:
+            raise ValueError(f"Unknown entity label: {owner_label!r}")
+        attribute = next((a for a in entity.properties if a.name == name), None)
+        if attribute is None:
+            raise ValueError(
+                f"Unknown attribute {owner_label}.{name!r} — declare it first "
+                f"via add_attribute()."
+            )
+
+        op_id = f"backfill_attribute:{owner_label}:{name}"
+        chunk_rows = await self._graph_store.list_chunks_for_attribute_backfill(
+            owner_label, name, op_id=op_id
+        )
+
+        async def _iter() -> Any:
+            for row in chunk_rows:
+                yield ChunkContext(
+                    chunk_id=row["chunk_id"],
+                    chunk_text=row["chunk_text"],
+                    payload={"entities": row["entities"]},
+                    ontology=self._global_ontology,
+                )
+
+        attr_desc_line = f"- description: {attribute.description}\n" if attribute.description else ""
+
+        def _prompt(ctx: ChunkContext) -> str:
+            entity_lines = "\n".join(
+                f"- {ent.get('name') or ent.get('id')}"
+                for ent in ctx.payload["entities"]
+            ) or "(none)"
+            return BACKFILL_ATTRIBUTE_PROMPT.format(
+                owner_label=owner_label,
+                attr_name=name,
+                attr_type=attribute.type,
+                attr_description=attr_desc_line,
+                entities_block=entity_lines,
+                chunk_text=ctx.chunk_text,
+            )
+
+        def _parse(text: str, _ctx: ChunkContext) -> dict[str, Any]:
+            payload = _strip_and_load_json(text)
+            return payload.get("results", {}) if isinstance(payload, dict) else {}
+
+        async def _merge(
+            parsed: dict[str, Any], ctx: ChunkContext
+        ) -> BackfillMergeStats:
+            filled = skipped = dropped = 0
+            by_name = {
+                (ent.get("name") or "").strip(): ent
+                for ent in ctx.payload["entities"]
+            }
+            for ent_name, raw_value in parsed.items():
+                ent = by_name.get((ent_name or "").strip())
+                if ent is None:
+                    continue
+                if raw_value is None or raw_value == "":
+                    skipped += 1
+                    continue
+                ok, coerced = _coerce_attribute_value(raw_value, attribute.type)
+                if not ok:
+                    dropped += 1
+                    continue
+                await self._graph_store.set_node_property_by_id(
+                    owner_label, ent["id"], name, coerced
+                )
+                filled += 1
+            return BackfillMergeStats(
+                values_filled=filled,
+                values_skipped=skipped,
+                dropped_for_coercion=dropped,
+            )
+
+        executor = BackfillExecutor(self.llm, self._graph_store, concurrency=concurrency)
+        result = await executor.run(
+            op_id=op_id,
+            chunks=_iter(),
+            prompt_builder=_prompt,
+            parse_fn=_parse,
+            merge_fn=_merge,
+        )
+        result.target_nodes = sum(len(r["entities"]) for r in chunk_rows)
+        return result
+
+    async def backfill_entity(
+        self,
+        label: str,
+        *,
+        scope: str | list[str] = "all",
+        concurrency: int = 4,
+    ) -> BackfillResult:
+        """Find new instances of a newly-declared entity type by re-scanning
+        chunks.
+
+        ``scope="all"`` re-scans every chunk in the graph. Pass a list of
+        chunk ids to constrain. Idempotent via the ``extracted_ops``
+        marker.
+
+        Newly-found entities are inserted with ``MENTIONED_IN`` edges to
+        the originating chunk. Cost is proportional to the chunk count
+        in scope.
+        """
+        await self._ensure_ontology_initialized()
+        entity = next(
+            (e for e in self._global_ontology.entities if e.label == label),
+            None,
+        )
+        if entity is None:
+            raise ValueError(f"Unknown entity label: {label!r}")
+
+        op_id = f"backfill_entity:{label}"
+        chunk_ids = scope if isinstance(scope, list) else None
+        if not isinstance(scope, list) and scope != "all":
+            raise ValueError(
+                f"backfill_entity: scope must be 'all' or a list of chunk ids; got {scope!r}"
+            )
+        chunk_rows = await self._graph_store.list_chunks_for_entity_backfill(
+            op_id=op_id, chunk_ids=chunk_ids
+        )
+
+        async def _iter() -> Any:
+            for row in chunk_rows:
+                yield ChunkContext(
+                    chunk_id=row["chunk_id"],
+                    chunk_text=row["chunk_text"],
+                    payload={},
+                    ontology=self._global_ontology,
+                )
+
+        attribute_block = (
+            "\n".join(
+                f"- {a.name} ({a.type})" + (f" — {a.description}" if a.description else "")
+                for a in entity.properties
+            )
+            or "(none)"
+        )
+        target_desc_line = f"- description: {entity.description}\n" if entity.description else ""
+
+        def _prompt(ctx: ChunkContext) -> str:
+            return BACKFILL_ENTITY_PROMPT.format(
+                target_label=label,
+                target_description=target_desc_line,
+                attribute_block=attribute_block,
+                chunk_text=ctx.chunk_text,
+            )
+
+        def _parse(text: str, _ctx: ChunkContext) -> list[dict[str, Any]]:
+            payload = _strip_and_load_json(text)
+            return payload.get("entities", []) if isinstance(payload, dict) else []
+
+        async def _merge(
+            parsed: list[dict[str, Any]], ctx: ChunkContext
+        ) -> BackfillMergeStats:
+            filled = skipped = 0
+            from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
+                compute_entity_id,
+                is_valid_entity_name,
+            )
+
+            new_nodes: list[GraphNode] = []
+            new_mentions: list[GraphRelationship] = []
+            for ent in parsed:
+                ent_name = (ent.get("name") or "").strip()
+                if not is_valid_entity_name(ent_name):
+                    skipped += 1
+                    continue
+                ent_id = compute_entity_id(label, ent_name)
+                props: dict[str, Any] = {
+                    "name": ent_name,
+                    "description": ent.get("description", ""),
+                }
+                for attr in entity.properties:
+                    raw = (ent.get("attributes") or {}).get(attr.name)
+                    if raw is None:
+                        continue
+                    ok, coerced = _coerce_attribute_value(raw, attr.type)
+                    if ok:
+                        props[attr.name] = coerced
+                new_nodes.append(GraphNode(id=ent_id, label=label, properties=props))
+                new_mentions.append(
+                    GraphRelationship(
+                        start_node_id=ent_id,
+                        end_node_id=ctx.chunk_id,
+                        type="MENTIONED_IN",
+                        properties={},
+                    )
+                )
+                filled += 1
+            if new_nodes:
+                await self._graph_store.upsert_nodes(new_nodes)
+                await self._graph_store.upsert_relationships(new_mentions)
+            return BackfillMergeStats(values_filled=filled, values_skipped=skipped)
+
+        executor = BackfillExecutor(self.llm, self._graph_store, concurrency=concurrency)
+        result = await executor.run(
+            op_id=op_id,
+            chunks=_iter(),
+            prompt_builder=_prompt,
+            parse_fn=_parse,
+            merge_fn=_merge,
+        )
+        result.target_nodes = len(chunk_rows)
+        return result
+
+    async def backfill_relation_pattern(
+        self,
+        rel_label: str,
+        source: str,
+        target: str,
+        *,
+        scope: str = "candidate-pairs",
+        concurrency: int = 4,
+    ) -> BackfillResult:
+        """Find new ``(source) -[rel_label]-> (target)`` edges by asking
+        the LLM about candidate co-mention pairs in already-ingested
+        chunks.
+
+        ``scope="candidate-pairs"`` (the only mode in v1) restricts the
+        scan to chunks where both source-type and target-type entities
+        co-occur — the universe of plausible new edges. Edges that
+        already exist between the same pair are skipped at MERGE time.
+        """
+        if scope != "candidate-pairs":
+            raise ValueError(
+                f"backfill_relation_pattern: unsupported scope {scope!r}; "
+                f"only 'candidate-pairs' is implemented."
+            )
+        await self._ensure_ontology_initialized()
+        relation = next(
+            (r for r in self._global_ontology.relations if r.label == rel_label),
+            None,
+        )
+        if relation is None:
+            raise ValueError(f"Unknown relation label: {rel_label!r}")
+
+        op_id = f"backfill_relation_pattern:{rel_label}:{source}:{target}"
+        chunk_rows = await self._graph_store.list_chunks_for_relation_pattern_backfill(
+            source, target, op_id=op_id
+        )
+
+        async def _iter() -> Any:
+            for row in chunk_rows:
+                yield ChunkContext(
+                    chunk_id=row["chunk_id"],
+                    chunk_text=row["chunk_text"],
+                    payload={"pairs": row["pairs"]},
+                    ontology=self._global_ontology,
+                )
+
+        rel_desc_line = f"- description: {relation.description}\n" if relation.description else ""
+
+        def _prompt(ctx: ChunkContext) -> str:
+            pair_lines = "\n".join(
+                f"- {p.get('src_name') or p.get('src_id')} → {p.get('tgt_name') or p.get('tgt_id')}"
+                for p in ctx.payload["pairs"]
+            ) or "(none)"
+            return BACKFILL_RELATION_PATTERN_PROMPT.format(
+                rel_label=rel_label,
+                src_label=source,
+                tgt_label=target,
+                rel_description=rel_desc_line,
+                pairs_block=pair_lines,
+                chunk_text=ctx.chunk_text,
+            )
+
+        def _parse(text: str, _ctx: ChunkContext) -> list[dict[str, Any]]:
+            payload = _strip_and_load_json(text)
+            return payload.get("links", []) if isinstance(payload, dict) else []
+
+        async def _merge(
+            parsed: list[dict[str, Any]], ctx: ChunkContext
+        ) -> BackfillMergeStats:
+            filled = skipped = 0
+            by_src = {
+                (p.get("src_name") or "").strip(): p for p in ctx.payload["pairs"]
+            }
+            by_tgt = {
+                (p.get("tgt_name") or "").strip(): p for p in ctx.payload["pairs"]
+            }
+            new_edges: list[GraphRelationship] = []
+            for link in parsed:
+                src_name = (link.get("src") or "").strip()
+                tgt_name = (link.get("tgt") or "").strip()
+                src_pair = by_src.get(src_name)
+                tgt_pair = by_tgt.get(tgt_name)
+                if src_pair is None or tgt_pair is None:
+                    skipped += 1
+                    continue
+                new_edges.append(
+                    GraphRelationship(
+                        start_node_id=src_pair["src_id"],
+                        end_node_id=tgt_pair["tgt_id"],
+                        type=rel_label,
+                        properties={
+                            "description": link.get("description", ""),
+                            "source_chunk_ids": [ctx.chunk_id],
+                        },
+                    )
+                )
+                filled += 1
+            if new_edges:
+                await self._graph_store.upsert_relationships(new_edges)
+            return BackfillMergeStats(values_filled=filled, values_skipped=skipped)
+
+        executor = BackfillExecutor(self.llm, self._graph_store, concurrency=concurrency)
+        result = await executor.run(
+            op_id=op_id,
+            chunks=_iter(),
+            prompt_builder=_prompt,
+            parse_fn=_parse,
+            merge_fn=_merge,
+        )
+        result.target_nodes = sum(len(r["pairs"]) for r in chunk_rows)
+        return result
+
+    async def backfill_attribute_semantic(
+        self,
+        owner_label: str,
+        name: str,
+        target_type: str,
+        *,
+        concurrency: int = 4,
+    ) -> BackfillResult:
+        """LLM-assisted coercion of an attribute's existing string values
+        to ``target_type``. Use when mechanical Cypher coercion would
+        drop too many values (e.g. ``"twelve"`` → 12, free-form dates
+        → ISO 8601).
+
+        Operates on existing node values directly — no chunk re-scan.
+        Updates the ontology graph's declared type once values land;
+        nodes whose value couldn't be coerced have the property
+        dropped.
+        """
+        await self._ensure_ontology_initialized()
+        kind = self._resolve_owner_kind(owner_label)
+        if kind != "entity":
+            raise ValueError(
+                "backfill_attribute_semantic on relation owners is not "
+                "implemented in v1 (relation-property coercion would require "
+                "iterating edges)."
+            )
+        rows = await self._graph_store.list_node_values_for_semantic_coerce(
+            owner_label, name
+        )
+        op_id = f"backfill_attribute_semantic:{owner_label}:{name}:{target_type}"
+
+        result = BackfillResult(operation_id=op_id, target_nodes=len(rows))
+        import time as _time
+
+        start = _time.monotonic()
+        sem = asyncio.Semaphore(concurrency)
+
+        async def _coerce_one(node_id: str, current: Any) -> None:
+            async with sem:
+                try:
+                    prompt = BACKFILL_SEMANTIC_COERCION_PROMPT.format(
+                        owner_label=owner_label,
+                        attr_name=name,
+                        target_type=target_type,
+                        current_value=current,
+                    )
+                    response = await self.llm.ainvoke(prompt)
+                    result.llm_calls += 1
+                    payload = _strip_and_load_json(response.content)
+                    new_value = payload.get("value") if isinstance(payload, dict) else None
+                    if new_value is None:
+                        await self._graph_store.set_node_property_by_id(
+                            owner_label, node_id, name, None
+                        )
+                        result.dropped_for_coercion += 1
+                        return
+                    ok, coerced = _coerce_attribute_value(new_value, target_type)
+                    if not ok:
+                        await self._graph_store.set_node_property_by_id(
+                            owner_label, node_id, name, None
+                        )
+                        result.dropped_for_coercion += 1
+                        return
+                    await self._graph_store.set_node_property_by_id(
+                        owner_label, node_id, name, coerced
+                    )
+                    result.values_filled += 1
+                except Exception as exc:
+                    logger.warning(
+                        "backfill_attribute_semantic: node %s failed: %s",
+                        node_id, exc,
+                    )
+                    result.failed_chunks.append(node_id)
+
+        await asyncio.gather(*[_coerce_one(nid, val) for nid, val in rows])
+        # After coercion, update the ontology graph's declared type.
+        await self._ontology_store.retype_property(
+            "entity", owner_label, name, target_type
+        )
+        result.elapsed_s = _time.monotonic() - start
+        await self._refresh_global_ontology()
+        return result
 
     # ── Graph admin ──────────────────────────────────────────────
 

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -446,8 +446,8 @@ class GraphRAG:
     # Three tiers (see plan & module docstring of ingestion/backfill.py):
     #
     # - **Group 1** — pure ontology changes (descriptions, declarations).
-    # - **Group 2** — mechanical data migration via Cypher (renames,
-    #   drops, mechanical retypes).
+    # - **Group 2** — mechanical data migration via Cypher (renames
+    #   and drops).
     # - **Group 3** — LLM-driven re-scan over stored chunks.
     #
     # Each method is a thin orchestrator: it validates input against the
@@ -551,6 +551,7 @@ class GraphRAG:
         attribute: Attribute,
         *,
         concurrency: int = 4,
+        dry_run: bool = False,
     ) -> EvolutionResult:
         """Atomically declare an attribute and populate it from existing chunks.
 
@@ -574,13 +575,15 @@ class GraphRAG:
         idempotent.
 
         Cost: ~one LLM call per chunk that mentions an ``owner_label``
-        entity. Use sparingly on large corpora.
+        entity. See the :doc:`Concurrency rule </ontology-evolution>` in
+        the docs.
 
-        **Concurrency rule:** do NOT run ``ingest()`` concurrently with
-        ``add_attribute()``. The extractor reads the persisted ontology to
-        decide what to extract; while ``add_attribute`` is mid-flight, new
-        ingests would produce entities without the new attribute and leave
-        the data graph misaligned. Coordinate at the application level.
+        Pass ``dry_run=True`` to preview the LLM cost without invoking it.
+        The returned :py:class:`EvolutionResult` carries
+        ``chunks_in_scope`` (the count this run *would* scan); no LLM is
+        invoked and no ontology write happens. Cost preview is accurate
+        for this single run — chunk markers from prior partial runs are
+        already filtered into the count.
 
         v1: entity owners only. Relation-attribute evolution raises
         ``NotImplementedError`` — workaround is ``delete_all()`` followed by
@@ -604,6 +607,16 @@ class GraphRAG:
                 f"values from the chunks."
             )
 
+        if dry_run:
+            op_id = f"add_attribute:{owner_label}:{attribute.name}:{attribute.type}"
+            chunks = await self._graph_store.list_chunks_for_attribute_backfill(
+                owner_label, attribute.name, op_id=op_id
+            )
+            return EvolutionResult(
+                ontology=self._global_ontology,
+                chunks_in_scope=len(chunks),
+            )
+
         backfill = await self._run_atomic_attribute_backfill(
             owner_label, attribute, concurrency=concurrency
         )
@@ -613,6 +626,7 @@ class GraphRAG:
         refreshed = await self._refresh_global_ontology()
         return EvolutionResult(
             ontology=refreshed,
+            chunks_in_scope=backfill.chunks_scanned + backfill.chunks_skipped,
             chunks_scanned=backfill.chunks_scanned,
             chunks_skipped=backfill.chunks_skipped,
             llm_calls=backfill.llm_calls,
@@ -662,17 +676,26 @@ class GraphRAG:
         return await self._refresh_global_ontology()
 
     async def rename_attribute(self, owner_label: str, old_name: str, new_name: str) -> Ontology:
-        """Rename an attribute on an entity (data + ontology) or on a
-        relation (ontology only — relation-property data migration is
-        not implemented in this version; a warning is logged).
+        """Rename an attribute on an entity in data + ontology, atomically.
 
         Validates that ``old_name`` exists and ``new_name`` does not before
         touching either graph — without this guard a typo silently no-ops
         the rename, and a collision with an existing attribute would
         overwrite values on the data graph.
+
+        v1: entity owners only. Relation-attribute evolution raises
+        ``NotImplementedError`` — workaround is ``delete_all()`` followed by
+        a fresh ``ingest()`` against the updated ontology.
         """
         await self._ensure_ontology_initialized()
         kind = self._resolve_owner_kind(owner_label)
+        if kind != "entity":
+            raise NotImplementedError(
+                f"rename_attribute on relation owners is not implemented "
+                f"(label={owner_label!r}). Relation-attribute evolution would "
+                f"require iterating edges; for now, delete_all() and re-ingest "
+                f"with the updated ontology."
+            )
         if old_name == new_name:
             return self._global_ontology
         owner = self._owner_for_kind(owner_label, kind)
@@ -687,17 +710,9 @@ class GraphRAG:
                 f"Attribute {owner_label}.{new_name!r} already exists; "
                 f"merging attributes is not supported by rename_attribute."
             )
-        nodes_touched = 0
-        if kind == "entity":
-            nodes_touched = await self._graph_store.rename_node_property(
-                owner_label, old_name, new_name
-            )
-        else:
-            logger.warning(
-                "rename_attribute on relation %s: skipping data-graph property "
-                "rename (edge-property rename is out of scope for v1).",
-                owner_label,
-            )
+        nodes_touched = await self._graph_store.rename_node_property(
+            owner_label, old_name, new_name
+        )
         await self._ontology_store.rename_property_label(kind, owner_label, old_name, new_name)
         logger.info(
             "rename_attribute %s.%s → %s: %d nodes touched",
@@ -941,6 +956,7 @@ class GraphRAG:
         *,
         scope: str | list[str] = "all",
         concurrency: int = 4,
+        dry_run: bool = False,
     ) -> BackfillResult:
         """Find new instances of a newly-declared entity type by re-scanning
         chunks.
@@ -952,6 +968,11 @@ class GraphRAG:
         Newly-found entities are inserted with ``MENTIONED_IN`` edges to
         the originating chunk. Cost is proportional to the chunk count
         in scope.
+
+        Pass ``dry_run=True`` to preview the LLM cost without invoking
+        it. The returned :py:class:`BackfillResult` carries
+        ``chunks_in_scope`` (the count this run *would* scan) and
+        nothing else.
         """
         await self._ensure_ontology_initialized()
         entity = next(
@@ -970,6 +991,12 @@ class GraphRAG:
         chunk_rows = await self._graph_store.list_chunks_for_entity_backfill(
             op_id=op_id, chunk_ids=chunk_ids
         )
+        if dry_run:
+            return BackfillResult(
+                operation_id=op_id,
+                chunks_in_scope=len(chunk_rows),
+                target_nodes=len(chunk_rows),
+            )
 
         async def _iter() -> Any:
             for row in chunk_rows:
@@ -1056,6 +1083,9 @@ class GraphRAG:
             await self._graph_store.count_chunks_marked_with_op(op_id)
             - (result.chunks_scanned + len(result.failed_chunks)),
         )
+        result.chunks_in_scope = (
+            result.chunks_scanned + result.chunks_skipped + len(result.failed_chunks)
+        )
         return result
 
     async def backfill_relation_pattern(
@@ -1066,6 +1096,7 @@ class GraphRAG:
         *,
         scope: str = "candidate-pairs",
         concurrency: int = 4,
+        dry_run: bool = False,
     ) -> BackfillResult:
         """Find new ``(source) -[rel_label]-> (target)`` edges by asking
         the LLM about candidate co-mention pairs in already-ingested
@@ -1075,6 +1106,11 @@ class GraphRAG:
         scan to chunks where both source-type and target-type entities
         co-occur — the universe of plausible new edges. Edges that
         already exist between the same pair are skipped at MERGE time.
+
+        Pass ``dry_run=True`` to preview the LLM cost without invoking
+        it. The returned :py:class:`BackfillResult` carries
+        ``chunks_in_scope`` (the count this run *would* scan) and
+        nothing else.
         """
         if scope != "candidate-pairs":
             raise ValueError(
@@ -1093,6 +1129,12 @@ class GraphRAG:
         chunk_rows = await self._graph_store.list_chunks_for_relation_pattern_backfill(
             source, target, op_id=op_id
         )
+        if dry_run:
+            return BackfillResult(
+                operation_id=op_id,
+                chunks_in_scope=len(chunk_rows),
+                target_nodes=sum(len(r["pairs"]) for r in chunk_rows),
+            )
 
         async def _iter() -> Any:
             for row in chunk_rows:
@@ -1179,6 +1221,9 @@ class GraphRAG:
             0,
             await self._graph_store.count_chunks_marked_with_op(op_id)
             - (result.chunks_scanned + len(result.failed_chunks)),
+        )
+        result.chunks_in_scope = (
+            result.chunks_scanned + result.chunks_skipped + len(result.failed_chunks)
         )
         return result
 

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -1183,47 +1183,63 @@ class GraphRAG:
         import time as _time
 
         start = _time.monotonic()
-        sem = asyncio.Semaphore(concurrency)
+        # Worker-pool pattern: live task count stays O(concurrency)
+        # regardless of len(rows). With a plain asyncio.gather + per-row
+        # task, a 100k-node coercion would create 100k pending tasks up
+        # front, holding their captured state in memory until completion.
+        queue: asyncio.Queue[tuple[str, Any] | None] = asyncio.Queue(maxsize=concurrency * 2)
 
-        async def _coerce_one(node_id: str, current: Any) -> None:
-            async with sem:
+        async def _worker() -> None:
+            while True:
+                item = await queue.get()
                 try:
-                    prompt = BACKFILL_SEMANTIC_COERCION_PROMPT.format(
-                        owner_label=owner_label,
-                        attr_name=name,
-                        target_type=target_type,
-                        current_value=current,
-                    )
-                    response = await self.llm.ainvoke(prompt)
-                    result.llm_calls += 1
-                    payload = _strip_and_load_json(response.content)
-                    new_value = payload.get("value") if isinstance(payload, dict) else None
-                    if new_value is None:
-                        await self._graph_store.set_node_property_by_id(
-                            owner_label, node_id, name, None
-                        )
-                        result.dropped_for_coercion += 1
+                    if item is None:
                         return
-                    ok, coerced = _coerce_attribute_value(new_value, target_type)
-                    if not ok:
-                        await self._graph_store.set_node_property_by_id(
-                            owner_label, node_id, name, None
+                    node_id, current = item
+                    try:
+                        prompt = BACKFILL_SEMANTIC_COERCION_PROMPT.format(
+                            owner_label=owner_label,
+                            attr_name=name,
+                            target_type=target_type,
+                            current_value=current,
                         )
-                        result.dropped_for_coercion += 1
-                        return
-                    await self._graph_store.set_node_property_by_id(
-                        owner_label, node_id, name, coerced
-                    )
-                    result.values_filled += 1
-                except Exception as exc:
-                    logger.warning(
-                        "backfill_attribute_semantic: node %s failed: %s",
-                        node_id,
-                        exc,
-                    )
-                    result.failed_node_ids.append(node_id)
+                        response = await self.llm.ainvoke(prompt)
+                        result.llm_calls += 1
+                        payload = _strip_and_load_json(response.content)
+                        new_value = payload.get("value") if isinstance(payload, dict) else None
+                        if new_value is None:
+                            await self._graph_store.set_node_property_by_id(
+                                owner_label, node_id, name, None
+                            )
+                            result.dropped_for_coercion += 1
+                            continue
+                        ok, coerced = _coerce_attribute_value(new_value, target_type)
+                        if not ok:
+                            await self._graph_store.set_node_property_by_id(
+                                owner_label, node_id, name, None
+                            )
+                            result.dropped_for_coercion += 1
+                            continue
+                        await self._graph_store.set_node_property_by_id(
+                            owner_label, node_id, name, coerced
+                        )
+                        result.values_filled += 1
+                    except Exception as exc:
+                        logger.warning(
+                            "backfill_attribute_semantic: node %s failed: %s",
+                            node_id,
+                            exc,
+                        )
+                        result.failed_node_ids.append(node_id)
+                finally:
+                    queue.task_done()
 
-        await asyncio.gather(*[_coerce_one(nid, val) for nid, val in rows])
+        workers = [asyncio.create_task(_worker()) for _ in range(concurrency)]
+        for node_id, value in rows:
+            await queue.put((node_id, value))
+        for _ in workers:
+            await queue.put(None)
+        await asyncio.gather(*workers)
         # After coercion, update the ontology graph's declared type.
         await self._ontology_store.retype_property("entity", owner_label, name, target_type)
         result.elapsed_s = _time.monotonic() - start

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
@@ -5,9 +5,11 @@ attribute on an existing entity type, a brand-new entity type, a brand-new
 relation pattern), we need to re-scan the stored chunks and ask the LLM to
 fill the new shape in.
 
-The :py:class:`BackfillExecutor` owns the concurrency, retries, and
-per-chunk idempotency-marker bookkeeping. The caller supplies four
-operation-specific callbacks:
+The :py:class:`BackfillExecutor` owns the concurrency and per-chunk
+idempotency-marker bookkeeping. (Per-call retries are delegated to
+``LLMInterface.ainvoke`` — the executor itself does not retry; failed
+chunks land in ``BackfillResult.failed_chunks`` for caller-driven
+retry.) The caller supplies four operation-specific callbacks:
 
 - a scope iterator that yields :py:class:`ChunkContext` rows;
 - a ``prompt_builder`` that produces a focused per-chunk prompt;
@@ -65,8 +67,17 @@ class BackfillResult:
     """Post-run summary of a backfill operation.
 
     Returned by every Group-3 ``GraphRAG`` method. ``failed_chunks`` carries
-    the chunk ids that raised so the caller can retry just those; the
+    chunk ids that raised so the caller can retry just those; the
     operation as a whole does not raise on per-chunk failures.
+
+    ``failed_node_ids`` is the parallel field for operations that don't
+    iterate chunks (``backfill_attribute_semantic`` walks node values
+    directly). Both lists are present so callers always know what to
+    retry without parsing the operation_id.
+
+    ``chunks_skipped`` counts chunks already marked with the same
+    ``op_id`` from a prior run — i.e. work this run did NOT have to redo.
+    Read it to confirm idempotency on reruns.
 
     ``estimated_cost_usd`` is ``None`` in v1 — :py:class:`LLMInterface` does
     not expose usage stats. A future provider-specific hook can populate it.
@@ -81,6 +92,7 @@ class BackfillResult:
     values_skipped: int = 0
     dropped_for_coercion: int = 0
     failed_chunks: list[str] = field(default_factory=list)
+    failed_node_ids: list[str] = field(default_factory=list)
     elapsed_s: float = 0.0
     estimated_cost_usd: float | None = None
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
@@ -97,6 +97,55 @@ class BackfillResult:
     estimated_cost_usd: float | None = None
 
 
+@dataclass
+class EvolutionResult:
+    """Return value of an atomic ontology-evolution call.
+
+    Carries the refreshed ontology plus the observability counters from
+    the internal LLM backfill. Returned by ``GraphRAG.add_attribute``
+    and any future atomic-evolve methods. On a successful return:
+
+    - The ontology graph has been updated.
+    - Every chunk in scope was processed (LLM call + merge) or skipped
+      because a prior idempotent run already marked it.
+    - ``failed_chunks`` is empty — hard failures would have raised
+      :py:class:`OntologyEvolutionError` instead.
+    """
+
+    ontology: Any  # graphrag_sdk.core.models.Ontology (avoid circular import)
+    chunks_scanned: int = 0
+    chunks_skipped: int = 0
+    llm_calls: int = 0
+    values_filled: int = 0
+    values_skipped: int = 0  # LLM returned null
+    elapsed_s: float = 0.0
+
+
+class OntologyEvolutionError(RuntimeError):
+    """Raised when an atomic evolution call cannot complete its data migration.
+
+    The ontology graph is NOT updated when this is raised — the data graph
+    has been partially mutated but the schema still reflects the pre-call
+    state. Re-running the same evolution call is safe and idempotent
+    (chunk markers ensure already-processed chunks are skipped).
+
+    Inspect :py:attr:`failed_chunks` to identify the chunks that hard-failed
+    (LLM error, parse error, etc.) so the underlying cause can be addressed
+    before retry.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failed_chunks: list[str],
+        chunks_scanned: int,
+    ) -> None:
+        super().__init__(message)
+        self.failed_chunks = list(failed_chunks)
+        self.chunks_scanned = chunks_scanned
+
+
 PromptBuilder = Callable[[ChunkContext], str]
 ParseFn = Callable[[str, ChunkContext], Any]
 MergeFn = Callable[[Any, ChunkContext], Awaitable[BackfillMergeStats]]

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
@@ -138,39 +138,56 @@ class BackfillExecutor:
         ``chunks`` is consumed once. ``op_id`` is the deterministic
         operation signature used both for the chunk marker and the
         ``BackfillResult.operation_id`` echo.
+
+        Concurrency is bounded by a worker-pool pattern: ``concurrency``
+        long-lived worker tasks consume ``ChunkContext`` instances from a
+        bounded :py:class:`asyncio.Queue`. Live ``asyncio.Task`` count is
+        therefore O(concurrency) regardless of corpus size — without this
+        pattern, a 50k-chunk backfill would create 50k pending tasks up
+        front and hold them all in memory.
         """
         result = BackfillResult(operation_id=op_id)
         start = time.monotonic()
-        sem = asyncio.Semaphore(self._concurrency)
+        # Queue size = 2x concurrency to keep workers warm without
+        # backpressuring the producer too eagerly.
+        queue: asyncio.Queue[ChunkContext | None] = asyncio.Queue(maxsize=self._concurrency * 2)
 
-        async def _process_one(ctx: ChunkContext) -> None:
-            async with sem:
+        async def _worker() -> None:
+            while True:
+                ctx = await queue.get()
                 try:
-                    prompt = prompt_builder(ctx)
-                    response = await self._llm.ainvoke(prompt)
-                    result.llm_calls += 1
-                    parsed = parse_fn(response.content, ctx)
-                    stats = await merge_fn(parsed, ctx)
-                    result.values_filled += stats.values_filled
-                    result.values_skipped += stats.values_skipped
-                    result.dropped_for_coercion += stats.dropped_for_coercion
-                    await self._graph_store.mark_chunk_extracted(ctx.chunk_id, op_id)
-                    result.chunks_scanned += 1
-                except Exception as exc:
-                    logger.warning(
-                        "Backfill chunk %s failed for op '%s': %s",
-                        ctx.chunk_id,
-                        op_id,
-                        exc,
-                    )
-                    logger.debug("Backfill chunk failure details", exc_info=True)
-                    result.failed_chunks.append(ctx.chunk_id)
+                    if ctx is None:
+                        return
+                    try:
+                        prompt = prompt_builder(ctx)
+                        response = await self._llm.ainvoke(prompt)
+                        result.llm_calls += 1
+                        parsed = parse_fn(response.content, ctx)
+                        stats = await merge_fn(parsed, ctx)
+                        result.values_filled += stats.values_filled
+                        result.values_skipped += stats.values_skipped
+                        result.dropped_for_coercion += stats.dropped_for_coercion
+                        await self._graph_store.mark_chunk_extracted(ctx.chunk_id, op_id)
+                        result.chunks_scanned += 1
+                    except Exception as exc:
+                        logger.warning(
+                            "Backfill chunk %s failed for op '%s': %s",
+                            ctx.chunk_id,
+                            op_id,
+                            exc,
+                        )
+                        logger.debug("Backfill chunk failure details", exc_info=True)
+                        result.failed_chunks.append(ctx.chunk_id)
+                finally:
+                    queue.task_done()
 
-        tasks: list[asyncio.Task[None]] = []
+        workers = [asyncio.create_task(_worker()) for _ in range(self._concurrency)]
         async for ctx in chunks:
-            tasks.append(asyncio.create_task(_process_one(ctx)))
-        if tasks:
-            await asyncio.gather(*tasks)
+            await queue.put(ctx)
+        # One sentinel per worker — graceful stop after the queue drains.
+        for _ in workers:
+            await queue.put(None)
+        await asyncio.gather(*workers)
 
         result.elapsed_s = time.monotonic() - start
         logger.info(

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
@@ -108,8 +108,9 @@ class EvolutionResult:
     - The ontology graph has been updated.
     - Every chunk in scope was processed (LLM call + merge) or skipped
       because a prior idempotent run already marked it.
-    - ``failed_chunks`` is empty — hard failures would have raised
-      :py:class:`OntologyEvolutionError` instead.
+    - No chunk failures remain — hard failures would have raised
+      :py:class:`OntologyEvolutionError` instead, which carries the
+      failing chunk ids on ``OntologyEvolutionError.failed_chunks``.
     """
 
     ontology: Any  # graphrag_sdk.core.models.Ontology (avoid circular import)

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
@@ -66,18 +66,18 @@ class BackfillMergeStats:
 class BackfillResult:
     """Post-run summary of a backfill operation.
 
-    Returned by every Group-3 ``GraphRAG`` method. ``failed_chunks`` carries
-    chunk ids that raised so the caller can retry just those; the
-    operation as a whole does not raise on per-chunk failures.
-
-    ``failed_node_ids`` is the parallel field for operations that don't
-    iterate chunks (``backfill_attribute_semantic`` walks node values
-    directly). Both lists are present so callers always know what to
-    retry without parsing the operation_id.
+    Returned by the opportunistic-discovery methods
+    (``GraphRAG.backfill_entity`` and ``GraphRAG.backfill_relation_pattern``).
+    ``failed_chunks`` carries chunk ids that raised so the caller can retry
+    just those; these methods do not raise on per-chunk failures.
 
     ``chunks_skipped`` counts chunks already marked with the same
     ``op_id`` from a prior run — i.e. work this run did NOT have to redo.
     Read it to confirm idempotency on reruns.
+
+    ``chunks_in_scope`` is the total chunks that match the scope query
+    before the marker filter — populated even on a dry run so callers
+    can preview LLM cost before incurring it.
 
     ``estimated_cost_usd`` is ``None`` in v1 — :py:class:`LLMInterface` does
     not expose usage stats. A future provider-specific hook can populate it.
@@ -85,6 +85,7 @@ class BackfillResult:
 
     operation_id: str
     target_nodes: int = 0
+    chunks_in_scope: int = 0
     chunks_scanned: int = 0
     chunks_skipped: int = 0
     llm_calls: int = 0
@@ -92,7 +93,6 @@ class BackfillResult:
     values_skipped: int = 0
     dropped_for_coercion: int = 0
     failed_chunks: list[str] = field(default_factory=list)
-    failed_node_ids: list[str] = field(default_factory=list)
     elapsed_s: float = 0.0
     estimated_cost_usd: float | None = None
 
@@ -111,9 +111,17 @@ class EvolutionResult:
     - No chunk failures remain — hard failures would have raised
       :py:class:`OntologyEvolutionError` instead, which carries the
       failing chunk ids on ``OntologyEvolutionError.failed_chunks``.
+
+    ``chunks_in_scope`` is the total chunks the scope query matched
+    before the marker filter. Populated even on a dry run so callers
+    can preview LLM cost before incurring it.
+
+    On a ``dry_run=True`` call ``chunks_in_scope`` is the only
+    meaningful field — no LLM was invoked, no ontology was written.
     """
 
     ontology: Any  # graphrag_sdk.core.models.Ontology (avoid circular import)
+    chunks_in_scope: int = 0
     chunks_scanned: int = 0
     chunks_skipped: int = 0
     llm_calls: int = 0

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
@@ -1,0 +1,171 @@
+"""LLM-driven backfill executor for ontology evolution.
+
+When the ontology gains structure that already-ingested data lacks (a new
+attribute on an existing entity type, a brand-new entity type, a brand-new
+relation pattern), we need to re-scan the stored chunks and ask the LLM to
+fill the new shape in.
+
+The :py:class:`BackfillExecutor` owns the concurrency, retries, and
+per-chunk idempotency-marker bookkeeping. The caller supplies four
+operation-specific callbacks:
+
+- a scope iterator that yields :py:class:`ChunkContext` rows;
+- a ``prompt_builder`` that produces a focused per-chunk prompt;
+- a ``parse_fn`` that validates the LLM JSON;
+- a ``merge_fn`` that writes the parsed payload into the data graph.
+
+Markers live on the chunk node (``c.extracted_ops: list[string]``).
+``op_id`` is deterministic from the operation signature, so re-running the
+same backfill skips already-processed chunks naturally — see the module
+docstring of :py:mod:`graphrag_sdk.api.main` for the full evolution model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from graphrag_sdk.core.models import Ontology
+from graphrag_sdk.core.providers import LLMInterface
+from graphrag_sdk.storage.graph_store import GraphStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ChunkContext:
+    """Payload handed to ``prompt_builder`` / ``parse_fn`` / ``merge_fn``.
+
+    Carries the chunk identity, raw text, the in-scope entities (per the
+    scope query that produced this row), and a snapshot of the ontology
+    so prompt rendering doesn't have to round-trip to storage.
+    """
+
+    chunk_id: str
+    chunk_text: str
+    payload: dict[str, Any]
+    ontology: Ontology
+
+
+@dataclass(frozen=True)
+class BackfillMergeStats:
+    """Counts returned by ``merge_fn`` after writing one chunk's payload."""
+
+    values_filled: int = 0
+    values_skipped: int = 0
+    dropped_for_coercion: int = 0
+
+
+@dataclass
+class BackfillResult:
+    """Post-run summary of a backfill operation.
+
+    Returned by every Group-3 ``GraphRAG`` method. ``failed_chunks`` carries
+    the chunk ids that raised so the caller can retry just those; the
+    operation as a whole does not raise on per-chunk failures.
+
+    ``estimated_cost_usd`` is ``None`` in v1 — :py:class:`LLMInterface` does
+    not expose usage stats. A future provider-specific hook can populate it.
+    """
+
+    operation_id: str
+    target_nodes: int = 0
+    chunks_scanned: int = 0
+    chunks_skipped: int = 0
+    llm_calls: int = 0
+    values_filled: int = 0
+    values_skipped: int = 0
+    dropped_for_coercion: int = 0
+    failed_chunks: list[str] = field(default_factory=list)
+    elapsed_s: float = 0.0
+    estimated_cost_usd: float | None = None
+
+
+PromptBuilder = Callable[[ChunkContext], str]
+ParseFn = Callable[[str, ChunkContext], Any]
+MergeFn = Callable[[Any, ChunkContext], Awaitable[BackfillMergeStats]]
+
+
+class BackfillExecutor:
+    """Drive an LLM-backed re-scan over already-ingested chunks.
+
+    Concurrency-bounded (``asyncio.Semaphore``), per-chunk-idempotent
+    (``GraphStore.mark_chunk_extracted``), and resilient — a chunk that
+    raises during parse/merge lands in ``BackfillResult.failed_chunks``
+    and the run continues.
+    """
+
+    def __init__(
+        self,
+        llm: LLMInterface,
+        graph_store: GraphStore,
+        *,
+        concurrency: int = 4,
+    ) -> None:
+        if concurrency < 1:
+            raise ValueError("concurrency must be >= 1")
+        self._llm = llm
+        self._graph_store = graph_store
+        self._concurrency = concurrency
+
+    async def run(
+        self,
+        *,
+        op_id: str,
+        chunks: AsyncIterator[ChunkContext],
+        prompt_builder: PromptBuilder,
+        parse_fn: ParseFn,
+        merge_fn: MergeFn,
+    ) -> BackfillResult:
+        """Execute the backfill. See module docstring for callback contracts.
+
+        ``chunks`` is consumed once. ``op_id`` is the deterministic
+        operation signature used both for the chunk marker and the
+        ``BackfillResult.operation_id`` echo.
+        """
+        result = BackfillResult(operation_id=op_id)
+        start = time.monotonic()
+        sem = asyncio.Semaphore(self._concurrency)
+
+        async def _process_one(ctx: ChunkContext) -> None:
+            async with sem:
+                try:
+                    prompt = prompt_builder(ctx)
+                    response = await self._llm.ainvoke(prompt)
+                    result.llm_calls += 1
+                    parsed = parse_fn(response.content, ctx)
+                    stats = await merge_fn(parsed, ctx)
+                    result.values_filled += stats.values_filled
+                    result.values_skipped += stats.values_skipped
+                    result.dropped_for_coercion += stats.dropped_for_coercion
+                    await self._graph_store.mark_chunk_extracted(ctx.chunk_id, op_id)
+                    result.chunks_scanned += 1
+                except Exception as exc:
+                    logger.warning(
+                        "Backfill chunk %s failed for op '%s': %s",
+                        ctx.chunk_id, op_id, exc,
+                    )
+                    logger.debug("Backfill chunk failure details", exc_info=True)
+                    result.failed_chunks.append(ctx.chunk_id)
+
+        tasks: list[asyncio.Task[None]] = []
+        async for ctx in chunks:
+            tasks.append(asyncio.create_task(_process_one(ctx)))
+        if tasks:
+            await asyncio.gather(*tasks)
+
+        result.elapsed_s = time.monotonic() - start
+        logger.info(
+            "Backfill op '%s' done — scanned=%d failed=%d filled=%d skipped=%d elapsed=%.2fs",
+            op_id,
+            result.chunks_scanned,
+            len(result.failed_chunks),
+            result.values_filled,
+            result.values_skipped,
+            result.elapsed_s,
+        )
+        return result

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/backfill.py
@@ -147,7 +147,9 @@ class BackfillExecutor:
                 except Exception as exc:
                     logger.warning(
                         "Backfill chunk %s failed for op '%s': %s",
-                        ctx.chunk_id, op_id, exc,
+                        ctx.chunk_id,
+                        op_id,
+                        exc,
                     )
                     logger.debug("Backfill chunk failure details", exc_info=True)
                     result.failed_chunks.append(ctx.chunk_id)

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -165,24 +165,6 @@ BACKFILL_RELATION_PATTERN_PROMPT = (
     "Return ONLY valid JSON, nothing else."
 )
 
-BACKFILL_SEMANTIC_COERCION_PROMPT = (
-    "You are coercing a property value to a target type using semantic "
-    "understanding (mechanical toInteger/toFloat coercion already failed or "
-    "doesn't apply).\n\n"
-    "## Property\n"
-    "- owner label: {owner_label}\n"
-    "- name: {attr_name}\n"
-    "- target type: {target_type}\n\n"
-    "## Current value\n"
-    "{current_value!r}\n\n"
-    "## Instructions\n"
-    "Return the value coerced to the target type, or null if no sensible "
-    "coercion exists. For DATE, prefer ISO 8601 (YYYY-MM-DD). For numeric "
-    "targets, extract the canonical number. For LIST, split sensibly.\n\n"
-    'Return ONLY a JSON object: {{"value": <coerced value or null>}}\n\n'
-    "Return ONLY valid JSON, nothing else."
-)
-
 
 def _format_property_for_prompt(prop: Attribute) -> str:
     desc = f" — {prop.description}" if prop.description else ""

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -96,6 +96,94 @@ _JSON_EXAMPLE_WITH_ATTRS = (
 )
 
 
+# ── Backfill prompts (LLM-driven ontology evolution) ────────────────
+#
+# These are NARROWER than VERIFY_EXTRACT_RELS_PROMPT — each focuses on a
+# single new piece of structure (one attribute, one entity label, one
+# relation pattern) so the LLM doesn't have to juggle the whole ontology
+# while doing a corrective pass. Used by GraphRAG.backfill_* methods via
+# BackfillExecutor; see ingestion/backfill.py.
+
+BACKFILL_ATTRIBUTE_PROMPT = (
+    "You are extracting a SINGLE new attribute for already-known entities.\n\n"
+    "## Entity type: {owner_label}\n"
+    "## New attribute\n"
+    "- name: {attr_name}\n"
+    "- type: {attr_type}\n"
+    "{attr_description}\n\n"
+    "## Entities mentioned in this chunk\n"
+    "{entities_block}\n\n"
+    "## Chunk text\n"
+    "{chunk_text}\n\n"
+    "## Instructions\n"
+    "For each entity above, decide whether the chunk states or strongly implies "
+    "a value for the new attribute. If yes, return the value (typed to match the "
+    "attribute's declared type). If no, return null — do not guess.\n\n"
+    "Return ONLY a JSON object mapping entity name → value or null:\n"
+    '{{"results": {{"Entity Name": "value or null", ...}}}}\n\n'
+    "Return ONLY valid JSON, nothing else."
+)
+
+BACKFILL_ENTITY_PROMPT = (
+    "You are extracting entities of a SINGLE new label from text that has "
+    "already been processed for other labels.\n\n"
+    "## Target entity type\n"
+    "- label: {target_label}\n"
+    "{target_description}\n"
+    "## Declared attributes (extract when present)\n"
+    "{attribute_block}\n\n"
+    "## Chunk text\n"
+    "{chunk_text}\n\n"
+    "## Instructions\n"
+    "Find every distinct entity of the target type in the chunk. For each,\n"
+    "provide its name as it appears in the text plus any declared attributes "
+    "that the chunk states.\n\n"
+    "Return ONLY a JSON object:\n"
+    '{{"entities": [{{"name": "...", "description": "...", "attributes": {{}}}}, ...]}}\n\n'
+    "Return ONLY valid JSON, nothing else."
+)
+
+BACKFILL_RELATION_PATTERN_PROMPT = (
+    "You are extracting a SINGLE new relation pattern between already-known "
+    "entities.\n\n"
+    "## Relation\n"
+    "- type: {rel_label}\n"
+    "- pattern: ({src_label}) -[{rel_label}]-> ({tgt_label})\n"
+    "{rel_description}\n\n"
+    "## Candidate entity pairs in this chunk\n"
+    "{pairs_block}\n\n"
+    "## Chunk text\n"
+    "{chunk_text}\n\n"
+    "## Instructions\n"
+    "For each candidate pair, decide whether the chunk states a relationship "
+    "of the target type from source to target. Return only the pairs that ARE "
+    "linked. Skip uncertain or absent cases — false positives are worse than "
+    "misses.\n\n"
+    "Return ONLY a JSON object:\n"
+    '{{"links": [{{"src": "Source Name", "tgt": "Target Name", '
+    '"description": "..."}}, ...]}}\n\n'
+    "Return ONLY valid JSON, nothing else."
+)
+
+BACKFILL_SEMANTIC_COERCION_PROMPT = (
+    "You are coercing a property value to a target type using semantic "
+    "understanding (mechanical toInteger/toFloat coercion already failed or "
+    "doesn't apply).\n\n"
+    "## Property\n"
+    "- owner label: {owner_label}\n"
+    "- name: {attr_name}\n"
+    "- target type: {target_type}\n\n"
+    "## Current value\n"
+    "{current_value!r}\n\n"
+    "## Instructions\n"
+    "Return the value coerced to the target type, or null if no sensible "
+    "coercion exists. For DATE, prefer ISO 8601 (YYYY-MM-DD). For numeric "
+    "targets, extract the canonical number. For LIST, split sensibly.\n\n"
+    'Return ONLY a JSON object: {{"value": <coerced value or null>}}\n\n'
+    "Return ONLY valid JSON, nothing else."
+)
+
+
 def _format_property_for_prompt(prop: Attribute) -> str:
     desc = f" — {prop.description}" if prop.description else ""
     return f"    - {prop.name} ({prop.type}){desc}"

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -881,6 +881,378 @@ class GraphStore:
             deleted += r.result_set[0][0] if r.result_set else 0
         return deleted
 
+    # ── Ontology evolution (data-graph migration primitives) ────
+    #
+    # The ``GraphRAG`` evolution methods orchestrate ontology-graph writes
+    # (via ``OntologyStore``) with data-graph writes (via the helpers
+    # below). All are idempotent — re-running on already-converged state
+    # is a no-op that returns count=0.
+
+    _RETYPE_COERCERS: dict[str, str] = {
+        "INTEGER": "toInteger",
+        "FLOAT": "toFloat",
+        "STRING": "toString",
+        "BOOLEAN": "toBoolean",
+    }
+
+    async def rename_label(self, old: str, new: str) -> int:
+        """Move every node from ``:old`` to ``:new``.
+
+        Idempotent: nodes already moved no longer match the source label
+        so the second call's MATCH yields zero. Preserves any other
+        labels on the node (e.g. ``__Entity__``).
+
+        Returns the number of nodes relabelled.
+        """
+        safe_old = sanitize_cypher_label(old)
+        safe_new = sanitize_cypher_label(new)
+        if safe_old == safe_new:
+            return 0
+        r = await self._conn.query(
+            f"MATCH (n:`{safe_old}`) "
+            f"SET n:`{safe_new}` "
+            f"REMOVE n:`{safe_old}` "
+            f"RETURN count(n) AS n",
+        )
+        return r.result_set[0][0] if r.result_set else 0
+
+    async def rename_node_property(
+        self, label: str, old: str, new: str
+    ) -> int:
+        """Rename property ``old`` to ``new`` on every node carrying ``label``.
+
+        Property keys cannot be parameterised in Cypher, so the names are
+        sanitised through the same routine used for labels (which allows
+        only ``[A-Za-z_][A-Za-z0-9_]*``) before being interpolated.
+
+        Returns the number of nodes whose property was renamed.
+        """
+        safe_label = sanitize_cypher_label(label)
+        safe_old = sanitize_cypher_label(old)
+        safe_new = sanitize_cypher_label(new)
+        if safe_old == safe_new:
+            return 0
+        r = await self._conn.query(
+            f"MATCH (n:`{safe_label}`) WHERE n.`{safe_old}` IS NOT NULL "
+            f"SET n.`{safe_new}` = n.`{safe_old}` "
+            f"REMOVE n.`{safe_old}` "
+            f"RETURN count(n) AS n",
+        )
+        return r.result_set[0][0] if r.result_set else 0
+
+    async def drop_node_property(self, label: str, prop: str) -> int:
+        """Remove ``prop`` from every node carrying ``label``.
+
+        Returns the number of nodes touched.
+        """
+        safe_label = sanitize_cypher_label(label)
+        safe_prop = sanitize_cypher_label(prop)
+        r = await self._conn.query(
+            f"MATCH (n:`{safe_label}`) WHERE n.`{safe_prop}` IS NOT NULL "
+            f"REMOVE n.`{safe_prop}` "
+            f"RETURN count(n) AS n",
+        )
+        return r.result_set[0][0] if r.result_set else 0
+
+    async def delete_nodes_by_label(self, label: str) -> int:
+        """``DETACH DELETE`` every node with this label.
+
+        Returns the count of nodes removed.
+        """
+        safe_label = sanitize_cypher_label(label)
+        # Count first, then delete — FalkorDB's count-after-DELETE returns
+        # post-delete cardinality (zero) for a non-aggregated path.
+        count_r = await self._conn.query(
+            f"MATCH (n:`{safe_label}`) RETURN count(n) AS n",
+        )
+        count = count_r.result_set[0][0] if count_r.result_set else 0
+        if count == 0:
+            return 0
+        await self._conn.query(f"MATCH (n:`{safe_label}`) DETACH DELETE n")
+        return count
+
+    async def rename_relation_type(self, old: str, new: str) -> int:
+        """Recreate every ``[:old]`` edge as ``[:new]``, preserving
+        endpoints and properties.
+
+        FalkorDB cannot mutate a relationship's type in place, so the
+        operation is recreate-and-delete. Logs a warning when the edge
+        count exceeds 10k because the rebuild is O(edges).
+
+        Returns the number of edges relabelled.
+        """
+        safe_old = sanitize_cypher_label(old)
+        safe_new = sanitize_cypher_label(new)
+        if safe_old == safe_new:
+            return 0
+        count_r = await self._conn.query(
+            f"MATCH ()-[r:`{safe_old}`]->() RETURN count(r) AS n"
+        )
+        count = count_r.result_set[0][0] if count_r.result_set else 0
+        if count > 10_000:
+            logger.warning(
+                "rename_relation_type: %d [%s] edges will be recreated as "
+                "[%s] (expensive); FalkorDB lacks in-place type rewrite.",
+                count, safe_old, safe_new,
+            )
+        if count == 0:
+            return 0
+        # Two-phase rebuild: collect via id pairs, then re-MERGE.
+        await self._conn.query(
+            f"MATCH (a)-[r:`{safe_old}`]->(b) "
+            f"WITH a, b, r, properties(r) AS props "
+            f"CREATE (a)-[r2:`{safe_new}`]->(b) "
+            f"SET r2 = props "
+            f"DELETE r"
+        )
+        return count
+
+    async def delete_relations_by_type(self, rel_type: str) -> int:
+        """``DELETE`` every edge of type ``rel_type``. Returns the count."""
+        safe = sanitize_cypher_label(rel_type)
+        count_r = await self._conn.query(
+            f"MATCH ()-[r:`{safe}`]->() RETURN count(r) AS n"
+        )
+        count = count_r.result_set[0][0] if count_r.result_set else 0
+        if count == 0:
+            return 0
+        await self._conn.query(f"MATCH ()-[r:`{safe}`]->() DELETE r")
+        return count
+
+    async def delete_relations_by_pattern(
+        self, rel_type: str, src_label: str, tgt_label: str
+    ) -> int:
+        """Delete edges of ``rel_type`` only when source/target labels match.
+
+        Used for ``drop_relation_pattern``: other patterns of the same
+        relation type (with different endpoint labels) are preserved.
+        """
+        safe_rel = sanitize_cypher_label(rel_type)
+        safe_src = sanitize_cypher_label(src_label)
+        safe_tgt = sanitize_cypher_label(tgt_label)
+        count_r = await self._conn.query(
+            f"MATCH (s:`{safe_src}`)-[r:`{safe_rel}`]->(t:`{safe_tgt}`) "
+            "RETURN count(r) AS n"
+        )
+        count = count_r.result_set[0][0] if count_r.result_set else 0
+        if count == 0:
+            return 0
+        await self._conn.query(
+            f"MATCH (s:`{safe_src}`)-[r:`{safe_rel}`]->(t:`{safe_tgt}`) DELETE r"
+        )
+        return count
+
+    async def coerce_node_property(
+        self, label: str, prop: str, target_type: str
+    ) -> tuple[int, int]:
+        """Coerce values of ``label.prop`` to ``target_type`` via Cypher.
+
+        Cypher's ``toInteger`` / ``toFloat`` / ``toString`` / ``toBoolean``
+        return ``null`` for unconvertible values. We split the work into
+        two passes:
+        1. Convert and write back where the coerced value is non-null.
+        2. ``REMOVE`` the property on rows that produced null (the value
+           was unconvertible — better dropped than left mistyped).
+
+        Returns ``(coerced, dropped)`` counts. ``LIST`` and ``DATE``
+        target types are out of scope here (LIST is structural; DATE
+        needs a parser per format) — use ``backfill_attribute_semantic``
+        for LLM-assisted coercion of those.
+        """
+        normalized = (target_type or "STRING").strip().upper()
+        if normalized not in self._RETYPE_COERCERS:
+            raise ValueError(
+                f"coerce_node_property: cannot mechanically coerce to "
+                f"{normalized!r}. Mechanical coercion supports "
+                f"{sorted(self._RETYPE_COERCERS)}. Use "
+                f"backfill_attribute_semantic for LLM-assisted coercion."
+            )
+        coercer = self._RETYPE_COERCERS[normalized]
+        safe_label = sanitize_cypher_label(label)
+        safe_prop = sanitize_cypher_label(prop)
+        # Pass 1 — coerce non-null convertible values.
+        r1 = await self._conn.query(
+            f"MATCH (n:`{safe_label}`) "
+            f"WHERE n.`{safe_prop}` IS NOT NULL "
+            f"AND {coercer}(n.`{safe_prop}`) IS NOT NULL "
+            f"SET n.`{safe_prop}` = {coercer}(n.`{safe_prop}`) "
+            f"RETURN count(n) AS n"
+        )
+        coerced = r1.result_set[0][0] if r1.result_set else 0
+        # Pass 2 — drop unconvertible. We have to compare via the coercer
+        # again rather than caching from pass 1 because FalkorDB doesn't
+        # carry "did pass 1 touch this row" state across statements.
+        r2 = await self._conn.query(
+            f"MATCH (n:`{safe_label}`) "
+            f"WHERE n.`{safe_prop}` IS NOT NULL "
+            f"AND {coercer}(n.`{safe_prop}`) IS NULL "
+            f"REMOVE n.`{safe_prop}` "
+            f"RETURN count(n) AS n"
+        )
+        dropped = r2.result_set[0][0] if r2.result_set else 0
+        return (coerced, dropped)
+
+    # ── Chunk-scoped backfill helpers ───────────────────────────
+
+    async def mark_chunk_extracted(self, chunk_id: str, op_id: str) -> None:
+        """Append ``op_id`` to a chunk's ``extracted_ops`` list (idempotent).
+
+        Used by ``BackfillExecutor`` to record that a chunk has been
+        successfully processed for a given backfill operation, so a
+        resumed or repeated run skips it.
+        """
+        await self._conn.query(
+            "MATCH (c:Chunk {id: $id}) "
+            "WITH c, coalesce(c.extracted_ops, []) AS ops "
+            "WHERE NOT $op IN ops "
+            "SET c.extracted_ops = ops + [$op]",
+            {"id": chunk_id, "op": op_id},
+        )
+
+    async def list_chunks_for_attribute_backfill(
+        self,
+        owner_label: str,
+        prop_name: str,
+        *,
+        op_id: str,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return chunks mentioning entities of ``owner_label`` that
+        are missing ``prop_name``, excluding already-processed chunks.
+
+        Each row:
+            {"chunk_id": str, "chunk_text": str,
+             "entities": [{"id": str, "name": str | None}, ...]}
+        """
+        safe_label = sanitize_cypher_label(owner_label)
+        safe_prop = sanitize_cypher_label(prop_name)
+        limit_clause = f" LIMIT {int(limit)}" if limit else ""
+        result = await self._conn.query(
+            f"MATCH (e:`{safe_label}`)-[:MENTIONED_IN]->(c:Chunk) "
+            f"WHERE e.`{safe_prop}` IS NULL "
+            "AND NOT $op IN coalesce(c.extracted_ops, []) "
+            "WITH c, collect(DISTINCT {id: e.id, name: e.name}) AS ents "
+            f"RETURN c.id AS chunk_id, c.text AS chunk_text, ents{limit_clause}",
+            {"op": op_id},
+        )
+        rows: list[dict[str, Any]] = []
+        for row in result.result_set or []:
+            rows.append(
+                {
+                    "chunk_id": row[0],
+                    "chunk_text": row[1],
+                    "entities": row[2] or [],
+                }
+            )
+        return rows
+
+    async def list_chunks_for_entity_backfill(
+        self,
+        *,
+        op_id: str,
+        chunk_ids: list[str] | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return chunks (entire corpus, or a constrained ``chunk_ids``
+        scope) that have not been marked with ``op_id`` yet.
+
+        Each row: ``{"chunk_id": str, "chunk_text": str}``.
+        """
+        limit_clause = f" LIMIT {int(limit)}" if limit else ""
+        if chunk_ids is None:
+            result = await self._conn.query(
+                "MATCH (c:Chunk) "
+                "WHERE NOT $op IN coalesce(c.extracted_ops, []) "
+                f"RETURN c.id AS chunk_id, c.text AS chunk_text{limit_clause}",
+                {"op": op_id},
+            )
+        else:
+            result = await self._conn.query(
+                "UNWIND $ids AS cid "
+                "MATCH (c:Chunk {id: cid}) "
+                "WHERE NOT $op IN coalesce(c.extracted_ops, []) "
+                f"RETURN c.id AS chunk_id, c.text AS chunk_text{limit_clause}",
+                {"op": op_id, "ids": chunk_ids},
+            )
+        return [
+            {"chunk_id": row[0], "chunk_text": row[1]}
+            for row in (result.result_set or [])
+        ]
+
+    async def list_chunks_for_relation_pattern_backfill(
+        self,
+        src_label: str,
+        tgt_label: str,
+        *,
+        op_id: str,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return chunks where at least one ``src_label`` entity and one
+        ``tgt_label`` entity co-occur (both have ``MENTIONED_IN`` to the
+        same chunk), excluding already-processed chunks.
+
+        Each row carries the candidate pairs so the LLM can answer
+        per-pair without re-scanning.
+        """
+        safe_src = sanitize_cypher_label(src_label)
+        safe_tgt = sanitize_cypher_label(tgt_label)
+        limit_clause = f" LIMIT {int(limit)}" if limit else ""
+        result = await self._conn.query(
+            f"MATCH (s:`{safe_src}`)-[:MENTIONED_IN]->(c:Chunk) "
+            f"MATCH (t:`{safe_tgt}`)-[:MENTIONED_IN]->(c) "
+            "WHERE s <> t "
+            "AND NOT $op IN coalesce(c.extracted_ops, []) "
+            "WITH c, collect(DISTINCT {src_id: s.id, src_name: s.name, "
+            "tgt_id: t.id, tgt_name: t.name}) AS pairs "
+            f"RETURN c.id AS chunk_id, c.text AS chunk_text, pairs{limit_clause}",
+            {"op": op_id},
+        )
+        return [
+            {"chunk_id": row[0], "chunk_text": row[1], "pairs": row[2] or []}
+            for row in (result.result_set or [])
+        ]
+
+    async def list_node_values_for_semantic_coerce(
+        self,
+        label: str,
+        prop: str,
+    ) -> list[tuple[str, Any]]:
+        """Return ``(node_id, current_value)`` for every node carrying a
+        non-null value for ``label.prop`` — input to LLM-assisted
+        coercion (``backfill_attribute_semantic``).
+        """
+        safe_label = sanitize_cypher_label(label)
+        safe_prop = sanitize_cypher_label(prop)
+        result = await self._conn.query(
+            f"MATCH (n:`{safe_label}`) WHERE n.`{safe_prop}` IS NOT NULL "
+            f"RETURN n.id AS id, n.`{safe_prop}` AS value"
+        )
+        return [(row[0], row[1]) for row in (result.result_set or [])]
+
+    async def set_node_property_by_id(
+        self,
+        label: str,
+        node_id: str,
+        prop: str,
+        value: Any,
+    ) -> None:
+        """SET a single property on a node identified by ``label`` + ``id``.
+
+        Used by backfill merge fns. ``value=None`` removes the property.
+        """
+        safe_label = sanitize_cypher_label(label)
+        safe_prop = sanitize_cypher_label(prop)
+        if value is None:
+            await self._conn.query(
+                f"MATCH (n:`{safe_label}` {{id: $id}}) REMOVE n.`{safe_prop}`",
+                {"id": node_id},
+            )
+        else:
+            await self._conn.query(
+                f"MATCH (n:`{safe_label}` {{id: $id}}) SET n.`{safe_prop}` = $value",
+                {"id": node_id, "value": value},
+            )
+
     # ── Helpers ──────────────────────────────────────────────────
 
     @staticmethod

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -909,16 +909,11 @@ class GraphStore:
         if safe_old == safe_new:
             return 0
         r = await self._conn.query(
-            f"MATCH (n:`{safe_old}`) "
-            f"SET n:`{safe_new}` "
-            f"REMOVE n:`{safe_old}` "
-            f"RETURN count(n) AS n",
+            f"MATCH (n:`{safe_old}`) SET n:`{safe_new}` REMOVE n:`{safe_old}` RETURN count(n) AS n",
         )
         return r.result_set[0][0] if r.result_set else 0
 
-    async def rename_node_property(
-        self, label: str, old: str, new: str
-    ) -> int:
+    async def rename_node_property(self, label: str, old: str, new: str) -> int:
         """Rename property ``old`` to ``new`` on every node carrying ``label``.
 
         Property keys cannot be parameterised in Cypher, so the names are
@@ -985,15 +980,15 @@ class GraphStore:
         safe_new = sanitize_cypher_label(new)
         if safe_old == safe_new:
             return 0
-        count_r = await self._conn.query(
-            f"MATCH ()-[r:`{safe_old}`]->() RETURN count(r) AS n"
-        )
+        count_r = await self._conn.query(f"MATCH ()-[r:`{safe_old}`]->() RETURN count(r) AS n")
         count = count_r.result_set[0][0] if count_r.result_set else 0
         if count > 10_000:
             logger.warning(
                 "rename_relation_type: %d [%s] edges will be recreated as "
                 "[%s] (expensive); FalkorDB lacks in-place type rewrite.",
-                count, safe_old, safe_new,
+                count,
+                safe_old,
+                safe_new,
             )
         if count == 0:
             return 0
@@ -1010,9 +1005,7 @@ class GraphStore:
     async def delete_relations_by_type(self, rel_type: str) -> int:
         """``DELETE`` every edge of type ``rel_type``. Returns the count."""
         safe = sanitize_cypher_label(rel_type)
-        count_r = await self._conn.query(
-            f"MATCH ()-[r:`{safe}`]->() RETURN count(r) AS n"
-        )
+        count_r = await self._conn.query(f"MATCH ()-[r:`{safe}`]->() RETURN count(r) AS n")
         count = count_r.result_set[0][0] if count_r.result_set else 0
         if count == 0:
             return 0
@@ -1031,8 +1024,7 @@ class GraphStore:
         safe_src = sanitize_cypher_label(src_label)
         safe_tgt = sanitize_cypher_label(tgt_label)
         count_r = await self._conn.query(
-            f"MATCH (s:`{safe_src}`)-[r:`{safe_rel}`]->(t:`{safe_tgt}`) "
-            "RETURN count(r) AS n"
+            f"MATCH (s:`{safe_src}`)-[r:`{safe_rel}`]->(t:`{safe_tgt}`) RETURN count(r) AS n"
         )
         count = count_r.result_set[0][0] if count_r.result_set else 0
         if count == 0:
@@ -1174,10 +1166,7 @@ class GraphStore:
                 f"RETURN c.id AS chunk_id, c.text AS chunk_text{limit_clause}",
                 {"op": op_id, "ids": chunk_ids},
             )
-        return [
-            {"chunk_id": row[0], "chunk_text": row[1]}
-            for row in (result.result_set or [])
-        ]
+        return [{"chunk_id": row[0], "chunk_text": row[1]} for row in (result.result_set or [])]
 
     async def list_chunks_for_relation_pattern_backfill(
         self,

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -1086,6 +1086,19 @@ class GraphStore:
 
     # ── Chunk-scoped backfill helpers ───────────────────────────
 
+    async def count_chunks_marked_with_op(self, op_id: str) -> int:
+        """Count chunks that already carry the given backfill ``op_id``.
+
+        Used to populate ``BackfillResult.chunks_skipped`` — on a fresh
+        run this is 0, on an idempotent rerun it equals the work the
+        previous run completed.
+        """
+        r = await self._conn.query(
+            "MATCH (c:Chunk) WHERE $op IN coalesce(c.extracted_ops, []) RETURN count(c) AS n",
+            {"op": op_id},
+        )
+        return r.result_set[0][0] if r.result_set else 0
+
     async def mark_chunk_extracted(self, chunk_id: str, op_id: str) -> None:
         """Append ``op_id`` to a chunk's ``extracted_ops`` list (idempotent).
 

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -888,13 +888,6 @@ class GraphStore:
     # below). All are idempotent — re-running on already-converged state
     # is a no-op that returns count=0.
 
-    _RETYPE_COERCERS: dict[str, str] = {
-        "INTEGER": "toInteger",
-        "FLOAT": "toFloat",
-        "STRING": "toString",
-        "BOOLEAN": "toBoolean",
-    }
-
     async def rename_label(self, old: str, new: str) -> int:
         """Move every node from ``:old`` to ``:new``.
 
@@ -1034,56 +1027,6 @@ class GraphStore:
         )
         return count
 
-    async def coerce_node_property(
-        self, label: str, prop: str, target_type: str
-    ) -> tuple[int, int]:
-        """Coerce values of ``label.prop`` to ``target_type`` via Cypher.
-
-        Cypher's ``toInteger`` / ``toFloat`` / ``toString`` / ``toBoolean``
-        return ``null`` for unconvertible values. We split the work into
-        two passes:
-        1. Convert and write back where the coerced value is non-null.
-        2. ``REMOVE`` the property on rows that produced null (the value
-           was unconvertible — better dropped than left mistyped).
-
-        Returns ``(coerced, dropped)`` counts. ``LIST`` and ``DATE``
-        target types are out of scope here (LIST is structural; DATE
-        needs a parser per format) — use ``backfill_attribute_semantic``
-        for LLM-assisted coercion of those.
-        """
-        normalized = (target_type or "STRING").strip().upper()
-        if normalized not in self._RETYPE_COERCERS:
-            raise ValueError(
-                f"coerce_node_property: cannot mechanically coerce to "
-                f"{normalized!r}. Mechanical coercion supports "
-                f"{sorted(self._RETYPE_COERCERS)}. Use "
-                f"backfill_attribute_semantic for LLM-assisted coercion."
-            )
-        coercer = self._RETYPE_COERCERS[normalized]
-        safe_label = sanitize_cypher_label(label)
-        safe_prop = sanitize_cypher_label(prop)
-        # Pass 1 — coerce non-null convertible values.
-        r1 = await self._conn.query(
-            f"MATCH (n:`{safe_label}`) "
-            f"WHERE n.`{safe_prop}` IS NOT NULL "
-            f"AND {coercer}(n.`{safe_prop}`) IS NOT NULL "
-            f"SET n.`{safe_prop}` = {coercer}(n.`{safe_prop}`) "
-            f"RETURN count(n) AS n"
-        )
-        coerced = r1.result_set[0][0] if r1.result_set else 0
-        # Pass 2 — drop unconvertible. We have to compare via the coercer
-        # again rather than caching from pass 1 because FalkorDB doesn't
-        # carry "did pass 1 touch this row" state across statements.
-        r2 = await self._conn.query(
-            f"MATCH (n:`{safe_label}`) "
-            f"WHERE n.`{safe_prop}` IS NOT NULL "
-            f"AND {coercer}(n.`{safe_prop}`) IS NULL "
-            f"REMOVE n.`{safe_prop}` "
-            f"RETURN count(n) AS n"
-        )
-        dropped = r2.result_set[0][0] if r2.result_set else 0
-        return (coerced, dropped)
-
     # ── Chunk-scoped backfill helpers ───────────────────────────
 
     async def count_chunks_marked_with_op(self, op_id: str) -> int:
@@ -1222,23 +1165,6 @@ class GraphStore:
             {"chunk_id": row[0], "chunk_text": row[1], "pairs": row[2] or []}
             for row in (result.result_set or [])
         ]
-
-    async def list_node_values_for_semantic_coerce(
-        self,
-        label: str,
-        prop: str,
-    ) -> list[tuple[str, Any]]:
-        """Return ``(node_id, current_value)`` for every node carrying a
-        non-null value for ``label.prop`` — input to LLM-assisted
-        coercion (``backfill_attribute_semantic``).
-        """
-        safe_label = sanitize_cypher_label(label)
-        safe_prop = sanitize_cypher_label(prop)
-        result = await self._conn.query(
-            f"MATCH (n:`{safe_label}`) WHERE n.`{safe_prop}` IS NOT NULL "
-            f"RETURN n.id AS id, n.`{safe_prop}` AS value"
-        )
-        return [(row[0], row[1]) for row in (result.result_set or [])]
 
     async def set_node_property_by_id(
         self,

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -1188,17 +1188,25 @@ class GraphStore:
         *,
         op_id: str,
         limit: int | None = None,
+        pairs_per_chunk: int = 50,
     ) -> list[dict[str, Any]]:
         """Return chunks where at least one ``src_label`` entity and one
         ``tgt_label`` entity co-occur (both have ``MENTIONED_IN`` to the
         same chunk), excluding already-processed chunks.
 
         Each row carries the candidate pairs so the LLM can answer
-        per-pair without re-scanning.
+        per-pair without re-scanning. ``pairs_per_chunk`` (default 50)
+        caps the candidate Cartesian product per chunk — without it, a
+        single chunk with M source-type and N target-type entities
+        would emit ``M*N`` pairs and explode both the LLM prompt size
+        and the per-call cost. Tune up if you have evidence many of the
+        clipped pairs are real edges; leave at the default for typical
+        domain corpora.
         """
         safe_src = sanitize_cypher_label(src_label)
         safe_tgt = sanitize_cypher_label(tgt_label)
         limit_clause = f" LIMIT {int(limit)}" if limit else ""
+        cap = max(1, int(pairs_per_chunk))
         result = await self._conn.query(
             f"MATCH (s:`{safe_src}`)-[:MENTIONED_IN]->(c:Chunk) "
             f"MATCH (t:`{safe_tgt}`)-[:MENTIONED_IN]->(c) "
@@ -1206,7 +1214,8 @@ class GraphStore:
             "AND NOT $op IN coalesce(c.extracted_ops, []) "
             "WITH c, collect(DISTINCT {src_id: s.id, src_name: s.name, "
             "tgt_id: t.id, tgt_name: t.name}) AS pairs "
-            f"RETURN c.id AS chunk_id, c.text AS chunk_text, pairs{limit_clause}",
+            f"RETURN c.id AS chunk_id, c.text AS chunk_text, pairs[0..{cap}] AS pairs"
+            f"{limit_clause}",
             {"op": op_id},
         )
         return [

--- a/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
@@ -625,9 +625,7 @@ class OntologyStore:
             )
         elif kind in ("entity_property", "relation_property"):
             if owner_label is None:
-                raise ValueError(
-                    "set_description(kind='%s', ...) requires owner_label" % kind
-                )
+                raise ValueError(f"set_description(kind='{kind}', ...) requires owner_label")
             owner_lbl = "Entity" if kind == "entity_property" else "Relation"
             await self._query(
                 f"MATCH (o:{owner_lbl} {{label: $owner}})-[:HAS_PROPERTY]->"
@@ -670,8 +668,7 @@ class OntologyStore:
         """
         # Drop property children first (they're owner-scoped).
         await self._query(
-            "MATCH (e:Entity {label: $label})-[:HAS_PROPERTY]->(p:Property) "
-            "DETACH DELETE p",
+            "MATCH (e:Entity {label: $label})-[:HAS_PROPERTY]->(p:Property) DETACH DELETE p",
             {"label": label},
         )
         # Drop Relation pattern nodes that pointed at this entity, and their
@@ -701,9 +698,7 @@ class OntologyStore:
             {"label": label},
         )
 
-    async def drop_relation_pattern_node(
-        self, rel_label: str, src: str, tgt: str
-    ) -> None:
+    async def drop_relation_pattern_node(self, rel_label: str, src: str, tgt: str) -> None:
         """Remove a single ``(src, tgt)`` pattern of a relation.
 
         Other patterns of the same relation label are untouched.

--- a/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
@@ -65,10 +65,6 @@ from graphrag_sdk.core.models import (
     Relation,
 )
 
-_VALID_PROPERTY_TYPES: frozenset[str] = frozenset(
-    {"STRING", "INTEGER", "FLOAT", "BOOLEAN", "DATE", "LIST"}
-)
-
 OwnerKind = Literal["entity", "relation"]
 DescriptionKind = Literal["entity", "relation", "entity_property", "relation_property"]
 
@@ -499,9 +495,11 @@ class OntologyStore:
 
         Raised pre-write so a stray ``add_entity_property(... type="STRING")``
         on an existing INTEGER property doesn't silently retype the schema
-        (and leave the data graph mistyped). Use :py:meth:`retype_property`
-        or ``GraphRAG.retype_attribute`` / ``backfill_attribute_semantic``
-        to deliberately change types.
+        (and leave the data graph mistyped). To deliberately change a
+        property's type, callers must go through
+        ``GraphRAG.drop_attribute`` + ``GraphRAG.add_attribute`` with the
+        new type — the LLM re-derives values from chunks, keeping the
+        data and ontology aligned.
         """
         owner_lbl = "Entity" if owner_kind == "entity" else "Relation"
         result = await self._query(
@@ -514,8 +512,9 @@ class OntologyStore:
         if rows and rows[0] and rows[0][0] and rows[0][0] != attribute.type:
             raise OntologyContradictionError(
                 f"Property '{owner_label}.{attribute.name}' is already registered "
-                f"as {rows[0][0]}; refusing to redefine as {attribute.type}. Use "
-                f"retype_property() to deliberately change the declared type."
+                f"as {rows[0][0]}; refusing to redefine as {attribute.type}. "
+                f"To change the type, call drop_attribute() then add_attribute() "
+                f"with the new type — the LLM will re-derive values."
             )
 
     async def add_entity_property(self, entity_label: str, attribute: Attribute) -> None:
@@ -524,9 +523,9 @@ class OntologyStore:
         Idempotent on identical re-declarations. Raises
         :py:class:`OntologyContradictionError` if the same property name
         already exists with a different type — the caller must explicitly
-        ``retype_property`` (or ``backfill_attribute_semantic``) to
-        change a type. Description is coalesced (existing wins unless the
-        caller supplies a non-null one).
+        ``GraphRAG.drop_attribute`` + ``GraphRAG.add_attribute`` with the
+        new type to change a type. Description is coalesced (existing
+        wins unless the caller supplies a non-null one).
         """
         await self._check_no_property_retype("entity", entity_label, attribute)
         await self._upsert_entity_property(entity_label, attribute)
@@ -745,33 +744,6 @@ class OntologyStore:
             "OPTIONAL MATCH (r)-[:HAS_PROPERTY]->(p:Property) "
             "DETACH DELETE r, p",
             {"rel_label": rel_label, "src": src, "tgt": tgt},
-        )
-
-    async def retype_property(
-        self,
-        owner_kind: OwnerKind,
-        owner_label: str,
-        prop_name: str,
-        new_type: str,
-    ) -> None:
-        """Change the declared type of a property on the ontology graph.
-
-        Validates ``new_type`` against the SDK's supported property types
-        before issuing the write. The caller is responsible for coercing
-        the data-graph values to match.
-        """
-        normalized = (new_type or "STRING").strip().upper()
-        if normalized not in _VALID_PROPERTY_TYPES:
-            raise ValueError(
-                f"retype_property: unsupported type {new_type!r}. "
-                f"Allowed: {sorted(_VALID_PROPERTY_TYPES)}"
-            )
-        owner_lbl = "Entity" if owner_kind == "entity" else "Relation"
-        await self._query(
-            f"MATCH (o:{owner_lbl} {{label: $owner}})-[:HAS_PROPERTY]->"
-            "(p:Property {label: $name}) "
-            "SET p.type = $new_type",
-            {"owner": owner_label, "name": prop_name, "new_type": normalized},
         )
 
     # ── Clear ────────────────────────────────────────────────────

--- a/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
@@ -489,13 +489,46 @@ class OntologyStore:
     # keeping the data graph in lockstep (or for explicitly running a backfill
     # to populate new structure on existing data).
 
+    async def _check_no_property_retype(
+        self,
+        owner_kind: OwnerKind,
+        owner_label: str,
+        attribute: Attribute,
+    ) -> None:
+        """Refuse to silently change the declared type of an existing property.
+
+        Raised pre-write so a stray ``add_entity_property(... type="STRING")``
+        on an existing INTEGER property doesn't silently retype the schema
+        (and leave the data graph mistyped). Use :py:meth:`retype_property`
+        or ``GraphRAG.retype_attribute`` / ``backfill_attribute_semantic``
+        to deliberately change types.
+        """
+        owner_lbl = "Entity" if owner_kind == "entity" else "Relation"
+        result = await self._query(
+            f"MATCH (o:{owner_lbl} {{label: $owner}})-[:HAS_PROPERTY]->"
+            "(p:Property {label: $name}) "
+            "RETURN p.type AS type LIMIT 1",
+            {"owner": owner_label, "name": attribute.name},
+        )
+        rows = getattr(result, "result_set", None) or []
+        if rows and rows[0] and rows[0][0] and rows[0][0] != attribute.type:
+            raise OntologyContradictionError(
+                f"Property '{owner_label}.{attribute.name}' is already registered "
+                f"as {rows[0][0]}; refusing to redefine as {attribute.type}. Use "
+                f"retype_property() to deliberately change the declared type."
+            )
+
     async def add_entity_property(self, entity_label: str, attribute: Attribute) -> None:
         """Attach a new ``Property`` node to an existing ``Entity``.
 
-        No-op if a property with the same name already hangs off this
-        entity. Description is coalesced (existing wins unless the caller
-        supplies a non-null one).
+        Idempotent on identical re-declarations. Raises
+        :py:class:`OntologyContradictionError` if the same property name
+        already exists with a different type — the caller must explicitly
+        ``retype_property`` (or ``backfill_attribute_semantic``) to
+        change a type. Description is coalesced (existing wins unless the
+        caller supplies a non-null one).
         """
+        await self._check_no_property_retype("entity", entity_label, attribute)
         await self._upsert_entity_property(entity_label, attribute)
 
     async def add_relation_property(self, rel_label: str, attribute: Attribute) -> None:
@@ -505,13 +538,16 @@ class OntologyStore:
 
         Mirrors how :py:meth:`_upsert_relation_type` lays out properties
         per-pattern, so the property appears uniformly across all patterns
-        of the relation.
+        of the relation. Raises :py:class:`OntologyContradictionError` on
+        type re-declaration (same semantics as
+        :py:meth:`add_entity_property`).
         """
+        await self._check_no_property_retype("relation", rel_label, attribute)
         await self._query(
             "MATCH (r:Relation {label: $rel_label}) "
             "MERGE (r)-[:HAS_PROPERTY]->(p:Property {label: $name}) "
-            "SET p.type = $type, "
-            "p.description = coalesce($description, p.description)",
+            "ON CREATE SET p.type = $type "
+            "SET p.description = coalesce($description, p.description)",
             {
                 "rel_label": rel_label,
                 "name": attribute.name,

--- a/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
@@ -560,14 +560,21 @@ class OntologyStore:
     ) -> None:
         """Add a new ``(src, tgt)`` pattern to an existing relation label.
 
-        MERGEs source/target ``Entity`` nodes (idempotent — if they exist they
-        are reused), creates a fresh ``:Relation`` pattern node, and copies
-        properties from any existing pattern node of the same label so the
-        new pattern lines up with siblings.
+        The source and target Entity nodes MUST already exist on the
+        ontology graph — this method MATCHes them rather than MERGEing
+        so a stray call with unknown labels is a silent no-op instead of
+        creating phantom Entity nodes. The public facade
+        (``GraphRAG.add_relation_pattern``) validates the endpoint
+        labels before calling this primitive, so the no-op is unreachable
+        from normal use.
+
+        After the pattern node is created, copies properties from any
+        existing sibling pattern node of the same relation label so the
+        new pattern lines up with its siblings.
         """
         await self._query(
-            "MERGE (s:Entity {label: $src}) "
-            "MERGE (t:Entity {label: $tgt}) "
+            "MATCH (s:Entity {label: $src}) "
+            "MATCH (t:Entity {label: $tgt}) "
             "MERGE (s)<-[:SOURCE]-(r:Relation {label: $rel_label})-[:TARGET]->(t) "
             "SET r.description = coalesce($description, r.description)",
             {"src": src, "tgt": tgt, "rel_label": rel_label, "description": description},

--- a/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
@@ -55,7 +55,7 @@ them — no sharing across labels.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Literal
 
 from graphrag_sdk.core.connection import FalkorDBConnection
 from graphrag_sdk.core.models import (
@@ -64,6 +64,13 @@ from graphrag_sdk.core.models import (
     Ontology,
     Relation,
 )
+
+_VALID_PROPERTY_TYPES: frozenset[str] = frozenset(
+    {"STRING", "INTEGER", "FLOAT", "BOOLEAN", "DATE", "LIST"}
+)
+
+OwnerKind = Literal["entity", "relation"]
+DescriptionKind = Literal["entity", "relation", "entity_property", "relation_property"]
 
 logger = logging.getLogger(__name__)
 
@@ -471,6 +478,269 @@ class OntologyStore:
                 "type": prop.type,
                 "description": prop.description,
             },
+        )
+
+    # ── Evolution primitives (bypass register() strictness) ──────
+    #
+    # These lower-level methods are called by ``GraphRAG`` ontology-evolution
+    # APIs (``rename_entity``, ``add_attribute``, ``drop_relation``, …). They
+    # deliberately mutate already-registered labels in ways ``register()``
+    # rejects, because the public ``GraphRAG`` methods are responsible for
+    # keeping the data graph in lockstep (or for explicitly running a backfill
+    # to populate new structure on existing data).
+
+    async def add_entity_property(self, entity_label: str, attribute: Attribute) -> None:
+        """Attach a new ``Property`` node to an existing ``Entity``.
+
+        No-op if a property with the same name already hangs off this
+        entity. Description is coalesced (existing wins unless the caller
+        supplies a non-null one).
+        """
+        await self._upsert_entity_property(entity_label, attribute)
+
+    async def add_relation_property(self, rel_label: str, attribute: Attribute) -> None:
+        """Attach a new ``Property`` node to every ``Relation`` node carrying
+        ``rel_label`` — i.e. every pattern of that relation, plus the
+        open-mode node if any.
+
+        Mirrors how :py:meth:`_upsert_relation_type` lays out properties
+        per-pattern, so the property appears uniformly across all patterns
+        of the relation.
+        """
+        await self._query(
+            "MATCH (r:Relation {label: $rel_label}) "
+            "MERGE (r)-[:HAS_PROPERTY]->(p:Property {label: $name}) "
+            "SET p.type = $type, "
+            "p.description = coalesce($description, p.description)",
+            {
+                "rel_label": rel_label,
+                "name": attribute.name,
+                "type": attribute.type,
+                "description": attribute.description,
+            },
+        )
+
+    async def add_relation_pattern_node(
+        self, rel_label: str, src: str, tgt: str, *, description: str | None = None
+    ) -> None:
+        """Add a new ``(src, tgt)`` pattern to an existing relation label.
+
+        MERGEs source/target ``Entity`` nodes (idempotent — if they exist they
+        are reused), creates a fresh ``:Relation`` pattern node, and copies
+        properties from any existing pattern node of the same label so the
+        new pattern lines up with siblings.
+        """
+        await self._query(
+            "MERGE (s:Entity {label: $src}) "
+            "MERGE (t:Entity {label: $tgt}) "
+            "MERGE (s)<-[:SOURCE]-(r:Relation {label: $rel_label})-[:TARGET]->(t) "
+            "SET r.description = coalesce($description, r.description)",
+            {"src": src, "tgt": tgt, "rel_label": rel_label, "description": description},
+        )
+        # Copy properties from any sibling pattern node, if one exists.
+        # The MERGE above may have created a fresh Relation node; ensure
+        # any properties declared on the original carry over to the new
+        # pattern so retrieval-time prompts surface identical attrs.
+        await self._query(
+            "MATCH (existing:Relation {label: $rel_label})-[:HAS_PROPERTY]->(p:Property) "
+            "MATCH (new:Relation {label: $rel_label})-[:SOURCE]->(s:Entity {label: $src}) "
+            "MATCH (new)-[:TARGET]->(t:Entity {label: $tgt}) "
+            "WHERE existing <> new "
+            "MERGE (new)-[:HAS_PROPERTY]->(p2:Property {label: p.label}) "
+            "SET p2.type = p.type, p2.description = p.description",
+            {"rel_label": rel_label, "src": src, "tgt": tgt},
+        )
+
+    async def rename_entity_label(self, old: str, new: str) -> None:
+        """Rename the ``:Entity`` label on the ontology graph.
+
+        Only updates the ``label`` property on the ontology graph's
+        ``:Entity`` node — the underlying data-graph rename is the
+        caller's responsibility (handled by ``GraphRAG.rename_entity``).
+        """
+        await self._query(
+            "MATCH (e:Entity {label: $old}) SET e.label = $new",
+            {"old": old, "new": new},
+        )
+
+    async def rename_relation_label(self, old: str, new: str) -> None:
+        """Rename the ``:Relation`` label on the ontology graph.
+
+        Updates every ``:Relation`` node carrying this label (i.e. all
+        declared patterns of the relation, plus the open-mode node if any).
+        """
+        await self._query(
+            "MATCH (r:Relation {label: $old}) SET r.label = $new",
+            {"old": old, "new": new},
+        )
+
+    async def rename_property_label(
+        self,
+        owner_kind: OwnerKind,
+        owner_label: str,
+        old_name: str,
+        new_name: str,
+    ) -> None:
+        """Rename a property hanging off an Entity or every Relation node
+        with the given label.
+
+        Properties are scoped per-owner in the schema graph (one ``:Property``
+        node per owner via the ``HAS_PROPERTY`` edge), so the MATCH pattern
+        ensures we only touch the right node and never collide with
+        same-named properties on a different owner.
+        """
+        owner_label_cypher = "Entity" if owner_kind == "entity" else "Relation"
+        await self._query(
+            f"MATCH (o:{owner_label_cypher} {{label: $owner}})-[:HAS_PROPERTY]->"
+            "(p:Property {label: $old_name}) "
+            "SET p.label = $new_name",
+            {"owner": owner_label, "old_name": old_name, "new_name": new_name},
+        )
+
+    async def set_description(
+        self,
+        kind: DescriptionKind,
+        label: str,
+        description: str | None,
+        *,
+        owner_label: str | None = None,
+    ) -> None:
+        """Update the ``description`` on an Entity, Relation, or Property node.
+
+        For ``kind in {"entity", "relation"}``, ``label`` identifies the
+        node directly. For ``kind in {"entity_property", "relation_property"}``,
+        ``label`` is the property name and ``owner_label`` MUST be passed —
+        property nodes are scoped per owner so we always disambiguate.
+        Setting ``description=None`` clears the description.
+        """
+        if kind == "entity":
+            await self._query(
+                "MATCH (e:Entity {label: $label}) SET e.description = $description",
+                {"label": label, "description": description},
+            )
+        elif kind == "relation":
+            await self._query(
+                "MATCH (r:Relation {label: $label}) SET r.description = $description",
+                {"label": label, "description": description},
+            )
+        elif kind in ("entity_property", "relation_property"):
+            if owner_label is None:
+                raise ValueError(
+                    "set_description(kind='%s', ...) requires owner_label" % kind
+                )
+            owner_lbl = "Entity" if kind == "entity_property" else "Relation"
+            await self._query(
+                f"MATCH (o:{owner_lbl} {{label: $owner}})-[:HAS_PROPERTY]->"
+                "(p:Property {label: $name}) "
+                "SET p.description = $description",
+                {"owner": owner_label, "name": label, "description": description},
+            )
+        else:
+            raise ValueError(f"Unknown description kind: {kind}")
+
+    async def drop_entity_property(self, entity_label: str, prop_name: str) -> None:
+        """Remove a property declaration from an Entity in the ontology graph.
+
+        DETACH DELETEs the ``:Property`` node scoped to this entity. Properties
+        are owner-scoped so a same-named property on another entity is
+        untouched.
+        """
+        await self._query(
+            "MATCH (e:Entity {label: $owner})-[:HAS_PROPERTY]->(p:Property {label: $name}) "
+            "DETACH DELETE p",
+            {"owner": entity_label, "name": prop_name},
+        )
+
+    async def drop_relation_property(self, rel_label: str, prop_name: str) -> None:
+        """Remove a property declaration from every Relation node with this label."""
+        await self._query(
+            "MATCH (r:Relation {label: $owner})-[:HAS_PROPERTY]->(p:Property {label: $name}) "
+            "DETACH DELETE p",
+            {"owner": rel_label, "name": prop_name},
+        )
+
+    async def drop_entity_label(self, label: str) -> None:
+        """Remove an entity from the ontology graph entirely.
+
+        Cascades:
+        - Property nodes attached to this Entity → deleted.
+        - Relation pattern nodes that referenced this Entity as SOURCE or
+          TARGET → deleted along with their property children (the pattern is
+          no longer expressible without one of its endpoints).
+        """
+        # Drop property children first (they're owner-scoped).
+        await self._query(
+            "MATCH (e:Entity {label: $label})-[:HAS_PROPERTY]->(p:Property) "
+            "DETACH DELETE p",
+            {"label": label},
+        )
+        # Drop Relation pattern nodes that pointed at this entity, and their
+        # property children.  Two passes because the property children hang
+        # off the Relation node, not the Entity.
+        await self._query(
+            "MATCH (r:Relation)-[:SOURCE|TARGET]->(e:Entity {label: $label}) "
+            "OPTIONAL MATCH (r)-[:HAS_PROPERTY]->(p:Property) "
+            "DETACH DELETE r, p",
+            {"label": label},
+        )
+        await self._query(
+            "MATCH (e:Entity {label: $label}) DETACH DELETE e",
+            {"label": label},
+        )
+
+    async def drop_relation_label(self, label: str) -> None:
+        """Remove a relation from the ontology graph entirely.
+
+        Cascades all Relation pattern nodes carrying this label plus their
+        property children.
+        """
+        await self._query(
+            "MATCH (r:Relation {label: $label}) "
+            "OPTIONAL MATCH (r)-[:HAS_PROPERTY]->(p:Property) "
+            "DETACH DELETE r, p",
+            {"label": label},
+        )
+
+    async def drop_relation_pattern_node(
+        self, rel_label: str, src: str, tgt: str
+    ) -> None:
+        """Remove a single ``(src, tgt)`` pattern of a relation.
+
+        Other patterns of the same relation label are untouched.
+        """
+        await self._query(
+            "MATCH (s:Entity {label: $src})<-[:SOURCE]-(r:Relation {label: $rel_label})"
+            "-[:TARGET]->(t:Entity {label: $tgt}) "
+            "OPTIONAL MATCH (r)-[:HAS_PROPERTY]->(p:Property) "
+            "DETACH DELETE r, p",
+            {"rel_label": rel_label, "src": src, "tgt": tgt},
+        )
+
+    async def retype_property(
+        self,
+        owner_kind: OwnerKind,
+        owner_label: str,
+        prop_name: str,
+        new_type: str,
+    ) -> None:
+        """Change the declared type of a property on the ontology graph.
+
+        Validates ``new_type`` against the SDK's supported property types
+        before issuing the write. The caller is responsible for coercing
+        the data-graph values to match.
+        """
+        normalized = (new_type or "STRING").strip().upper()
+        if normalized not in _VALID_PROPERTY_TYPES:
+            raise ValueError(
+                f"retype_property: unsupported type {new_type!r}. "
+                f"Allowed: {sorted(_VALID_PROPERTY_TYPES)}"
+            )
+        owner_lbl = "Entity" if owner_kind == "entity" else "Relation"
+        await self._query(
+            f"MATCH (o:{owner_lbl} {{label: $owner}})-[:HAS_PROPERTY]->"
+            "(p:Property {label: $name}) "
+            "SET p.type = $new_type",
+            {"owner": owner_label, "name": prop_name, "new_type": normalized},
         )
 
     # ── Clear ────────────────────────────────────────────────────

--- a/graphrag_sdk/tests/test_backfill.py
+++ b/graphrag_sdk/tests/test_backfill.py
@@ -296,9 +296,7 @@ class TestAddAttributeAtomic:
         rag.llm = MockLLM(responses=[json.dumps({"results": {}})])
         # Simulate "role is no longer declared" by mutating the fixture
         # ontology in place (the actual drop runs in production).
-        person = next(
-            e for e in rag._global_ontology.entities if e.label == "Person"
-        )
+        person = next(e for e in rag._global_ontology.entities if e.label == "Person")
         person.properties = [p for p in person.properties if p.name != "role"]
         await rag.add_attribute("Person", Attribute(name="role", type="INTEGER"))
         second_op = rag._graph_store.mark_chunk_extracted.await_args.args[1]
@@ -330,6 +328,29 @@ class TestAddAttributeAtomic:
         rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
             "Person", "alice-id-7", "role", "engineer"
         )
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_chunks_in_scope_without_llm(self, rag):
+        """dry_run=True runs the scope query and returns chunks_in_scope
+        but does NOT invoke the LLM, write to the data graph, or commit
+        the ontology — letting callers preview cost on large corpora."""
+        from graphrag_sdk.core.models import Attribute
+
+        rag.llm = MockLLM(strict=True)  # any LLM call would assert
+        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
+            return_value=[
+                {"chunk_id": f"c{i}", "chunk_text": "...", "entities": []} for i in range(7)
+            ]
+        )
+        result = await rag.add_attribute(
+            "Person", Attribute(name="role", type="STRING"), dry_run=True
+        )
+        assert result.chunks_in_scope == 7
+        assert result.chunks_scanned == 0
+        assert result.llm_calls == 0
+        rag._graph_store.set_node_property_by_id.assert_not_awaited()
+        rag._ontology_store.add_entity_property.assert_not_awaited()
+        rag._graph_store.mark_chunk_extracted.assert_not_awaited()
 
 
 # ── backfill_entity ─────────────────────────────────────────────
@@ -368,6 +389,18 @@ class TestBackfillEntity:
         assert rel_call[0].type == "MENTIONED_IN"
         assert rel_call[0].end_node_id == "c1"
         assert result.values_filled == 1
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_chunks_in_scope_without_llm(self, rag):
+        rag.llm = MockLLM(strict=True)
+        rag._graph_store.list_chunks_for_entity_backfill = AsyncMock(
+            return_value=[{"chunk_id": f"c{i}", "chunk_text": "..."} for i in range(3)]
+        )
+        rag._graph_store.upsert_nodes = AsyncMock()
+        result = await rag.backfill_entity("Person", scope="all", dry_run=True)
+        assert result.chunks_in_scope == 3
+        assert result.llm_calls == 0
+        rag._graph_store.upsert_nodes.assert_not_awaited()
 
 
 # ── backfill_relation_pattern ───────────────────────────────────
@@ -452,6 +485,22 @@ class TestBackfillRelationPattern:
         await rag.backfill_relation_pattern("WORKS_AT", "Person", "Company")
         edge = rag._graph_store.upsert_relationships.await_args.args[0][0]
         assert "source_chunk_ids" not in edge.properties
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_chunks_in_scope_without_llm(self, rag):
+        rag.llm = MockLLM(strict=True)
+        rag._graph_store.list_chunks_for_relation_pattern_backfill = AsyncMock(
+            return_value=[
+                {"chunk_id": "c1", "chunk_text": "...", "pairs": [{}, {}]},
+                {"chunk_id": "c2", "chunk_text": "...", "pairs": [{}]},
+            ]
+        )
+        rag._graph_store.upsert_relationships = AsyncMock()
+        result = await rag.backfill_relation_pattern("WORKS_AT", "Person", "Company", dry_run=True)
+        assert result.chunks_in_scope == 2
+        assert result.target_nodes == 3  # 2 + 1 candidate pairs
+        assert result.llm_calls == 0
+        rag._graph_store.upsert_relationships.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_links_recognised_pairs(self, rag):

--- a/graphrag_sdk/tests/test_backfill.py
+++ b/graphrag_sdk/tests/test_backfill.py
@@ -228,7 +228,7 @@ class TestAddAttributeAtomic:
             "Person", "alice", "role", "engineer"
         )
         rag._graph_store.mark_chunk_extracted.assert_awaited_once_with(
-            "c1", "add_attribute:Person:role"
+            "c1", "add_attribute:Person:role:STRING"
         )
         # Ontology commit happened LAST.
         rag._ontology_store.add_entity_property.assert_awaited_once_with("Person", attr)
@@ -271,7 +271,43 @@ class TestAddAttributeAtomic:
         )
         await rag.add_attribute("Person", Attribute(name="role"))
         # The mark call carries the op_id; assert it matches the signature.
-        rag._graph_store.mark_chunk_extracted.assert_awaited_with("c1", "add_attribute:Person:role")
+        rag._graph_store.mark_chunk_extracted.assert_awaited_with(
+            "c1", "add_attribute:Person:role:STRING"
+        )
+
+    @pytest.mark.asyncio
+    async def test_op_id_includes_type_so_drop_add_rescans(self, rag):
+        """The documented type-change pattern is drop_attribute + add_attribute
+        with the new type. Without the type in op_id, chunk markers from
+        the prior backfill would short-circuit the second add — committing
+        the new schema while leaving the data graph at the old type.
+        Regression test for PR #268 comment #3319054109."""
+        from graphrag_sdk.core.models import Attribute
+
+        rag.llm = MockLLM(responses=[json.dumps({"results": {}})])
+        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
+            return_value=[{"chunk_id": "c1", "chunk_text": "", "entities": []}]
+        )
+        await rag.add_attribute("Person", Attribute(name="role", type="STRING"))
+        first_op = rag._graph_store.mark_chunk_extracted.await_args.args[1]
+
+        # Pretend a drop + re-add with new type.
+        rag._graph_store.mark_chunk_extracted.reset_mock()
+        rag.llm = MockLLM(responses=[json.dumps({"results": {}})])
+        # Simulate "role is no longer declared" by mutating the fixture
+        # ontology in place (the actual drop runs in production).
+        person = next(
+            e for e in rag._global_ontology.entities if e.label == "Person"
+        )
+        person.properties = [p for p in person.properties if p.name != "role"]
+        await rag.add_attribute("Person", Attribute(name="role", type="INTEGER"))
+        second_op = rag._graph_store.mark_chunk_extracted.await_args.args[1]
+
+        assert first_op != second_op, (
+            f"op_id must differ between type changes; got {first_op!r} both times"
+        )
+        assert first_op.endswith(":STRING")
+        assert second_op.endswith(":INTEGER")
 
     @pytest.mark.asyncio
     async def test_id_only_entity_lookup_matches(self, rag):

--- a/graphrag_sdk/tests/test_backfill.py
+++ b/graphrag_sdk/tests/test_backfill.py
@@ -24,13 +24,11 @@ from graphrag_sdk.core.models import Attribute, Entity, Ontology, Relation
 from graphrag_sdk.ingestion.backfill import (
     BackfillExecutor,
     BackfillMergeStats,
-    BackfillResult,
     ChunkContext,
 )
 from graphrag_sdk.storage.ontology_store import OntologyStore
 
 from .conftest import MockLLM
-
 
 # ── Fixtures ─────────────────────────────────────────────────────
 
@@ -89,9 +87,7 @@ class TestBackfillExecutor:
         mock_graph_store.mark_chunk_extracted = AsyncMock()
 
         async def chunks():
-            yield ChunkContext(
-                chunk_id="c1", chunk_text="hi", payload={}, ontology=small_ontology
-            )
+            yield ChunkContext(chunk_id="c1", chunk_text="hi", payload={}, ontology=small_ontology)
 
         async def merge_fn(parsed, ctx):
             return BackfillMergeStats(values_filled=2)
@@ -108,6 +104,52 @@ class TestBackfillExecutor:
         assert result.chunks_scanned == 1
         assert result.failed_chunks == []
         assert result.llm_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_live_task_count_stays_bounded(self, small_ontology, mock_graph_store):
+        """Worker-pool pattern: live ``asyncio.Task`` count stays O(concurrency)
+        regardless of corpus size. The previous implementation created one
+        task per chunk up-front, which scales linearly with the corpus
+        and pins memory until the LLM drains."""
+        import asyncio as _asyncio
+
+        chunk_count = 200
+        concurrency = 4
+        llm = MockLLM(responses=['{"results": {}}'])
+        executor = BackfillExecutor(llm, mock_graph_store, concurrency=concurrency)
+        mock_graph_store.mark_chunk_extracted = AsyncMock()
+
+        peak = 0
+
+        async def chunks():
+            nonlocal peak
+            for i in range(chunk_count):
+                # Each yield happens after the previous chunks have been
+                # consumed by workers, so this samples the live count
+                # roughly when one chunk is in flight.
+                peak = max(peak, len(_asyncio.all_tasks()))
+                yield ChunkContext(
+                    chunk_id=f"c{i}",
+                    chunk_text="",
+                    payload={},
+                    ontology=small_ontology,
+                )
+
+        async def merge_fn(parsed, ctx):
+            return BackfillMergeStats(values_filled=1)
+
+        await executor.run(
+            op_id="op:bounded",
+            chunks=chunks(),
+            prompt_builder=lambda c: "p",
+            parse_fn=lambda t, c: {},
+            merge_fn=merge_fn,
+        )
+        # Sanity ceiling: at most concurrency + producer + test driver +
+        # a small constant. If the executor regresses to one-task-per-chunk
+        # this leaps to ~chunk_count.
+        assert peak < chunk_count, f"task count exploded: peak={peak}, chunks={chunk_count}"
+        assert peak <= concurrency + 8
 
     @pytest.mark.asyncio
     async def test_failures_dont_poison_run(self, small_ontology, mock_graph_store):
@@ -170,7 +212,9 @@ class TestBackfillAttribute:
         rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
             "Person", "alice", "age", 42
         )
-        rag._graph_store.mark_chunk_extracted.assert_awaited_once_with("c1", "backfill_attribute:Person:age")
+        rag._graph_store.mark_chunk_extracted.assert_awaited_once_with(
+            "c1", "backfill_attribute:Person:age"
+        )
 
     @pytest.mark.asyncio
     async def test_op_id_is_deterministic(self, rag):
@@ -249,11 +293,7 @@ class TestBackfillEntity:
         rag.llm = MockLLM(
             responses=[
                 json.dumps(
-                    {
-                        "entities": [
-                            {"name": "Bob", "description": "A founder", "attributes": {}}
-                        ]
-                    }
+                    {"entities": [{"name": "Bob", "description": "A founder", "attributes": {}}]}
                 )
             ]
         )
@@ -279,9 +319,7 @@ class TestBackfillRelationPattern:
     @pytest.mark.asyncio
     async def test_rejects_unsupported_scope(self, rag):
         with pytest.raises(ValueError, match="unsupported scope"):
-            await rag.backfill_relation_pattern(
-                "WORKS_AT", "Person", "Company", scope="all"
-            )
+            await rag.backfill_relation_pattern("WORKS_AT", "Person", "Company", scope="all")
 
     @pytest.mark.asyncio
     async def test_pair_lookup_is_tuple_keyed_no_id_mismatch(self, rag):
@@ -292,11 +330,7 @@ class TestBackfillRelationPattern:
         rag.llm = MockLLM(
             responses=[
                 json.dumps(
-                    {
-                        "links": [
-                            {"src": "Alice", "tgt": "Globex", "description": "joined later"}
-                        ]
-                    }
+                    {"links": [{"src": "Alice", "tgt": "Globex", "description": "joined later"}]}
                 )
             ]
         )
@@ -338,9 +372,7 @@ class TestBackfillRelationPattern:
         RELATES, so writing it on (e.g.) WORKS_AT would be silently
         overwritten by future MERGE calls."""
         rag.llm = MockLLM(
-            responses=[
-                json.dumps({"links": [{"src": "Alice", "tgt": "Acme", "description": "x"}]})
-            ]
+            responses=[json.dumps({"links": [{"src": "Alice", "tgt": "Acme", "description": "x"}]})]
         )
         rag._graph_store.list_chunks_for_relation_pattern_backfill = AsyncMock(
             return_value=[
@@ -348,8 +380,12 @@ class TestBackfillRelationPattern:
                     "chunk_id": "c1",
                     "chunk_text": "...",
                     "pairs": [
-                        {"src_id": "alice", "src_name": "Alice",
-                         "tgt_id": "acme", "tgt_name": "Acme"}
+                        {
+                            "src_id": "alice",
+                            "src_name": "Alice",
+                            "tgt_id": "acme",
+                            "tgt_name": "Acme",
+                        }
                     ],
                 }
             ]
@@ -364,11 +400,7 @@ class TestBackfillRelationPattern:
         rag.llm = MockLLM(
             responses=[
                 json.dumps(
-                    {
-                        "links": [
-                            {"src": "Alice", "tgt": "Acme", "description": "joined 2020"}
-                        ]
-                    }
+                    {"links": [{"src": "Alice", "tgt": "Acme", "description": "joined 2020"}]}
                 )
             ]
         )

--- a/graphrag_sdk/tests/test_backfill.py
+++ b/graphrag_sdk/tests/test_backfill.py
@@ -74,6 +74,7 @@ def rag(embedder, small_ontology, mock_graph_store):
     rag._graph_store.list_node_values_for_semantic_coerce = AsyncMock(return_value=[])
     rag._graph_store.mark_chunk_extracted = AsyncMock()
     rag._graph_store.set_node_property_by_id = AsyncMock()
+    rag._graph_store.count_chunks_marked_with_op = AsyncMock(return_value=0)
     return rag
 
 
@@ -180,6 +181,54 @@ class TestBackfillAttribute:
         result = await rag.backfill_attribute("Person", "email")
         assert result.operation_id == "backfill_attribute:Person:email"
 
+    @pytest.mark.asyncio
+    async def test_lookup_keys_by_both_name_and_id(self, rag):
+        """If the LLM echoes the entity id (because the entity had no name and
+        the prompt fell back to id), the merge must still match — keying by
+        name alone would silently drop the value."""
+        rag.llm = MockLLM(responses=[json.dumps({"results": {"alice-id-7": "42"}})])
+        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
+            return_value=[
+                {
+                    "chunk_id": "c1",
+                    "chunk_text": "...",
+                    # Entity has no name — only an id.
+                    "entities": [{"id": "alice-id-7", "name": None}],
+                }
+            ]
+        )
+        result = await rag.backfill_attribute("Person", "age")
+        assert result.values_filled == 1
+        rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
+            "Person", "alice-id-7", "age", 42
+        )
+
+    @pytest.mark.asyncio
+    async def test_chunks_skipped_reflects_prior_run(self, rag):
+        """``chunks_skipped`` should count chunks already marked from a
+        previous run — i.e. work this run didn't have to redo."""
+        rag.llm = MockLLM(responses=[json.dumps({"results": {}})])
+        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
+            return_value=[{"chunk_id": "c1", "chunk_text": "", "entities": []}]
+        )
+        # Pretend 5 prior chunks are already marked.
+        rag._graph_store.count_chunks_marked_with_op = AsyncMock(return_value=6)
+        result = await rag.backfill_attribute("Person", "age")
+        # 1 scanned this run, 6 marked total → 5 skipped from prior runs.
+        assert result.chunks_skipped == 5
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_lands_in_failed_chunks(self, rag):
+        """Malformed JSON must raise from the parser so the BackfillExecutor
+        adds the chunk to ``failed_chunks`` instead of marking it done."""
+        rag.llm = MockLLM(responses=["this is not json"])
+        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
+            return_value=[{"chunk_id": "c-bad", "chunk_text": "", "entities": []}]
+        )
+        result = await rag.backfill_attribute("Person", "age")
+        assert result.failed_chunks == ["c-bad"]
+        rag._graph_store.mark_chunk_extracted.assert_not_awaited()
+
 
 # ── backfill_entity ─────────────────────────────────────────────
 
@@ -233,6 +282,82 @@ class TestBackfillRelationPattern:
             await rag.backfill_relation_pattern(
                 "WORKS_AT", "Person", "Company", scope="all"
             )
+
+    @pytest.mark.asyncio
+    async def test_pair_lookup_is_tuple_keyed_no_id_mismatch(self, rag):
+        """Two candidate pairs sharing the same src_name must not produce a
+        crossed edge: ``(Alice, Acme)`` and ``(Alice, Globex)`` in the same
+        chunk used to be lookup-collapsible; the merge now keys by the
+        full ``(src_name, tgt_name)`` tuple so each pair stays paired."""
+        rag.llm = MockLLM(
+            responses=[
+                json.dumps(
+                    {
+                        "links": [
+                            {"src": "Alice", "tgt": "Globex", "description": "joined later"}
+                        ]
+                    }
+                )
+            ]
+        )
+        rag._graph_store.list_chunks_for_relation_pattern_backfill = AsyncMock(
+            return_value=[
+                {
+                    "chunk_id": "c1",
+                    "chunk_text": "Alice was at Acme, then Globex.",
+                    "pairs": [
+                        {
+                            "src_id": "alice",
+                            "src_name": "Alice",
+                            "tgt_id": "acme",
+                            "tgt_name": "Acme",
+                        },
+                        {
+                            "src_id": "alice",
+                            "src_name": "Alice",
+                            "tgt_id": "globex",
+                            "tgt_name": "Globex",
+                        },
+                    ],
+                }
+            ]
+        )
+        rag._graph_store.upsert_relationships = AsyncMock(return_value=1)
+        result = await rag.backfill_relation_pattern("WORKS_AT", "Person", "Company")
+        assert result.values_filled == 1
+        edge = rag._graph_store.upsert_relationships.await_args.args[0][0]
+        # Must be Alice → Globex, NOT Alice → Acme (would happen if name maps
+        # collided).
+        assert edge.start_node_id == "alice"
+        assert edge.end_node_id == "globex"
+
+    @pytest.mark.asyncio
+    async def test_no_source_chunk_ids_on_non_relates(self, rag):
+        """Backfill edges of arbitrary type must not write source_chunk_ids:
+        ``GraphStore.upsert_relationships`` only unions provenance for
+        RELATES, so writing it on (e.g.) WORKS_AT would be silently
+        overwritten by future MERGE calls."""
+        rag.llm = MockLLM(
+            responses=[
+                json.dumps({"links": [{"src": "Alice", "tgt": "Acme", "description": "x"}]})
+            ]
+        )
+        rag._graph_store.list_chunks_for_relation_pattern_backfill = AsyncMock(
+            return_value=[
+                {
+                    "chunk_id": "c1",
+                    "chunk_text": "...",
+                    "pairs": [
+                        {"src_id": "alice", "src_name": "Alice",
+                         "tgt_id": "acme", "tgt_name": "Acme"}
+                    ],
+                }
+            ]
+        )
+        rag._graph_store.upsert_relationships = AsyncMock(return_value=1)
+        await rag.backfill_relation_pattern("WORKS_AT", "Person", "Company")
+        edge = rag._graph_store.upsert_relationships.await_args.args[0][0]
+        assert "source_chunk_ids" not in edge.properties
 
     @pytest.mark.asyncio
     async def test_links_recognised_pairs(self, rag):
@@ -310,3 +435,20 @@ class TestBackfillAttributeSemantic:
     async def test_relation_owner_rejected(self, rag):
         with pytest.raises(ValueError, match="relation owners"):
             await rag.backfill_attribute_semantic("WORKS_AT", "since", "DATE")
+
+    @pytest.mark.asyncio
+    async def test_failures_land_in_failed_node_ids(self, rag):
+        """Per-node failures in semantic backfill must populate
+        ``failed_node_ids`` (not ``failed_chunks`` — these aren't chunks)
+        so callers retry against the right surface."""
+
+        async def _boom(prompt, **kwargs):
+            raise RuntimeError("LLM down")
+
+        rag.llm.ainvoke = _boom  # type: ignore[method-assign]
+        rag._graph_store.list_node_values_for_semantic_coerce = AsyncMock(
+            return_value=[("alice", "twelve")]
+        )
+        result = await rag.backfill_attribute_semantic("Person", "age", "INTEGER")
+        assert result.failed_node_ids == ["alice"]
+        assert result.failed_chunks == []

--- a/graphrag_sdk/tests/test_backfill.py
+++ b/graphrag_sdk/tests/test_backfill.py
@@ -1,14 +1,11 @@
-"""Unit tests for Group-3 (LLM-driven backfill) ontology evolution.
+"""Unit tests for LLM-backed ontology evolution + discovery.
 
 Exercises:
 - :py:class:`BackfillExecutor` (concurrency, idempotency markers, partial failure)
-- ``GraphRAG.backfill_attribute`` (scope → LLM → merge → marker)
-- ``GraphRAG.backfill_entity`` (full chunk re-scan, new MENTIONED_IN edges)
-- ``GraphRAG.backfill_relation_pattern`` (candidate-pair filter)
-- ``GraphRAG.backfill_attribute_semantic`` (no-chunk LLM coercion)
-
-The LLM is always ``MockLLM(strict=True)`` so the second run of an
-idempotent backfill catches itself if it tries to make extra calls.
+- ``GraphRAG.add_attribute`` — atomic declare + LLM backfill + commit
+  (the invariant-enforcing core)
+- ``GraphRAG.backfill_entity`` — opportunistic: scan chunks for missed instances
+- ``GraphRAG.backfill_relation_pattern`` — opportunistic: discover missed edges
 """
 
 from __future__ import annotations
@@ -61,7 +58,7 @@ def rag(embedder, small_ontology, mock_graph_store):
     rag._graph_store = mock_graph_store
     rag._ontology_store = MagicMock(spec=OntologyStore)
     rag._ontology_store.load = AsyncMock(return_value=small_ontology)
-    rag._ontology_store.retype_property = AsyncMock()
+    rag._ontology_store.add_entity_property = AsyncMock()
     rag._ontology_initialized = True
     rag._global_ontology = small_ontology
     rag.ontology = small_ontology
@@ -69,7 +66,6 @@ def rag(embedder, small_ontology, mock_graph_store):
     rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(return_value=[])
     rag._graph_store.list_chunks_for_entity_backfill = AsyncMock(return_value=[])
     rag._graph_store.list_chunks_for_relation_pattern_backfill = AsyncMock(return_value=[])
-    rag._graph_store.list_node_values_for_semantic_coerce = AsyncMock(return_value=[])
     rag._graph_store.mark_chunk_extracted = AsyncMock()
     rag._graph_store.set_node_property_by_id = AsyncMock()
     rag._graph_store.count_chunks_marked_with_op = AsyncMock(return_value=0)
@@ -180,98 +176,124 @@ class TestBackfillExecutor:
         assert result.values_filled == 1
 
 
-# ── backfill_attribute ──────────────────────────────────────────
+# ── add_attribute (atomic declare + LLM backfill + commit) ──────
 
 
-class TestBackfillAttribute:
-    @pytest.mark.asyncio
-    async def test_rejects_unsupported_scope(self, rag):
-        with pytest.raises(ValueError, match="unsupported scope"):
-            await rag.backfill_attribute("Person", "age", scope="all")
-
-    @pytest.mark.asyncio
-    async def test_rejects_unknown_attribute(self, rag):
-        with pytest.raises(ValueError, match="Unknown attribute"):
-            await rag.backfill_attribute("Person", "phone")
+class TestAddAttributeAtomic:
+    """``add_attribute`` is atomic: LLM backfill → ontology graph write
+    as commit point. On hard failure the ontology stays at its pre-call
+    state; the data graph may be partially mutated but is idempotent on
+    retry via chunk markers."""
 
     @pytest.mark.asyncio
-    async def test_fills_value_and_marks_chunk(self, rag):
-        rag.llm = MockLLM(responses=[json.dumps({"results": {"Alice": "42"}})])
+    async def test_relation_owner_raises_not_implemented(self, rag):
+        from graphrag_sdk.core.models import Attribute
+
+        with pytest.raises(NotImplementedError, match="relation owners"):
+            await rag.add_attribute("WORKS_AT", Attribute(name="since"))
+
+    @pytest.mark.asyncio
+    async def test_already_declared_raises(self, rag):
+        """Type changes go through drop+add, not a silent retype on add."""
+        from graphrag_sdk.core.models import Attribute
+
+        with pytest.raises(ValueError, match="already declared"):
+            await rag.add_attribute("Person", Attribute(name="age", type="STRING"))
+
+    @pytest.mark.asyncio
+    async def test_unknown_label_raises(self, rag):
+        from graphrag_sdk.core.models import Attribute
+
+        with pytest.raises(ValueError, match="Unknown ontology label"):
+            await rag.add_attribute("Alien", Attribute(name="x"))
+
+    @pytest.mark.asyncio
+    async def test_happy_path_backfills_then_commits(self, rag):
+        from graphrag_sdk.core.models import Attribute
+
+        attr = Attribute(name="role", type="STRING")
+        rag.llm = MockLLM(responses=[json.dumps({"results": {"Alice": "engineer"}})])
         rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
             return_value=[
                 {
                     "chunk_id": "c1",
-                    "chunk_text": "Alice is 42 years old.",
+                    "chunk_text": "Alice is an engineer.",
                     "entities": [{"id": "alice", "name": "Alice"}],
                 }
             ]
         )
-        result = await rag.backfill_attribute("Person", "age")
-        assert result.values_filled == 1
-        assert result.dropped_for_coercion == 0
+        result = await rag.add_attribute("Person", attr)
+        # Data write happened.
         rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
-            "Person", "alice", "age", 42
+            "Person", "alice", "role", "engineer"
         )
         rag._graph_store.mark_chunk_extracted.assert_awaited_once_with(
-            "c1", "backfill_attribute:Person:age"
+            "c1", "add_attribute:Person:role"
         )
+        # Ontology commit happened LAST.
+        rag._ontology_store.add_entity_property.assert_awaited_once_with("Person", attr)
+        # EvolutionResult returned with backfill stats.
+        from graphrag_sdk.ingestion.backfill import EvolutionResult
+
+        assert isinstance(result, EvolutionResult)
+        assert result.values_filled == 1
+        assert result.chunks_scanned == 1
 
     @pytest.mark.asyncio
-    async def test_op_id_is_deterministic(self, rag):
+    async def test_hard_failure_does_not_commit_ontology(self, rag):
+        """If any chunk hard-fails (malformed JSON beyond retries),
+        OntologyEvolutionError is raised and the ontology graph write is
+        skipped. Schema stays at pre-call state; data graph may be
+        partially mutated but a retry of the same add_attribute call is
+        idempotent (chunk markers)."""
+        from graphrag_sdk.core.models import Attribute
+        from graphrag_sdk.ingestion.backfill import OntologyEvolutionError
+
+        rag.llm = MockLLM(responses=["this is not json"])
+        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
+            return_value=[{"chunk_id": "c-bad", "chunk_text": "", "entities": []}]
+        )
+        with pytest.raises(OntologyEvolutionError) as excinfo:
+            await rag.add_attribute("Person", Attribute(name="role"))
+        assert excinfo.value.failed_chunks == ["c-bad"]
+        # Commit point NOT reached.
+        rag._ontology_store.add_entity_property.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_op_id_is_deterministic_from_signature(self, rag):
+        """Re-running the same add_attribute call generates the same op_id,
+        so chunk markers from a partial prior run are respected on retry."""
+        from graphrag_sdk.core.models import Attribute
+
         rag.llm = MockLLM(responses=[json.dumps({"results": {}})])
         rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
             return_value=[{"chunk_id": "c1", "chunk_text": "", "entities": []}]
         )
-        result = await rag.backfill_attribute("Person", "email")
-        assert result.operation_id == "backfill_attribute:Person:email"
+        await rag.add_attribute("Person", Attribute(name="role"))
+        # The mark call carries the op_id; assert it matches the signature.
+        rag._graph_store.mark_chunk_extracted.assert_awaited_with("c1", "add_attribute:Person:role")
 
     @pytest.mark.asyncio
-    async def test_lookup_keys_by_both_name_and_id(self, rag):
-        """If the LLM echoes the entity id (because the entity had no name and
-        the prompt fell back to id), the merge must still match — keying by
-        name alone would silently drop the value."""
-        rag.llm = MockLLM(responses=[json.dumps({"results": {"alice-id-7": "42"}})])
+    async def test_id_only_entity_lookup_matches(self, rag):
+        """LLM may echo the entity id when the entity has no name (the prompt
+        falls back to id). The merge must match either."""
+        from graphrag_sdk.core.models import Attribute
+
+        rag.llm = MockLLM(responses=[json.dumps({"results": {"alice-id-7": "engineer"}})])
         rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
             return_value=[
                 {
                     "chunk_id": "c1",
                     "chunk_text": "...",
-                    # Entity has no name — only an id.
                     "entities": [{"id": "alice-id-7", "name": None}],
                 }
             ]
         )
-        result = await rag.backfill_attribute("Person", "age")
+        result = await rag.add_attribute("Person", Attribute(name="role", type="STRING"))
         assert result.values_filled == 1
         rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
-            "Person", "alice-id-7", "age", 42
+            "Person", "alice-id-7", "role", "engineer"
         )
-
-    @pytest.mark.asyncio
-    async def test_chunks_skipped_reflects_prior_run(self, rag):
-        """``chunks_skipped`` should count chunks already marked from a
-        previous run — i.e. work this run didn't have to redo."""
-        rag.llm = MockLLM(responses=[json.dumps({"results": {}})])
-        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
-            return_value=[{"chunk_id": "c1", "chunk_text": "", "entities": []}]
-        )
-        # Pretend 5 prior chunks are already marked.
-        rag._graph_store.count_chunks_marked_with_op = AsyncMock(return_value=6)
-        result = await rag.backfill_attribute("Person", "age")
-        # 1 scanned this run, 6 marked total → 5 skipped from prior runs.
-        assert result.chunks_skipped == 5
-
-    @pytest.mark.asyncio
-    async def test_malformed_json_lands_in_failed_chunks(self, rag):
-        """Malformed JSON must raise from the parser so the BackfillExecutor
-        adds the chunk to ``failed_chunks`` instead of marking it done."""
-        rag.llm = MockLLM(responses=["this is not json"])
-        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
-            return_value=[{"chunk_id": "c-bad", "chunk_text": "", "entities": []}]
-        )
-        result = await rag.backfill_attribute("Person", "age")
-        assert result.failed_chunks == ["c-bad"]
-        rag._graph_store.mark_chunk_extracted.assert_not_awaited()
 
 
 # ── backfill_entity ─────────────────────────────────────────────
@@ -430,57 +452,9 @@ class TestBackfillRelationPattern:
         assert rel.end_node_id == "acme"
 
 
-# ── backfill_attribute_semantic ─────────────────────────────────
-
-
-class TestBackfillAttributeSemantic:
-    @pytest.mark.asyncio
-    async def test_coerces_node_values(self, rag):
-        rag.llm = MockLLM(responses=[json.dumps({"value": 12})])
-        rag._graph_store.list_node_values_for_semantic_coerce = AsyncMock(
-            return_value=[("alice", "twelve")]
-        )
-        result = await rag.backfill_attribute_semantic("Person", "age", "INTEGER")
-        rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
-            "Person", "alice", "age", 12
-        )
-        rag._ontology_store.retype_property.assert_awaited_once_with(
-            "entity", "Person", "age", "INTEGER"
-        )
-        assert result.values_filled == 1
-        assert result.dropped_for_coercion == 0
-
-    @pytest.mark.asyncio
-    async def test_drops_unconvertible(self, rag):
-        rag.llm = MockLLM(responses=[json.dumps({"value": None})])
-        rag._graph_store.list_node_values_for_semantic_coerce = AsyncMock(
-            return_value=[("alice", "gibberish")]
-        )
-        result = await rag.backfill_attribute_semantic("Person", "age", "INTEGER")
-        rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
-            "Person", "alice", "age", None
-        )
-        assert result.dropped_for_coercion == 1
-        assert result.values_filled == 0
-
-    @pytest.mark.asyncio
-    async def test_relation_owner_rejected(self, rag):
-        with pytest.raises(ValueError, match="relation owners"):
-            await rag.backfill_attribute_semantic("WORKS_AT", "since", "DATE")
-
-    @pytest.mark.asyncio
-    async def test_failures_land_in_failed_node_ids(self, rag):
-        """Per-node failures in semantic backfill must populate
-        ``failed_node_ids`` (not ``failed_chunks`` — these aren't chunks)
-        so callers retry against the right surface."""
-
-        async def _boom(prompt, **kwargs):
-            raise RuntimeError("LLM down")
-
-        rag.llm.ainvoke = _boom  # type: ignore[method-assign]
-        rag._graph_store.list_node_values_for_semantic_coerce = AsyncMock(
-            return_value=[("alice", "twelve")]
-        )
-        result = await rag.backfill_attribute_semantic("Person", "age", "INTEGER")
-        assert result.failed_node_ids == ["alice"]
-        assert result.failed_chunks == []
+# Under the strict alignment design, retype_attribute and the
+# backfill_attribute_semantic that supported it are gone. Type changes
+# go through drop_attribute + add_attribute; the LLM re-derives values
+# from the chunks. The Attribute-Semantic tests are removed; coverage
+# of the LLM-coercion path lives in test_attribute_prompt for the
+# parser side and in TestAddAttributeAtomic for the end-to-end shape.

--- a/graphrag_sdk/tests/test_backfill.py
+++ b/graphrag_sdk/tests/test_backfill.py
@@ -1,0 +1,312 @@
+"""Unit tests for Group-3 (LLM-driven backfill) ontology evolution.
+
+Exercises:
+- :py:class:`BackfillExecutor` (concurrency, idempotency markers, partial failure)
+- ``GraphRAG.backfill_attribute`` (scope → LLM → merge → marker)
+- ``GraphRAG.backfill_entity`` (full chunk re-scan, new MENTIONED_IN edges)
+- ``GraphRAG.backfill_relation_pattern`` (candidate-pair filter)
+- ``GraphRAG.backfill_attribute_semantic`` (no-chunk LLM coercion)
+
+The LLM is always ``MockLLM(strict=True)`` so the second run of an
+idempotent backfill catches itself if it tries to make extra calls.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphrag_sdk.api.main import GraphRAG
+from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
+from graphrag_sdk.core.models import Attribute, Entity, Ontology, Relation
+from graphrag_sdk.ingestion.backfill import (
+    BackfillExecutor,
+    BackfillMergeStats,
+    BackfillResult,
+    ChunkContext,
+)
+from graphrag_sdk.storage.ontology_store import OntologyStore
+
+from .conftest import MockLLM
+
+
+# ── Fixtures ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def small_ontology() -> Ontology:
+    return Ontology(
+        entities=[
+            Entity(
+                label="Person",
+                properties=[
+                    Attribute(name="age", type="INTEGER"),
+                    Attribute(name="email", type="STRING"),
+                ],
+            ),
+            Entity(label="Company"),
+        ],
+        relations=[
+            Relation(label="WORKS_AT", patterns=[("Person", "Company")]),
+        ],
+    )
+
+
+@pytest.fixture
+def rag(embedder, small_ontology, mock_graph_store):
+    """GraphRAG with mocked stores. LLM is configured per-test."""
+    conn = MagicMock(spec=FalkorDBConnection)
+    conn.config = ConnectionConfig()
+    rag = GraphRAG(connection=conn, llm=MockLLM(), embedder=embedder, embedding_dimension=8)
+    rag._graph_store = mock_graph_store
+    rag._ontology_store = MagicMock(spec=OntologyStore)
+    rag._ontology_store.load = AsyncMock(return_value=small_ontology)
+    rag._ontology_store.retype_property = AsyncMock()
+    rag._ontology_initialized = True
+    rag._global_ontology = small_ontology
+    rag.ontology = small_ontology
+    # Backfill scope helpers
+    rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(return_value=[])
+    rag._graph_store.list_chunks_for_entity_backfill = AsyncMock(return_value=[])
+    rag._graph_store.list_chunks_for_relation_pattern_backfill = AsyncMock(return_value=[])
+    rag._graph_store.list_node_values_for_semantic_coerce = AsyncMock(return_value=[])
+    rag._graph_store.mark_chunk_extracted = AsyncMock()
+    rag._graph_store.set_node_property_by_id = AsyncMock()
+    return rag
+
+
+# ── BackfillExecutor unit tests ─────────────────────────────────
+
+
+class TestBackfillExecutor:
+    @pytest.mark.asyncio
+    async def test_marks_chunks_on_success(self, small_ontology, mock_graph_store):
+        llm = MockLLM(responses=['{"results": {}}'])
+        executor = BackfillExecutor(llm, mock_graph_store, concurrency=1)
+        mock_graph_store.mark_chunk_extracted = AsyncMock()
+
+        async def chunks():
+            yield ChunkContext(
+                chunk_id="c1", chunk_text="hi", payload={}, ontology=small_ontology
+            )
+
+        async def merge_fn(parsed, ctx):
+            return BackfillMergeStats(values_filled=2)
+
+        result = await executor.run(
+            op_id="op:test",
+            chunks=chunks(),
+            prompt_builder=lambda c: "prompt",
+            parse_fn=lambda t, c: {},
+            merge_fn=merge_fn,
+        )
+        mock_graph_store.mark_chunk_extracted.assert_awaited_once_with("c1", "op:test")
+        assert result.values_filled == 2
+        assert result.chunks_scanned == 1
+        assert result.failed_chunks == []
+        assert result.llm_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_failures_dont_poison_run(self, small_ontology, mock_graph_store):
+        llm = MockLLM(responses=["bad", '{"results": {}}'])
+        executor = BackfillExecutor(llm, mock_graph_store, concurrency=1)
+
+        async def chunks():
+            yield ChunkContext(chunk_id="c1", chunk_text="", payload={}, ontology=small_ontology)
+            yield ChunkContext(chunk_id="c2", chunk_text="", payload={}, ontology=small_ontology)
+
+        def parse(text, ctx):
+            if text == "bad":
+                raise ValueError("nope")
+            return {}
+
+        async def merge_fn(parsed, ctx):
+            return BackfillMergeStats(values_filled=1)
+
+        result = await executor.run(
+            op_id="op:fail",
+            chunks=chunks(),
+            prompt_builder=lambda c: "p",
+            parse_fn=parse,
+            merge_fn=merge_fn,
+        )
+        assert result.failed_chunks == ["c1"]
+        assert result.chunks_scanned == 1
+        assert result.values_filled == 1
+
+
+# ── backfill_attribute ──────────────────────────────────────────
+
+
+class TestBackfillAttribute:
+    @pytest.mark.asyncio
+    async def test_rejects_unsupported_scope(self, rag):
+        with pytest.raises(ValueError, match="unsupported scope"):
+            await rag.backfill_attribute("Person", "age", scope="all")
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_attribute(self, rag):
+        with pytest.raises(ValueError, match="Unknown attribute"):
+            await rag.backfill_attribute("Person", "phone")
+
+    @pytest.mark.asyncio
+    async def test_fills_value_and_marks_chunk(self, rag):
+        rag.llm = MockLLM(responses=[json.dumps({"results": {"Alice": "42"}})])
+        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
+            return_value=[
+                {
+                    "chunk_id": "c1",
+                    "chunk_text": "Alice is 42 years old.",
+                    "entities": [{"id": "alice", "name": "Alice"}],
+                }
+            ]
+        )
+        result = await rag.backfill_attribute("Person", "age")
+        assert result.values_filled == 1
+        assert result.dropped_for_coercion == 0
+        rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
+            "Person", "alice", "age", 42
+        )
+        rag._graph_store.mark_chunk_extracted.assert_awaited_once_with("c1", "backfill_attribute:Person:age")
+
+    @pytest.mark.asyncio
+    async def test_op_id_is_deterministic(self, rag):
+        rag.llm = MockLLM(responses=[json.dumps({"results": {}})])
+        rag._graph_store.list_chunks_for_attribute_backfill = AsyncMock(
+            return_value=[{"chunk_id": "c1", "chunk_text": "", "entities": []}]
+        )
+        result = await rag.backfill_attribute("Person", "email")
+        assert result.operation_id == "backfill_attribute:Person:email"
+
+
+# ── backfill_entity ─────────────────────────────────────────────
+
+
+class TestBackfillEntity:
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_label(self, rag):
+        with pytest.raises(ValueError, match="Unknown entity"):
+            await rag.backfill_entity("Alien")
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_scope(self, rag):
+        with pytest.raises(ValueError, match="scope must be"):
+            await rag.backfill_entity("Person", scope="weird")
+
+    @pytest.mark.asyncio
+    async def test_creates_entity_and_mention_edge(self, rag):
+        rag.llm = MockLLM(
+            responses=[
+                json.dumps(
+                    {
+                        "entities": [
+                            {"name": "Bob", "description": "A founder", "attributes": {}}
+                        ]
+                    }
+                )
+            ]
+        )
+        rag._graph_store.list_chunks_for_entity_backfill = AsyncMock(
+            return_value=[{"chunk_id": "c1", "chunk_text": "Bob runs Acme"}]
+        )
+        rag._graph_store.upsert_nodes = AsyncMock(return_value=1)
+        rag._graph_store.upsert_relationships = AsyncMock(return_value=1)
+        result = await rag.backfill_entity("Person", scope="all")
+        rag._graph_store.upsert_nodes.assert_awaited_once()
+        rag._graph_store.upsert_relationships.assert_awaited_once()
+        # The MENTIONED_IN edge points the entity at the chunk.
+        rel_call = rag._graph_store.upsert_relationships.await_args.args[0]
+        assert rel_call[0].type == "MENTIONED_IN"
+        assert rel_call[0].end_node_id == "c1"
+        assert result.values_filled == 1
+
+
+# ── backfill_relation_pattern ───────────────────────────────────
+
+
+class TestBackfillRelationPattern:
+    @pytest.mark.asyncio
+    async def test_rejects_unsupported_scope(self, rag):
+        with pytest.raises(ValueError, match="unsupported scope"):
+            await rag.backfill_relation_pattern(
+                "WORKS_AT", "Person", "Company", scope="all"
+            )
+
+    @pytest.mark.asyncio
+    async def test_links_recognised_pairs(self, rag):
+        rag.llm = MockLLM(
+            responses=[
+                json.dumps(
+                    {
+                        "links": [
+                            {"src": "Alice", "tgt": "Acme", "description": "joined 2020"}
+                        ]
+                    }
+                )
+            ]
+        )
+        rag._graph_store.list_chunks_for_relation_pattern_backfill = AsyncMock(
+            return_value=[
+                {
+                    "chunk_id": "c1",
+                    "chunk_text": "Alice joined Acme.",
+                    "pairs": [
+                        {
+                            "src_id": "alice",
+                            "src_name": "Alice",
+                            "tgt_id": "acme",
+                            "tgt_name": "Acme",
+                        }
+                    ],
+                }
+            ]
+        )
+        rag._graph_store.upsert_relationships = AsyncMock(return_value=1)
+        result = await rag.backfill_relation_pattern("WORKS_AT", "Person", "Company")
+        assert result.values_filled == 1
+        rag._graph_store.upsert_relationships.assert_awaited_once()
+        rel = rag._graph_store.upsert_relationships.await_args.args[0][0]
+        assert rel.type == "WORKS_AT"
+        assert rel.start_node_id == "alice"
+        assert rel.end_node_id == "acme"
+
+
+# ── backfill_attribute_semantic ─────────────────────────────────
+
+
+class TestBackfillAttributeSemantic:
+    @pytest.mark.asyncio
+    async def test_coerces_node_values(self, rag):
+        rag.llm = MockLLM(responses=[json.dumps({"value": 12})])
+        rag._graph_store.list_node_values_for_semantic_coerce = AsyncMock(
+            return_value=[("alice", "twelve")]
+        )
+        result = await rag.backfill_attribute_semantic("Person", "age", "INTEGER")
+        rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
+            "Person", "alice", "age", 12
+        )
+        rag._ontology_store.retype_property.assert_awaited_once_with(
+            "entity", "Person", "age", "INTEGER"
+        )
+        assert result.values_filled == 1
+        assert result.dropped_for_coercion == 0
+
+    @pytest.mark.asyncio
+    async def test_drops_unconvertible(self, rag):
+        rag.llm = MockLLM(responses=[json.dumps({"value": None})])
+        rag._graph_store.list_node_values_for_semantic_coerce = AsyncMock(
+            return_value=[("alice", "gibberish")]
+        )
+        result = await rag.backfill_attribute_semantic("Person", "age", "INTEGER")
+        rag._graph_store.set_node_property_by_id.assert_awaited_once_with(
+            "Person", "alice", "age", None
+        )
+        assert result.dropped_for_coercion == 1
+        assert result.values_filled == 0
+
+    @pytest.mark.asyncio
+    async def test_relation_owner_rejected(self, rag):
+        with pytest.raises(ValueError, match="relation owners"):
+            await rag.backfill_attribute_semantic("WORKS_AT", "since", "DATE")

--- a/graphrag_sdk/tests/test_backfill_integration.py
+++ b/graphrag_sdk/tests/test_backfill_integration.py
@@ -11,15 +11,14 @@ import os
 
 import pytest
 
-from graphrag_sdk.core.models import Attribute, Entity, Ontology, Relation
+from graphrag_sdk.core.models import Attribute, Entity, Ontology
 
 pytestmark = pytest.mark.skipif(
-    not os.getenv("RUN_INTEGRATION") or not os.getenv("OPENAI_API_KEY"),
+    os.getenv("RUN_INTEGRATION") != "1" or not os.getenv("OPENAI_API_KEY"),
     reason="Requires RUN_INTEGRATION=1 and OPENAI_API_KEY",
 )
 
 
-@pytest.mark.asyncio
 async def test_backfill_attribute_fills_missing_values(
     real_falkordb_rag_factory,
 ):
@@ -33,9 +32,7 @@ async def test_backfill_attribute_fills_missing_values(
     starter = Ontology(
         entities=[Entity(label="Person")],
     )
-    rag = real_falkordb_rag_factory(
-        llm=llm, resolver=ExactMatchResolution(), ontology=starter
-    )
+    rag = real_falkordb_rag_factory(llm=llm, resolver=ExactMatchResolution(), ontology=starter)
     await rag.ingest(
         text="Alice is 32 years old. Bob is 27. They are both engineers.",
         document_id="people",

--- a/graphrag_sdk/tests/test_backfill_integration.py
+++ b/graphrag_sdk/tests/test_backfill_integration.py
@@ -1,4 +1,4 @@
-"""End-to-end backfill tests against a real LLM + FalkorDB.
+"""End-to-end attribute-evolution tests against a real LLM + FalkorDB.
 
 Gated by ``RUN_INTEGRATION=1`` AND ``OPENAI_API_KEY``. The LLM call cost
 is small (one focused prompt per chunk) but real — keep the test corpus
@@ -19,33 +19,78 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-async def test_backfill_attribute_fills_missing_values(
+async def test_add_attribute_fills_values_from_chunks(
     real_falkordb_rag_factory,
 ):
-    """Ingest with no `age` attribute → add it → backfill → values appear."""
+    """add_attribute is atomic: declare + LLM backfill + commit. After it
+    returns, every Person mentioned in chunks has been LLM-asked for its
+    age value (or null where the LLM honestly doesn't know)."""
     from graphrag_sdk.core.providers import LiteLLM
     from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
         ExactMatchResolution,
     )
 
     llm = LiteLLM(model="gpt-4o-mini")
-    starter = Ontology(
-        entities=[Entity(label="Person")],
-    )
+    starter = Ontology(entities=[Entity(label="Person")])
     rag = real_falkordb_rag_factory(llm=llm, resolver=ExactMatchResolution(), ontology=starter)
     await rag.ingest(
         text="Alice is 32 years old. Bob is 27. They are both engineers.",
         document_id="people",
     )
 
-    # Add the new attribute (declaration only — no values yet).
-    await rag.add_attribute("Person", Attribute(name="age", type="INTEGER"))
-
-    # Backfill the attribute from existing chunks.
-    result = await rag.backfill_attribute("Person", "age")
+    # Atomic: schema declaration + LLM backfill + commit, in one call.
+    result = await rag.add_attribute("Person", Attribute(name="age", type="INTEGER"))
     assert result.values_filled >= 1, "expected at least one age value filled"
 
-    # Re-running is idempotent — no new LLM calls because every chunk in
-    # scope was already marked.
-    result2 = await rag.backfill_attribute("Person", "age")
-    assert result2.llm_calls == 0
+    # The ontology graph has been updated as the commit point.
+    ontology = await rag.get_ontology()
+    person = next(e for e in ontology.entities if e.label == "Person")
+    assert any(a.name == "age" and a.type == "INTEGER" for a in person.properties)
+
+
+async def test_add_attribute_rejects_duplicate(real_falkordb_rag_factory):
+    """Re-declaring the same attribute raises — type changes go through
+    drop_attribute + add_attribute with the new type."""
+    from graphrag_sdk.core.providers import LiteLLM
+    from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+        ExactMatchResolution,
+    )
+
+    llm = LiteLLM(model="gpt-4o-mini")
+    starter = Ontology(entities=[Entity(label="Person")])
+    rag = real_falkordb_rag_factory(llm=llm, resolver=ExactMatchResolution(), ontology=starter)
+    await rag.ingest(text="Alice is 32 years old.", document_id="people")
+
+    await rag.add_attribute("Person", Attribute(name="age", type="INTEGER"))
+    with pytest.raises(ValueError, match="already declared"):
+        await rag.add_attribute("Person", Attribute(name="age", type="STRING"))
+
+
+async def test_drop_then_add_triggers_fresh_backfill(real_falkordb_rag_factory):
+    """op_id includes the attribute type, so drop+add with a new type
+    runs a NEW backfill (chunk markers from the previous type don't
+    short-circuit it). Without this, the documented type-change pattern
+    would silently commit the new schema with stale values."""
+    from graphrag_sdk.core.providers import LiteLLM
+    from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+        ExactMatchResolution,
+    )
+
+    llm = LiteLLM(model="gpt-4o-mini")
+    starter = Ontology(entities=[Entity(label="Person")])
+    rag = real_falkordb_rag_factory(llm=llm, resolver=ExactMatchResolution(), ontology=starter)
+    await rag.ingest(text="Alice is 32 years old.", document_id="people")
+
+    # First add as INTEGER.
+    await rag.add_attribute("Person", Attribute(name="age", type="INTEGER"))
+
+    # Type change: drop then add with new type.
+    await rag.drop_attribute("Person", "age")
+    second = await rag.add_attribute("Person", Attribute(name="age", type="STRING"))
+
+    # The second add MUST have made fresh LLM calls — its op_id differs
+    # from the INTEGER one, so chunk markers don't filter it out.
+    assert second.llm_calls >= 1, (
+        "drop+add with new type must trigger a fresh backfill — chunk "
+        "markers from the previous (INTEGER) op_id must not short-circuit it."
+    )

--- a/graphrag_sdk/tests/test_backfill_integration.py
+++ b/graphrag_sdk/tests/test_backfill_integration.py
@@ -1,0 +1,54 @@
+"""End-to-end backfill tests against a real LLM + FalkorDB.
+
+Gated by ``RUN_INTEGRATION=1`` AND ``OPENAI_API_KEY``. The LLM call cost
+is small (one focused prompt per chunk) but real — keep the test corpus
+tiny.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from graphrag_sdk.core.models import Attribute, Entity, Ontology, Relation
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("RUN_INTEGRATION") or not os.getenv("OPENAI_API_KEY"),
+    reason="Requires RUN_INTEGRATION=1 and OPENAI_API_KEY",
+)
+
+
+@pytest.mark.asyncio
+async def test_backfill_attribute_fills_missing_values(
+    real_falkordb_rag_factory,
+):
+    """Ingest with no `age` attribute → add it → backfill → values appear."""
+    from graphrag_sdk.core.providers import LiteLLM
+    from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+        ExactMatchResolution,
+    )
+
+    llm = LiteLLM(model="gpt-4o-mini")
+    starter = Ontology(
+        entities=[Entity(label="Person")],
+    )
+    rag = real_falkordb_rag_factory(
+        llm=llm, resolver=ExactMatchResolution(), ontology=starter
+    )
+    await rag.ingest(
+        text="Alice is 32 years old. Bob is 27. They are both engineers.",
+        document_id="people",
+    )
+
+    # Add the new attribute (declaration only — no values yet).
+    await rag.add_attribute("Person", Attribute(name="age", type="INTEGER"))
+
+    # Backfill the attribute from existing chunks.
+    result = await rag.backfill_attribute("Person", "age")
+    assert result.values_filled >= 1, "expected at least one age value filled"
+
+    # Re-running is idempotent — no new LLM calls because every chunk in
+    # scope was already marked.
+    result2 = await rag.backfill_attribute("Person", "age")
+    assert result2.llm_calls == 0

--- a/graphrag_sdk/tests/test_ontology_evolve.py
+++ b/graphrag_sdk/tests/test_ontology_evolve.py
@@ -147,12 +147,22 @@ class TestAddRelationProperty:
 
 class TestAddRelationPatternNode:
     @pytest.mark.asyncio
-    async def test_creates_new_pattern_node_and_copies_properties(self, store_factory):
+    async def test_matches_entities_does_not_merge_them(self, store_factory):
+        """Endpoints must MATCH, not MERGE. The public facade validates the
+        endpoint labels already; if the OntologyStore primitive MERGEd, a
+        stray direct call would create phantom :Entity nodes — exactly the
+        drift the alignment invariant exists to prevent.
+        """
         store, fake = store_factory()
         await store.add_relation_pattern_node("WORKS_AT", "Person", "Startup")
-        # Two queries: (1) the MERGE pattern, (2) the property-copy from siblings.
-        merge_calls = [c for c in fake.calls if "MERGE (s:Entity {label: $src})" in c[0]]
-        assert len(merge_calls) == 1
+        # The Cypher MATCHes the endpoint entities (does NOT MERGE them) and
+        # only MERGEs the new pattern node.
+        match_calls = [c for c in fake.calls if "MATCH (s:Entity {label: $src})" in c[0]]
+        assert len(match_calls) == 1
+        # Must NOT MERGE the endpoints.
+        for cypher, _ in fake.calls:
+            assert "MERGE (s:Entity {label: $src})" not in cypher
+            assert "MERGE (t:Entity {label: $tgt})" not in cypher
         copy_calls = [
             c
             for c in fake.calls
@@ -384,6 +394,17 @@ class TestRenameAttributeValidation:
         with pytest.raises(ValueError, match="already exists"):
             await graphrag_evolving.rename_attribute("Person", "age", "email")
         graphrag_evolving._graph_store.rename_node_property.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_relation_owner_raises_not_implemented(self, graphrag_evolving):
+        """Under the strict alignment design, rename on a relation owner
+        used to half-apply: ontology graph renamed, edges kept their old
+        property key — silent drift. Must raise NotImplementedError,
+        matching add_attribute / drop_attribute on relations."""
+        with pytest.raises(NotImplementedError, match="relation owners"):
+            await graphrag_evolving.rename_attribute("WORKS_AT", "since", "started")
+        graphrag_evolving._graph_store.rename_node_property.assert_not_awaited()
+        graphrag_evolving._ontology_store.rename_property_label.assert_not_awaited()
 
 
 class TestRefreshGlobalOntologySyncsSelf:

--- a/graphrag_sdk/tests/test_ontology_evolve.py
+++ b/graphrag_sdk/tests/test_ontology_evolve.py
@@ -85,7 +85,6 @@ def graphrag_evolving(embedder, llm, evolving_ontology, mock_graph_store):
     rag._ontology_store.drop_entity_label = AsyncMock()
     rag._ontology_store.drop_relation_label = AsyncMock()
     rag._ontology_store.drop_relation_pattern_node = AsyncMock()
-    rag._ontology_store.retype_property = AsyncMock()
     # Pretend the lazy init has already happened so methods don't try to
     # re-register the (mocked-away) initial ontology.
     rag._ontology_initialized = True
@@ -99,7 +98,6 @@ def graphrag_evolving(embedder, llm, evolving_ontology, mock_graph_store):
     rag._graph_store.delete_nodes_by_label = AsyncMock(return_value=5)
     rag._graph_store.delete_relations_by_type = AsyncMock(return_value=7)
     rag._graph_store.delete_relations_by_pattern = AsyncMock(return_value=3)
-    rag._graph_store.coerce_node_property = AsyncMock(return_value=(10, 1))
     return rag
 
 
@@ -245,31 +243,13 @@ class TestDropEntityLabel:
         assert any("MATCH (e:Entity {label: $label}) DETACH DELETE e" in c[0] for c in fake.calls)
 
 
-class TestRetypeProperty:
-    @pytest.mark.asyncio
-    async def test_valid_type(self, store_factory):
-        store, fake = store_factory()
-        await store.retype_property("entity", "Person", "age", "INTEGER")
-        sets = [c for c in fake.calls if "SET p.type = $new_type" in c[0]]
-        assert len(sets) == 1
-        assert sets[0][1]["new_type"] == "INTEGER"
-
-    @pytest.mark.asyncio
-    async def test_invalid_type_rejected_before_query(self, store_factory):
-        store, fake = store_factory()
-        with pytest.raises(ValueError, match="unsupported type"):
-            await store.retype_property("entity", "Person", "age", "WIDGET")
-        # No write happened.
-        assert not any("SET p.type" in c[0] for c in fake.calls)
-
-
 class TestAddPropertyRefusesRetype:
     """``add_entity_property`` / ``add_relation_property`` must NOT silently
     retype an existing property — without this guard a stray
     ``add_attribute('Person', Attribute(name='age', type='STRING'))`` on a
-    Person.age INTEGER would mutate the schema in place. Use
-    ``retype_property`` / ``GraphRAG.retype_attribute`` for deliberate
-    type changes."""
+    Person.age INTEGER would mutate the schema in place. To change a
+    declared type, callers must go through ``GraphRAG.drop_attribute`` +
+    ``GraphRAG.add_attribute`` with the new type."""
 
     @pytest.mark.asyncio
     async def test_add_entity_property_raises_on_type_conflict(self, store_factory):

--- a/graphrag_sdk/tests/test_ontology_evolve.py
+++ b/graphrag_sdk/tests/test_ontology_evolve.py
@@ -336,21 +336,25 @@ class TestAddDeclarations:
             await graphrag_evolving.add_attribute("Alien", Attribute(name="x"))
 
     @pytest.mark.asyncio
-    async def test_add_attribute_on_relation_calls_relation_property(self, graphrag_evolving):
-        attr = Attribute(name="since", type="DATE")
-        await graphrag_evolving.add_attribute("WORKS_AT", attr)
-        graphrag_evolving._ontology_store.add_relation_property.assert_awaited_once_with(
-            "WORKS_AT", attr
-        )
+    async def test_add_attribute_on_relation_raises_not_implemented(self, graphrag_evolving):
+        """Under the strict alignment design, attribute evolution on relation
+        owners would require iterating edges. Relation-attribute mutation
+        raises NotImplementedError until that's implemented; the workaround
+        is documented in the error message."""
+        with pytest.raises(NotImplementedError, match="relation owners"):
+            await graphrag_evolving.add_attribute("WORKS_AT", Attribute(name="since"))
+        # The data graph must not have been touched either.
+        graphrag_evolving._ontology_store.add_relation_property.assert_not_awaited()
         graphrag_evolving._ontology_store.add_entity_property.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_add_attribute_calls_lower_level_primitive(self, graphrag_evolving):
-        attr = Attribute(name="email", type="STRING")
-        await graphrag_evolving.add_attribute("Person", attr)
-        graphrag_evolving._ontology_store.add_entity_property.assert_awaited_once_with(
-            "Person", attr
-        )
+    async def test_add_attribute_rejects_already_declared(self, graphrag_evolving):
+        """add_attribute is an atomic 'declare + backfill'. Re-declaring an
+        existing attribute would either be a no-op (wasteful) or a type
+        change (drift-prone). For type changes the user must drop_attribute
+        first — the LLM then re-derives values from chunks."""
+        with pytest.raises(ValueError, match="already declared"):
+            await graphrag_evolving.add_attribute("Person", Attribute(name="age", type="STRING"))
 
     @pytest.mark.asyncio
     async def test_add_relation_pattern_requires_known_endpoints(self, graphrag_evolving):
@@ -443,12 +447,14 @@ class TestDropAttribute:
         )
 
     @pytest.mark.asyncio
-    async def test_relation_owner_skips_data_graph(self, graphrag_evolving, caplog):
-        await graphrag_evolving.drop_attribute("WORKS_AT", "since")
+    async def test_relation_owner_raises_not_implemented(self, graphrag_evolving):
+        """Drop on a relation owner would leave edge properties orphaned
+        (no edge-property removal primitive yet). Raises under the strict
+        alignment invariant to prevent silent drift."""
+        with pytest.raises(NotImplementedError, match="relation owners"):
+            await graphrag_evolving.drop_attribute("WORKS_AT", "since")
         graphrag_evolving._graph_store.drop_node_property.assert_not_awaited()
-        graphrag_evolving._ontology_store.drop_relation_property.assert_awaited_once_with(
-            "WORKS_AT", "since"
-        )
+        graphrag_evolving._ontology_store.drop_relation_property.assert_not_awaited()
 
 
 class TestDropEntity:
@@ -479,13 +485,11 @@ class TestDropRelationPattern:
         )
 
 
-class TestRetypeAttribute:
-    @pytest.mark.asyncio
-    async def test_entity_owner_runs_mechanical_coercion(self, graphrag_evolving):
-        await graphrag_evolving.retype_attribute("Person", "age", "INTEGER")
-        graphrag_evolving._graph_store.coerce_node_property.assert_awaited_once_with(
-            "Person", "age", "INTEGER"
-        )
-        graphrag_evolving._ontology_store.retype_property.assert_awaited_once_with(
-            "entity", "Person", "age", "INTEGER"
-        )
+class TestRetypeRemoved:
+    """Under the strict alignment design, ``retype_attribute`` is gone.
+    Users compose ``drop_attribute`` + ``add_attribute`` with the new type
+    — the LLM re-derives values from chunks. Re-deriving is the only
+    honest move when the ontology's source of truth is the corpus."""
+
+    def test_retype_attribute_does_not_exist(self, graphrag_evolving):
+        assert not hasattr(graphrag_evolving, "retype_attribute")

--- a/graphrag_sdk/tests/test_ontology_evolve.py
+++ b/graphrag_sdk/tests/test_ontology_evolve.py
@@ -260,6 +260,41 @@ class TestRetypeProperty:
         assert not any("SET p.type" in c[0] for c in fake.calls)
 
 
+class TestAddPropertyRefusesRetype:
+    """``add_entity_property`` / ``add_relation_property`` must NOT silently
+    retype an existing property — without this guard a stray
+    ``add_attribute('Person', Attribute(name='age', type='STRING'))`` on a
+    Person.age INTEGER would mutate the schema in place. Use
+    ``retype_property`` / ``GraphRAG.retype_attribute`` for deliberate
+    type changes."""
+
+    @pytest.mark.asyncio
+    async def test_add_entity_property_raises_on_type_conflict(self, store_factory):
+        from graphrag_sdk.storage.ontology_store import OntologyContradictionError
+
+        store, fake = store_factory()
+
+        # Patch the type-check probe to report an existing INTEGER.
+        async def _scripted_query(cypher, params=None):
+            fake.calls.append((cypher, params))
+            from types import SimpleNamespace
+
+            if "RETURN p.type AS type LIMIT 1" in cypher:
+                return SimpleNamespace(result_set=[["INTEGER"]])
+            return SimpleNamespace(result_set=[])
+
+        fake.query = _scripted_query  # type: ignore[method-assign]
+        with pytest.raises(OntologyContradictionError, match="already registered"):
+            await store.add_entity_property(
+                "Person", Attribute(name="age", type="STRING")
+            )
+        # No SET p.type write — the contradiction check fires before the upsert.
+        assert not any(
+            "MERGE (e)-[:HAS_PROPERTY]" in c[0] and "SET p.type" in c[0]
+            for c in fake.calls
+        )
+
+
 # ── GraphRAG orchestration: Group 1 ──────────────────────────────
 
 
@@ -296,9 +331,18 @@ class TestAddDeclarations:
         graphrag_evolving._ontology_store.register.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_add_attribute_requires_known_entity(self, graphrag_evolving):
-        with pytest.raises(ValueError, match="Unknown entity"):
+    async def test_add_attribute_requires_known_label(self, graphrag_evolving):
+        with pytest.raises(ValueError, match="Unknown ontology label"):
             await graphrag_evolving.add_attribute("Alien", Attribute(name="x"))
+
+    @pytest.mark.asyncio
+    async def test_add_attribute_on_relation_calls_relation_property(self, graphrag_evolving):
+        attr = Attribute(name="since", type="DATE")
+        await graphrag_evolving.add_attribute("WORKS_AT", attr)
+        graphrag_evolving._ontology_store.add_relation_property.assert_awaited_once_with(
+            "WORKS_AT", attr
+        )
+        graphrag_evolving._ontology_store.add_entity_property.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_add_attribute_calls_lower_level_primitive(self, graphrag_evolving):
@@ -333,6 +377,41 @@ class TestRenameEntity:
     async def test_no_op_when_old_equals_new(self, graphrag_evolving):
         await graphrag_evolving.rename_entity("Person", "Person")
         graphrag_evolving._graph_store.rename_label.assert_not_awaited()
+
+
+class TestRenameAttributeValidation:
+    """``rename_attribute`` must refuse silent no-ops (typoed old_name) and
+    silent overwrites (collision on new_name) — without this guard a
+    misspelled rename does nothing or stamps over existing values."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_old_name(self, graphrag_evolving):
+        with pytest.raises(ValueError, match="Unknown attribute"):
+            await graphrag_evolving.rename_attribute("Person", "nonexistent", "new")
+        graphrag_evolving._graph_store.rename_node_property.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejects_existing_new_name(self, graphrag_evolving, evolving_ontology):
+        # Add a second attribute so we can test collision detection.
+        person = next(e for e in evolving_ontology.entities if e.label == "Person")
+        person.properties.append(Attribute(name="email", type="STRING"))
+        with pytest.raises(ValueError, match="already exists"):
+            await graphrag_evolving.rename_attribute("Person", "age", "email")
+        graphrag_evolving._graph_store.rename_node_property.assert_not_awaited()
+
+
+class TestRefreshGlobalOntologySyncsSelf:
+    """``_refresh_global_ontology`` must update ``self.ontology`` in lockstep
+    so a later ``ingest()`` (which reads ``self.ontology.entities`` in
+    ``_default_extractor``) sees the post-mutation label set."""
+
+    @pytest.mark.asyncio
+    async def test_self_ontology_updated(self, graphrag_evolving):
+        new_loaded = Ontology(entities=[Entity(label="Updated")])
+        graphrag_evolving._ontology_store.load = AsyncMock(return_value=new_loaded)
+        await graphrag_evolving._refresh_global_ontology()
+        assert graphrag_evolving._global_ontology is new_loaded
+        assert graphrag_evolving.ontology is new_loaded
 
 
 class TestRenameRelation:

--- a/graphrag_sdk/tests/test_ontology_evolve.py
+++ b/graphrag_sdk/tests/test_ontology_evolve.py
@@ -11,7 +11,7 @@ FalkorDB.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -21,7 +21,6 @@ from graphrag_sdk.core.models import Attribute, Entity, Ontology, Relation
 from graphrag_sdk.storage.ontology_store import OntologyStore
 
 from .test_ontology_store import _FakeGraph
-
 
 # ── Shared fixtures ──────────────────────────────────────────────
 
@@ -115,7 +114,8 @@ class TestAddEntityProperty:
             "Person", Attribute(name="email", type="STRING", description="email addr")
         )
         prop_merges = [
-            c for c in fake.calls
+            c
+            for c in fake.calls
             if "MATCH (e:Entity {label: $owner})" in c[0]
             and "MERGE (e)-[:HAS_PROPERTY]->(p:Property {label: $name})" in c[0]
         ]
@@ -130,11 +130,10 @@ class TestAddRelationProperty:
     @pytest.mark.asyncio
     async def test_merges_on_every_relation_node_with_label(self, store_factory):
         store, fake = store_factory()
-        await store.add_relation_property(
-            "WORKS_AT", Attribute(name="since", type="DATE")
-        )
+        await store.add_relation_property("WORKS_AT", Attribute(name="since", type="DATE"))
         merges = [
-            c for c in fake.calls
+            c
+            for c in fake.calls
             if "MATCH (r:Relation {label: $rel_label})" in c[0]
             and "MERGE (r)-[:HAS_PROPERTY]->(p:Property {label: $name})" in c[0]
         ]
@@ -157,7 +156,8 @@ class TestAddRelationPatternNode:
         merge_calls = [c for c in fake.calls if "MERGE (s:Entity {label: $src})" in c[0]]
         assert len(merge_calls) == 1
         copy_calls = [
-            c for c in fake.calls
+            c
+            for c in fake.calls
             if "MATCH (existing:Relation {label: $rel_label})" in c[0]
             and "MERGE (new)-[:HAS_PROPERTY]" in c[0]
         ]
@@ -237,7 +237,10 @@ class TestDropEntityLabel:
         await store.drop_entity_label("Company")
         # Three Cypher writes: drop entity props, drop relation pattern nodes
         # that reference the entity, drop the entity node itself.
-        assert any("DETACH DELETE p" in c[0] and "(e:Entity {label: $label})-[:HAS_PROPERTY]" in c[0] for c in fake.calls)
+        assert any(
+            "DETACH DELETE p" in c[0] and "(e:Entity {label: $label})-[:HAS_PROPERTY]" in c[0]
+            for c in fake.calls
+        )
         assert any("[:SOURCE|TARGET]->(e:Entity {label: $label})" in c[0] for c in fake.calls)
         assert any("MATCH (e:Entity {label: $label}) DETACH DELETE e" in c[0] for c in fake.calls)
 
@@ -285,13 +288,10 @@ class TestAddPropertyRefusesRetype:
 
         fake.query = _scripted_query  # type: ignore[method-assign]
         with pytest.raises(OntologyContradictionError, match="already registered"):
-            await store.add_entity_property(
-                "Person", Attribute(name="age", type="STRING")
-            )
+            await store.add_entity_property("Person", Attribute(name="age", type="STRING"))
         # No SET p.type write — the contradiction check fires before the upsert.
         assert not any(
-            "MERGE (e)-[:HAS_PROPERTY]" in c[0] and "SET p.type" in c[0]
-            for c in fake.calls
+            "MERGE (e)-[:HAS_PROPERTY]" in c[0] and "SET p.type" in c[0] for c in fake.calls
         )
 
 
@@ -366,7 +366,9 @@ class TestRenameEntity:
     async def test_data_migration_runs_before_ontology_update(self, graphrag_evolving):
         await graphrag_evolving.rename_entity("Person", "Human")
         graphrag_evolving._graph_store.rename_label.assert_awaited_once_with("Person", "Human")
-        graphrag_evolving._ontology_store.rename_entity_label.assert_awaited_once_with("Person", "Human")
+        graphrag_evolving._ontology_store.rename_entity_label.assert_awaited_once_with(
+            "Person", "Human"
+        )
 
     @pytest.mark.asyncio
     async def test_rejects_existing_target(self, graphrag_evolving):
@@ -436,13 +438,17 @@ class TestDropAttribute:
     async def test_entity_owner_drops_data_and_ontology(self, graphrag_evolving):
         await graphrag_evolving.drop_attribute("Person", "age")
         graphrag_evolving._graph_store.drop_node_property.assert_awaited_once_with("Person", "age")
-        graphrag_evolving._ontology_store.drop_entity_property.assert_awaited_once_with("Person", "age")
+        graphrag_evolving._ontology_store.drop_entity_property.assert_awaited_once_with(
+            "Person", "age"
+        )
 
     @pytest.mark.asyncio
     async def test_relation_owner_skips_data_graph(self, graphrag_evolving, caplog):
         await graphrag_evolving.drop_attribute("WORKS_AT", "since")
         graphrag_evolving._graph_store.drop_node_property.assert_not_awaited()
-        graphrag_evolving._ontology_store.drop_relation_property.assert_awaited_once_with("WORKS_AT", "since")
+        graphrag_evolving._ontology_store.drop_relation_property.assert_awaited_once_with(
+            "WORKS_AT", "since"
+        )
 
 
 class TestDropEntity:

--- a/graphrag_sdk/tests/test_ontology_evolve.py
+++ b/graphrag_sdk/tests/test_ontology_evolve.py
@@ -1,0 +1,406 @@
+"""Unit tests for ontology evolution — Groups 1 (pure ontology) and 2
+(mechanical data migration).
+
+OntologyStore evolution primitives are exercised against the existing
+``_FakeGraph`` from ``test_ontology_store.py``. GraphRAG orchestration
+methods are exercised with mocked ``OntologyStore`` and ``GraphStore``
+so we can assert on call ordering and input validation without booting
+FalkorDB.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from graphrag_sdk.api.main import GraphRAG
+from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
+from graphrag_sdk.core.models import Attribute, Entity, Ontology, Relation
+from graphrag_sdk.storage.ontology_store import OntologyStore
+
+from .test_ontology_store import _FakeGraph
+
+
+# ── Shared fixtures ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def store_factory():
+    def _make() -> tuple[OntologyStore, _FakeGraph]:
+        fake = _FakeGraph()
+        conn = MagicMock()
+        conn._ensure_client = MagicMock()
+        conn._driver = SimpleNamespace(select_graph=MagicMock(return_value=fake))
+        return OntologyStore(conn, "kg"), fake
+
+    return _make
+
+
+@pytest.fixture
+def evolving_ontology() -> Ontology:
+    """Ontology used by GraphRAG orchestration tests — must contain at
+    least one Entity (with attribute), one Relation (with pattern), so
+    every method has something to operate on."""
+    return Ontology(
+        entities=[
+            Entity(
+                label="Person",
+                description="A human",
+                properties=[Attribute(name="age", type="INTEGER")],
+            ),
+            Entity(label="Company"),
+        ],
+        relations=[
+            Relation(
+                label="WORKS_AT",
+                patterns=[("Person", "Company")],
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def graphrag_evolving(embedder, llm, evolving_ontology, mock_graph_store):
+    """A GraphRAG instance with mocked stores. ``_global_ontology`` is
+    pre-set so we can call evolution methods without firing the lazy
+    ontology load (which would hit the mocked connection).
+    """
+    conn = MagicMock(spec=FalkorDBConnection)
+    conn.config = ConnectionConfig()
+    rag = GraphRAG(connection=conn, llm=llm, embedder=embedder, embedding_dimension=8)
+    rag._graph_store = mock_graph_store
+    rag._ontology_store = MagicMock(spec=OntologyStore)
+    rag._ontology_store.load = AsyncMock(return_value=evolving_ontology)
+    rag._ontology_store.register = AsyncMock(return_value=evolving_ontology)
+    rag._ontology_store.add_entity_property = AsyncMock()
+    rag._ontology_store.add_relation_property = AsyncMock()
+    rag._ontology_store.add_relation_pattern_node = AsyncMock()
+    rag._ontology_store.rename_entity_label = AsyncMock()
+    rag._ontology_store.rename_relation_label = AsyncMock()
+    rag._ontology_store.rename_property_label = AsyncMock()
+    rag._ontology_store.set_description = AsyncMock()
+    rag._ontology_store.drop_entity_property = AsyncMock()
+    rag._ontology_store.drop_relation_property = AsyncMock()
+    rag._ontology_store.drop_entity_label = AsyncMock()
+    rag._ontology_store.drop_relation_label = AsyncMock()
+    rag._ontology_store.drop_relation_pattern_node = AsyncMock()
+    rag._ontology_store.retype_property = AsyncMock()
+    # Pretend the lazy init has already happened so methods don't try to
+    # re-register the (mocked-away) initial ontology.
+    rag._ontology_initialized = True
+    rag._global_ontology = evolving_ontology
+    rag.ontology = evolving_ontology
+    # GraphStore add primitives needed by orchestrators
+    rag._graph_store.rename_label = AsyncMock(return_value=3)
+    rag._graph_store.rename_node_property = AsyncMock(return_value=2)
+    rag._graph_store.rename_relation_type = AsyncMock(return_value=4)
+    rag._graph_store.drop_node_property = AsyncMock(return_value=2)
+    rag._graph_store.delete_nodes_by_label = AsyncMock(return_value=5)
+    rag._graph_store.delete_relations_by_type = AsyncMock(return_value=7)
+    rag._graph_store.delete_relations_by_pattern = AsyncMock(return_value=3)
+    rag._graph_store.coerce_node_property = AsyncMock(return_value=(10, 1))
+    return rag
+
+
+# ── OntologyStore primitives ─────────────────────────────────────
+
+
+class TestAddEntityProperty:
+    @pytest.mark.asyncio
+    async def test_merges_property_with_owner_scope(self, store_factory):
+        store, fake = store_factory()
+        await store.add_entity_property(
+            "Person", Attribute(name="email", type="STRING", description="email addr")
+        )
+        prop_merges = [
+            c for c in fake.calls
+            if "MATCH (e:Entity {label: $owner})" in c[0]
+            and "MERGE (e)-[:HAS_PROPERTY]->(p:Property {label: $name})" in c[0]
+        ]
+        assert len(prop_merges) == 1
+        params = prop_merges[0][1]
+        assert params["owner"] == "Person"
+        assert params["name"] == "email"
+        assert params["type"] == "STRING"
+
+
+class TestAddRelationProperty:
+    @pytest.mark.asyncio
+    async def test_merges_on_every_relation_node_with_label(self, store_factory):
+        store, fake = store_factory()
+        await store.add_relation_property(
+            "WORKS_AT", Attribute(name="since", type="DATE")
+        )
+        merges = [
+            c for c in fake.calls
+            if "MATCH (r:Relation {label: $rel_label})" in c[0]
+            and "MERGE (r)-[:HAS_PROPERTY]->(p:Property {label: $name})" in c[0]
+        ]
+        assert len(merges) == 1
+        params = merges[0][1]
+        assert params == {
+            "rel_label": "WORKS_AT",
+            "name": "since",
+            "type": "DATE",
+            "description": None,
+        }
+
+
+class TestAddRelationPatternNode:
+    @pytest.mark.asyncio
+    async def test_creates_new_pattern_node_and_copies_properties(self, store_factory):
+        store, fake = store_factory()
+        await store.add_relation_pattern_node("WORKS_AT", "Person", "Startup")
+        # Two queries: (1) the MERGE pattern, (2) the property-copy from siblings.
+        merge_calls = [c for c in fake.calls if "MERGE (s:Entity {label: $src})" in c[0]]
+        assert len(merge_calls) == 1
+        copy_calls = [
+            c for c in fake.calls
+            if "MATCH (existing:Relation {label: $rel_label})" in c[0]
+            and "MERGE (new)-[:HAS_PROPERTY]" in c[0]
+        ]
+        assert len(copy_calls) == 1
+
+
+class TestRenameLabel:
+    @pytest.mark.asyncio
+    async def test_rename_entity_label(self, store_factory):
+        store, fake = store_factory()
+        await store.rename_entity_label("Person", "Human")
+        ent_renames = [c for c in fake.calls if "SET e.label = $new" in c[0]]
+        assert len(ent_renames) == 1
+        assert ent_renames[0][1] == {"old": "Person", "new": "Human"}
+
+    @pytest.mark.asyncio
+    async def test_rename_relation_label(self, store_factory):
+        store, fake = store_factory()
+        await store.rename_relation_label("WORKS_AT", "EMPLOYED_AT")
+        rel_renames = [c for c in fake.calls if "SET r.label = $new" in c[0]]
+        assert len(rel_renames) == 1
+
+
+class TestRenameProperty:
+    @pytest.mark.asyncio
+    async def test_entity_property_rename_scoped_to_owner(self, store_factory):
+        store, fake = store_factory()
+        await store.rename_property_label("entity", "Person", "age", "years_old")
+        renames = [c for c in fake.calls if "SET p.label = $new_name" in c[0]]
+        assert len(renames) == 1
+        assert "MATCH (o:Entity {label: $owner})" in renames[0][0]
+
+    @pytest.mark.asyncio
+    async def test_relation_property_rename_uses_relation_match(self, store_factory):
+        store, fake = store_factory()
+        await store.rename_property_label("relation", "WORKS_AT", "since", "start_date")
+        renames = [c for c in fake.calls if "SET p.label = $new_name" in c[0]]
+        assert len(renames) == 1
+        assert "MATCH (o:Relation {label: $owner})" in renames[0][0]
+
+
+class TestSetDescription:
+    @pytest.mark.asyncio
+    async def test_entity_description(self, store_factory):
+        store, fake = store_factory()
+        await store.set_description("entity", "Person", "A human being")
+        updates = [c for c in fake.calls if "SET e.description = $description" in c[0]]
+        assert len(updates) == 1
+        assert updates[0][1] == {"label": "Person", "description": "A human being"}
+
+    @pytest.mark.asyncio
+    async def test_property_description_requires_owner(self, store_factory):
+        store, _ = store_factory()
+        with pytest.raises(ValueError, match="owner_label"):
+            await store.set_description("entity_property", "age", "Years")
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_kind(self, store_factory):
+        store, _ = store_factory()
+        with pytest.raises(ValueError, match="Unknown description kind"):
+            await store.set_description("widget", "Person", "x")  # type: ignore[arg-type]
+
+
+class TestDropProperty:
+    @pytest.mark.asyncio
+    async def test_drop_entity_property(self, store_factory):
+        store, fake = store_factory()
+        await store.drop_entity_property("Person", "age")
+        deletes = [c for c in fake.calls if "DETACH DELETE p" in c[0] and "Entity" in c[0]]
+        assert len(deletes) == 1
+
+
+class TestDropEntityLabel:
+    @pytest.mark.asyncio
+    async def test_cascades_relations_referencing_the_entity(self, store_factory):
+        store, fake = store_factory()
+        await store.drop_entity_label("Company")
+        # Three Cypher writes: drop entity props, drop relation pattern nodes
+        # that reference the entity, drop the entity node itself.
+        assert any("DETACH DELETE p" in c[0] and "(e:Entity {label: $label})-[:HAS_PROPERTY]" in c[0] for c in fake.calls)
+        assert any("[:SOURCE|TARGET]->(e:Entity {label: $label})" in c[0] for c in fake.calls)
+        assert any("MATCH (e:Entity {label: $label}) DETACH DELETE e" in c[0] for c in fake.calls)
+
+
+class TestRetypeProperty:
+    @pytest.mark.asyncio
+    async def test_valid_type(self, store_factory):
+        store, fake = store_factory()
+        await store.retype_property("entity", "Person", "age", "INTEGER")
+        sets = [c for c in fake.calls if "SET p.type = $new_type" in c[0]]
+        assert len(sets) == 1
+        assert sets[0][1]["new_type"] == "INTEGER"
+
+    @pytest.mark.asyncio
+    async def test_invalid_type_rejected_before_query(self, store_factory):
+        store, fake = store_factory()
+        with pytest.raises(ValueError, match="unsupported type"):
+            await store.retype_property("entity", "Person", "age", "WIDGET")
+        # No write happened.
+        assert not any("SET p.type" in c[0] for c in fake.calls)
+
+
+# ── GraphRAG orchestration: Group 1 ──────────────────────────────
+
+
+class TestSetDescriptionOrchestration:
+    @pytest.mark.asyncio
+    async def test_set_entity_description_rejects_unknown_label(self, graphrag_evolving):
+        with pytest.raises(ValueError, match="Unknown entity"):
+            await graphrag_evolving.set_entity_description("Alien", "x")
+
+    @pytest.mark.asyncio
+    async def test_set_entity_description_calls_ontology_store(self, graphrag_evolving):
+        await graphrag_evolving.set_entity_description("Person", "A human")
+        graphrag_evolving._ontology_store.set_description.assert_awaited_once_with(
+            "entity", "Person", "A human"
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_attribute_description_passes_owner_kind(self, graphrag_evolving):
+        await graphrag_evolving.set_attribute_description("Person", "age", "Years")
+        graphrag_evolving._ontology_store.set_description.assert_awaited_once_with(
+            "entity_property", "age", "Years", owner_label="Person"
+        )
+
+
+class TestAddDeclarations:
+    @pytest.mark.asyncio
+    async def test_add_entity_rejects_duplicate(self, graphrag_evolving):
+        with pytest.raises(ValueError, match="already exists"):
+            await graphrag_evolving.add_entity(Entity(label="Person"))
+
+    @pytest.mark.asyncio
+    async def test_add_entity_registers_new_label(self, graphrag_evolving):
+        await graphrag_evolving.add_entity(Entity(label="University"))
+        graphrag_evolving._ontology_store.register.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_add_attribute_requires_known_entity(self, graphrag_evolving):
+        with pytest.raises(ValueError, match="Unknown entity"):
+            await graphrag_evolving.add_attribute("Alien", Attribute(name="x"))
+
+    @pytest.mark.asyncio
+    async def test_add_attribute_calls_lower_level_primitive(self, graphrag_evolving):
+        attr = Attribute(name="email", type="STRING")
+        await graphrag_evolving.add_attribute("Person", attr)
+        graphrag_evolving._ontology_store.add_entity_property.assert_awaited_once_with(
+            "Person", attr
+        )
+
+    @pytest.mark.asyncio
+    async def test_add_relation_pattern_requires_known_endpoints(self, graphrag_evolving):
+        with pytest.raises(ValueError, match="source entity"):
+            await graphrag_evolving.add_relation_pattern("WORKS_AT", "Alien", "Company")
+
+
+# ── GraphRAG orchestration: Group 2 ──────────────────────────────
+
+
+class TestRenameEntity:
+    @pytest.mark.asyncio
+    async def test_data_migration_runs_before_ontology_update(self, graphrag_evolving):
+        await graphrag_evolving.rename_entity("Person", "Human")
+        graphrag_evolving._graph_store.rename_label.assert_awaited_once_with("Person", "Human")
+        graphrag_evolving._ontology_store.rename_entity_label.assert_awaited_once_with("Person", "Human")
+
+    @pytest.mark.asyncio
+    async def test_rejects_existing_target(self, graphrag_evolving):
+        with pytest.raises(ValueError, match="merging entity types"):
+            await graphrag_evolving.rename_entity("Person", "Company")
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_old_equals_new(self, graphrag_evolving):
+        await graphrag_evolving.rename_entity("Person", "Person")
+        graphrag_evolving._graph_store.rename_label.assert_not_awaited()
+
+
+class TestRenameRelation:
+    @pytest.mark.asyncio
+    async def test_orchestrates_recreate_then_ontology(self, graphrag_evolving):
+        await graphrag_evolving.rename_relation("WORKS_AT", "EMPLOYED_AT")
+        graphrag_evolving._graph_store.rename_relation_type.assert_awaited_once_with(
+            "WORKS_AT", "EMPLOYED_AT"
+        )
+        graphrag_evolving._ontology_store.rename_relation_label.assert_awaited_once_with(
+            "WORKS_AT", "EMPLOYED_AT"
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown(self, graphrag_evolving):
+        with pytest.raises(ValueError, match="Unknown relation"):
+            await graphrag_evolving.rename_relation("UNKNOWN", "NEW")
+
+
+class TestDropAttribute:
+    @pytest.mark.asyncio
+    async def test_entity_owner_drops_data_and_ontology(self, graphrag_evolving):
+        await graphrag_evolving.drop_attribute("Person", "age")
+        graphrag_evolving._graph_store.drop_node_property.assert_awaited_once_with("Person", "age")
+        graphrag_evolving._ontology_store.drop_entity_property.assert_awaited_once_with("Person", "age")
+
+    @pytest.mark.asyncio
+    async def test_relation_owner_skips_data_graph(self, graphrag_evolving, caplog):
+        await graphrag_evolving.drop_attribute("WORKS_AT", "since")
+        graphrag_evolving._graph_store.drop_node_property.assert_not_awaited()
+        graphrag_evolving._ontology_store.drop_relation_property.assert_awaited_once_with("WORKS_AT", "since")
+
+
+class TestDropEntity:
+    @pytest.mark.asyncio
+    async def test_deletes_data_then_ontology(self, graphrag_evolving):
+        await graphrag_evolving.drop_entity("Company")
+        graphrag_evolving._graph_store.delete_nodes_by_label.assert_awaited_once_with("Company")
+        graphrag_evolving._ontology_store.drop_entity_label.assert_awaited_once_with("Company")
+
+
+class TestDropRelation:
+    @pytest.mark.asyncio
+    async def test_deletes_edges_then_ontology(self, graphrag_evolving):
+        await graphrag_evolving.drop_relation("WORKS_AT")
+        graphrag_evolving._graph_store.delete_relations_by_type.assert_awaited_once_with("WORKS_AT")
+        graphrag_evolving._ontology_store.drop_relation_label.assert_awaited_once_with("WORKS_AT")
+
+
+class TestDropRelationPattern:
+    @pytest.mark.asyncio
+    async def test_targets_only_the_named_pattern(self, graphrag_evolving):
+        await graphrag_evolving.drop_relation_pattern("WORKS_AT", "Person", "Company")
+        graphrag_evolving._graph_store.delete_relations_by_pattern.assert_awaited_once_with(
+            "WORKS_AT", "Person", "Company"
+        )
+        graphrag_evolving._ontology_store.drop_relation_pattern_node.assert_awaited_once_with(
+            "WORKS_AT", "Person", "Company"
+        )
+
+
+class TestRetypeAttribute:
+    @pytest.mark.asyncio
+    async def test_entity_owner_runs_mechanical_coercion(self, graphrag_evolving):
+        await graphrag_evolving.retype_attribute("Person", "age", "INTEGER")
+        graphrag_evolving._graph_store.coerce_node_property.assert_awaited_once_with(
+            "Person", "age", "INTEGER"
+        )
+        graphrag_evolving._ontology_store.retype_property.assert_awaited_once_with(
+            "entity", "Person", "age", "INTEGER"
+        )

--- a/graphrag_sdk/tests/test_ontology_evolve_integration.py
+++ b/graphrag_sdk/tests/test_ontology_evolve_integration.py
@@ -16,7 +16,7 @@ from graphrag_sdk.core.models import Attribute, Entity, Ontology, Relation
 from .conftest import _scripted_extraction_llm
 
 pytestmark = pytest.mark.skipif(
-    not os.getenv("RUN_INTEGRATION"),
+    os.getenv("RUN_INTEGRATION") != "1",
     reason="Set RUN_INTEGRATION=1 to run real-FalkorDB integration tests",
 )
 
@@ -38,9 +38,7 @@ def starter_ontology() -> Ontology:
 
 
 @pytest.mark.asyncio
-async def test_rename_entity_relabels_data_nodes(
-    real_falkordb_rag_factory, starter_ontology
-):
+async def test_rename_entity_relabels_data_nodes(real_falkordb_rag_factory, starter_ontology):
     from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
         ExactMatchResolution,
     )
@@ -82,16 +80,12 @@ async def test_drop_attribute_removes_property_and_declaration(
 
 
 @pytest.mark.asyncio
-async def test_drop_entity_cascades_relations(
-    real_falkordb_rag_factory, starter_ontology
-):
+async def test_drop_entity_cascades_relations(real_falkordb_rag_factory, starter_ontology):
     from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
         ExactMatchResolution,
     )
 
-    llm = _scripted_extraction_llm(
-        [("Alice", "Person", "x"), ("Acme", "Company", "y")]
-    )
+    llm = _scripted_extraction_llm([("Alice", "Person", "x"), ("Acme", "Company", "y")])
     rag = real_falkordb_rag_factory(
         llm=llm, resolver=ExactMatchResolution(), ontology=starter_ontology
     )
@@ -100,7 +94,4 @@ async def test_drop_entity_cascades_relations(
     assert not any(e.label == "Company" for e in new_ontology.entities)
     # The WORKS_AT pattern (Person, Company) is no longer declarable since
     # the Company entity is gone.
-    assert all(
-        ("Company" not in (s, t) for s, t in r.patterns)
-        for r in new_ontology.relations
-    )
+    assert all(("Company" not in (s, t) for s, t in r.patterns) for r in new_ontology.relations)

--- a/graphrag_sdk/tests/test_ontology_evolve_integration.py
+++ b/graphrag_sdk/tests/test_ontology_evolve_integration.py
@@ -1,0 +1,106 @@
+"""End-to-end integration tests for Groups 1+2 against real FalkorDB.
+
+Gated by ``RUN_INTEGRATION=1``. Uses the ``real_falkordb_rag_factory``
+fixture (see ``conftest.py``) so each test runs against its own
+ephemeral graph and is cleaned up on teardown.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from graphrag_sdk.core.models import Attribute, Entity, Ontology, Relation
+
+from .conftest import _scripted_extraction_llm
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("RUN_INTEGRATION"),
+    reason="Set RUN_INTEGRATION=1 to run real-FalkorDB integration tests",
+)
+
+
+@pytest.fixture
+def starter_ontology() -> Ontology:
+    return Ontology(
+        entities=[
+            Entity(
+                label="Person",
+                properties=[Attribute(name="age", type="INTEGER")],
+            ),
+            Entity(label="Company"),
+        ],
+        relations=[
+            Relation(label="WORKS_AT", patterns=[("Person", "Company")]),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_rename_entity_relabels_data_nodes(
+    real_falkordb_rag_factory, starter_ontology
+):
+    from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+        ExactMatchResolution,
+    )
+
+    llm = _scripted_extraction_llm(
+        [("Alice", "Person", "An engineer"), ("Acme", "Company", "A firm")]
+    )
+    rag = real_falkordb_rag_factory(
+        llm=llm, resolver=ExactMatchResolution(), ontology=starter_ontology
+    )
+    await rag.ingest(text="Alice works at Acme.", document_id="doc1")
+
+    new_ontology = await rag.rename_entity("Person", "Human")
+    assert any(e.label == "Human" for e in new_ontology.entities)
+    assert not any(e.label == "Person" for e in new_ontology.entities)
+
+    stats = await rag.get_statistics()
+    assert "Human" in stats["entity_types"]
+    assert "Person" not in stats["entity_types"]
+
+
+@pytest.mark.asyncio
+async def test_drop_attribute_removes_property_and_declaration(
+    real_falkordb_rag_factory, starter_ontology
+):
+    from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+        ExactMatchResolution,
+    )
+
+    llm = _scripted_extraction_llm([("Alice", "Person", "An engineer")])
+    rag = real_falkordb_rag_factory(
+        llm=llm, resolver=ExactMatchResolution(), ontology=starter_ontology
+    )
+    await rag.ingest(text="Alice is mentioned.", document_id="doc1")
+
+    refreshed = await rag.drop_attribute("Person", "age")
+    person = next(e for e in refreshed.entities if e.label == "Person")
+    assert not any(a.name == "age" for a in person.properties)
+
+
+@pytest.mark.asyncio
+async def test_drop_entity_cascades_relations(
+    real_falkordb_rag_factory, starter_ontology
+):
+    from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+        ExactMatchResolution,
+    )
+
+    llm = _scripted_extraction_llm(
+        [("Alice", "Person", "x"), ("Acme", "Company", "y")]
+    )
+    rag = real_falkordb_rag_factory(
+        llm=llm, resolver=ExactMatchResolution(), ontology=starter_ontology
+    )
+    await rag.ingest(text="Alice works at Acme.", document_id="doc1")
+    new_ontology = await rag.drop_entity("Company")
+    assert not any(e.label == "Company" for e in new_ontology.entities)
+    # The WORKS_AT pattern (Person, Company) is no longer declarable since
+    # the Company entity is gone.
+    assert all(
+        ("Company" not in (s, t) for s, t in r.patterns)
+        for r in new_ontology.relations
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,5 +51,6 @@ nav:
   - Retrieval: retrieval.md
   - Storage: storage.md
   - Graph Schema: graph-schema.md
+  - Ontology Evolution: ontology-evolution.md
   - Benchmark: benchmark.md
   - API Reference: api-reference.md


### PR DESCRIPTION
## Summary

Follow-on to #256. PR #256 introduced a persistent ontology graph and a strict-by-default `OntologyStore.register()` that admits new labels but refuses any modification to an existing one. This PR adds the public seam to actually *evolve* the ontology after first ingest, under a strict design invariant: **a declared attribute is queryable on every instance of its owner entity type** — the SDK exposes no API that can declare schema your data doesn't match.

## The 15-method API surface

Every method is `async`, grouped by what it touches.

### Group 1 — Pure declarations (cheap, no LLM) — returns `Ontology`
- `set_entity_description`, `set_relation_description`, `set_attribute_description`
- `add_entity` (declaration only)
- `add_relation_pattern` (declaration only)

### Group 2 — Mechanical data migration (Cypher, no LLM) — returns `Ontology`
Data migration runs first; ontology graph is updated second. Idempotent on crash.
- `rename_entity`, `rename_attribute`, `rename_relation`
- `drop_entity` (cascades to relation patterns), `drop_relation`, `drop_relation_pattern`

### Group 3 — Atomic attribute evolution (LLM, invariant-enforcing) — returns `EvolutionResult`
The commit point is the ontology graph write — last. Backfill runs first; hard failures raise `OntologyEvolutionError` without committing the schema change.
- `add_attribute(owner_label, attribute, *, concurrency=4, dry_run=False)` — declare + LLM backfill across chunks mentioning the owner + ontology commit, atomically. Entity owners only.
- `drop_attribute(owner_label, name)` — REMOVE on every instance + ontology delete. Entity owners only.

Type changes go through `drop_attribute` + `add_attribute` (the LLM re-derives values from chunks — the only honest move when text is the source of truth). There is intentionally no `retype_attribute`.

### Group 4 — Opportunistic discovery (opt-in, not invariant-enforcing) — returns `BackfillResult`
- `backfill_entity(label, *, scope, concurrency=4, dry_run=False)` — re-scan chunks for any entities of this type you might have missed.
- `backfill_relation_pattern(rel_label, source, target, *, dry_run=False)` — re-scan candidate co-mention chunks for any edges of this pattern.

Declaring an entity type or relation pattern is "this is allowed," not "this exists." Zero instances is a valid state. Use these tools to opportunistically populate from the existing corpus when you want to.

## Concurrency

**Evolution calls are not safe to run concurrently with `ingest()` or with each other on the same graph.** The extractor reads the persisted ontology, and Group 2 / Group 4 calls use count-then-mutate Cypher across two statements. Gate evolution behind an application-level lock in multi-process deployments.

## Cost preview (`dry_run=True`)

`add_attribute`, `backfill_entity`, and `backfill_relation_pattern` accept `dry_run=True`. The scope query runs (cheap); the LLM is not invoked; the result carries `chunks_in_scope` so you can preview cost before committing to a large corpus-wide sweep.

## New types exported

`EvolutionResult` (return of `add_attribute`), `OntologyEvolutionError` (raised by `add_attribute` on hard failure, carries `failed_chunks`), `BackfillResult` (return of Group 4 methods). All under `graphrag_sdk`.

## Documentation

`docs/ontology-evolution.md` — full design doc covering the invariant, all four groups, atomicity model, failure & retry, type-change pattern, concurrency, cost preview, end-to-end example, reference tables, and what's not in the API and why.

`examples/09_ontology_evolution.py` — runnable walkthrough against real FalkorDB + LiteLLM.

## Test plan

- [x] `pytest graphrag_sdk/tests/test_ontology_evolve.py graphrag_sdk/tests/test_backfill.py` — 58 unit tests pass
- [x] Full unit suite — **960 passed, 24 skipped** (no regressions)
- [x] Package-level imports resolve cleanly for `EvolutionResult`, `OntologyEvolutionError`, `BackfillResult`
- [x] Lint + format clean on touched files
- [x] `examples/09_ontology_evolution.py` compiles
- [ ] `RUN_INTEGRATION=1 OPENAI_API_KEY=... pytest tests/test_backfill_integration.py` — needs reviewer with both
- [ ] Run `examples/09_ontology_evolution.py` against real FalkorDB + OpenAI to validate the focused prompts on a non-trivial corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)