### PR TITLE
feat: agentic retrieval - graph-walk, skills, MCP server, and MultiPath path router

### DIFF
--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -56,6 +56,7 @@ litellm = ["litellm>=1.83.0,<2.0"]
 openrouter = ["openai>=1.0,<3.0"]
 fastcoref = ["fastcoref>=2.0"]
 spacy = ["spacy>=3.0"]
+mcp = ["mcp>=1.0", "uvicorn>=0.23", "starlette>=0.37"]
 all = [
     "openai>=1.0,<3.0",
     "anthropic>=0.20,<1.0",
@@ -78,6 +79,9 @@ Documentation = "https://falkordb.github.io/GraphRAG-SDK/"
 Repository = "https://github.com/FalkorDB/GraphRAG-SDK"
 "Bug Tracker" = "https://github.com/FalkorDB/GraphRAG-SDK/issues"
 Changelog = "https://github.com/FalkorDB/GraphRAG-SDK/blob/main/CHANGELOG.md"
+
+[project.scripts]
+graphrag-mcp = "graphrag_sdk.mcp.__main__:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/graphrag_sdk"]

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -25,6 +25,8 @@ from graphrag_sdk.core.exceptions import (
     LatencyBudgetExceededError,
 )
 from graphrag_sdk.core.models import (
+    AgentStep,
+    AgentTrace,
     ApplyChangesResult,
     Attribute,
     BatchEntry,
@@ -46,7 +48,9 @@ from graphrag_sdk.core.models import (
     ResolutionResult,
     RetrieverResult,
     RetrieverResultItem,
+    ScoredPath,
     SearchType,
+    SkillResult,
     TextChunk,
     TextChunks,
     UpdateResult,
@@ -110,12 +114,35 @@ from graphrag_sdk.ingestion.resolution_strategies.llm_verified_resolution import
 from graphrag_sdk.ingestion.resolution_strategies.semantic_resolution import (
     SemanticResolution,
 )
+from graphrag_sdk.retrieval.agentic import AgenticRetrieval, ToolRegistry
+from graphrag_sdk.retrieval.graph_walk import (
+    DynamicGraphWalk,
+    GraphWalkRetrieval,
+    score_path,
+)
 
 # ── Retrieval Strategies ────────────────────────────────────────
 from graphrag_sdk.retrieval.reranking_strategies.base import RerankingStrategy
 from graphrag_sdk.retrieval.reranking_strategies.cosine import CosineReranker
 from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
 from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval
+from graphrag_sdk.retrieval.strategies.path_router import (
+    RETRIEVAL_PATHS,
+    HeuristicPathRouter,
+    LLMPathRouter,
+)
+
+# ── Skills ──────────────────────────────────────────────────────
+from graphrag_sdk.skills import (
+    SKILL_REGISTRY,
+    ContradictionDetectionSkill,
+    EntityComparisonSkill,
+    GapAnalysisSkill,
+    ImpactAnalysisSkill,
+    Skill,
+    TimelineReconstructionSkill,
+    build_skill,
+)
 
 # ── Storage ─────────────────────────────────────────────────────
 from graphrag_sdk.storage.graph_store import GraphStore
@@ -133,6 +160,8 @@ __all__ = [
     "GraphRAG",
     # Core
     "ApplyChangesResult",
+    "AgentStep",
+    "AgentTrace",
     "BatchEntry",
     "ChatMessage",
     "ConnectionConfig",
@@ -166,7 +195,9 @@ __all__ = [
     "ResolutionResult",
     "RetrieverResult",
     "RetrieverResultItem",
+    "ScoredPath",
     "SearchType",
+    "SkillResult",
     "TextChunk",
     "TextChunks",
     "UpdateResult",
@@ -199,10 +230,27 @@ __all__ = [
     "LLMVerifiedResolution",
     "SemanticResolution",
     # Retrieval
+    "AgenticRetrieval",
     "CosineReranker",
+    "DynamicGraphWalk",
+    "GraphWalkRetrieval",
+    "HeuristicPathRouter",
+    "LLMPathRouter",
     "MultiPathRetrieval",
+    "RETRIEVAL_PATHS",
     "RerankingStrategy",
     "RetrievalStrategy",
+    "ToolRegistry",
+    "score_path",
+    # Skills
+    "Skill",
+    "SKILL_REGISTRY",
+    "build_skill",
+    "ContradictionDetectionSkill",
+    "EntityComparisonSkill",
+    "GapAnalysisSkill",
+    "ImpactAnalysisSkill",
+    "TimelineReconstructionSkill",
     # Storage
     "GraphStore",
     "OntologyContradictionError",

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -37,6 +37,7 @@ from graphrag_sdk.core.models import (
     Ontology,
     RagResult,
     RetrieverResult,
+    SkillResult,
     UpdateResult,
 )
 from graphrag_sdk.core.providers import Embedder, LLMInterface
@@ -3012,6 +3013,33 @@ class GraphRAG:
     # IDE autocomplete and mypy enforcement on keyword arguments. When you
     # add a kwarg to an async method, also add it to the matching wrapper
     # below — the in-line "keep in sync with" notes mark the pairings.
+
+    async def run_skill(
+        self,
+        skill: str,
+        *,
+        ctx: Context | None = None,
+        **params: Any,
+    ) -> SkillResult:
+        """Run a high-level reasoning skill against the graph (Phase 3.4).
+
+        Args:
+            skill: Registered skill name (e.g. ``"entity_comparison"``,
+                ``"impact_analysis"``, ``"contradiction_detection"``,
+                ``"gap_analysis"``, ``"timeline_reconstruction"``).
+            ctx: Execution context.
+            **params: Skill-specific arguments.
+
+        Returns:
+            ``SkillResult`` with the skill's structured findings.
+        """
+        from graphrag_sdk.skills import build_skill
+
+        if ctx is None:
+            ctx = Context()
+        await self._ensure_ontology_initialized()
+        skill_impl = build_skill(skill, self._graph_store, self.llm)
+        return await skill_impl.run(ctx, **params)
 
     def retrieve_sync(
         self,

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -783,6 +783,53 @@ class SearchType(str, Enum):
     HYBRID = "hybrid"
 
 
+# ── Agentic / Graph-Walk / Skill Types (Phase 3) ─────────────────
+
+
+class AgentStep(DataModel):
+    """A single Thought→Action→Observation step in the agentic loop."""
+
+    index: int
+    thought: str = ""
+    action: str = ""
+    action_input: dict[str, Any] = Field(default_factory=dict)
+    observation: str = ""
+
+
+class AgentTrace(DataModel):
+    """Full record of an agentic retrieval run."""
+
+    steps: list[AgentStep] = Field(default_factory=list)
+    stop_reason: str = ""
+    answer: str = ""
+
+    @property
+    def num_steps(self) -> int:
+        return len(self.steps)
+
+
+class ScoredPath(DataModel):
+    """A scored path through the knowledge graph (graph-walk output)."""
+
+    nodes: list[str] = Field(default_factory=list)
+    score: float = 0.0
+    edges: list[str] = Field(default_factory=list)
+
+    @property
+    def length(self) -> int:
+        """Number of hops (edges) in the path."""
+        return max(0, len(self.nodes) - 1)
+
+
+class SkillResult(DataModel):
+    """Structured output of a high-level reasoning skill."""
+
+    skill: str
+    summary: str = ""
+    data: dict[str, Any] = Field(default_factory=dict)
+    sources: list[str] = Field(default_factory=list)
+
+
 # ── Deprecation aliases ──────────────────────────────────────────
 #
 # These older names were used prior to the v1.2.x ontology vocabulary rename

--- a/graphrag_sdk/src/graphrag_sdk/mcp/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/__init__.py
@@ -1,0 +1,11 @@
+# GraphRAG SDK — MCP (Phase 3.2)
+# Model Context Protocol server exposing GraphRAG as 8 tools over
+# stdio / SSE transports. Requires the optional `mcp` extra for the live
+# server; the tool definitions themselves have no extra dependency.
+
+from __future__ import annotations
+
+from graphrag_sdk.mcp.server import GraphRAGMCPServer
+from graphrag_sdk.mcp.tools import GraphRAGToolset, MCPTool
+
+__all__ = ["GraphRAGMCPServer", "GraphRAGToolset", "MCPTool"]

--- a/graphrag_sdk/src/graphrag_sdk/mcp/__main__.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/__main__.py
@@ -36,13 +36,16 @@ def _build_rag() -> object:
 def main() -> None:
     parser = argparse.ArgumentParser(description="GraphRAG SDK MCP server")
     parser.add_argument(
-        "--transport", choices=["stdio", "sse"], default="stdio",
+        "--transport",
+        choices=["stdio", "sse"],
+        default="stdio",
         help="Transport to serve over (default: stdio).",
     )
     parser.add_argument("--host", default="127.0.0.1", help="SSE bind host.")
     parser.add_argument("--port", type=int, default=8080, help="SSE bind port.")
     parser.add_argument(
-        "--log-level", default="INFO",
+        "--log-level",
+        default="INFO",
         help="Logging level (DEBUG, INFO, WARNING, ...).",
     )
     args = parser.parse_args()

--- a/graphrag_sdk/src/graphrag_sdk/mcp/__main__.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/__main__.py
@@ -52,7 +52,13 @@ def main() -> None:
 
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
 
-    from graphrag_sdk.mcp.server import GraphRAGMCPServer
+    try:
+        from graphrag_sdk.mcp.server import GraphRAGMCPServer
+    except ImportError as exc:
+        raise SystemExit(
+            "The MCP server requires extra dependencies. "
+            "Install them with: pip install 'graphrag-sdk[mcp]'"
+        ) from exc
 
     rag = _build_rag()
     server = GraphRAGMCPServer(rag)
@@ -64,7 +70,13 @@ def main() -> None:
             else:
                 await server.run("stdio")
 
-    asyncio.run(_serve())
+    try:
+        asyncio.run(_serve())
+    except ImportError as exc:
+        raise SystemExit(
+            "The MCP server requires extra dependencies. "
+            "Install them with: pip install 'graphrag-sdk[mcp]'"
+        ) from exc
 
 
 if __name__ == "__main__":

--- a/graphrag_sdk/src/graphrag_sdk/mcp/__main__.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/__main__.py
@@ -1,0 +1,68 @@
+# GraphRAG SDK — MCP server CLI (Phase 3.2)
+# Usage:
+#   python -m graphrag_sdk.mcp --transport stdio
+#   python -m graphrag_sdk.mcp --transport sse --host 0.0.0.0 --port 8080
+#
+# Connection and model are read from environment variables / CLI flags so
+# the server can be launched by an MCP client without code.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+
+
+def _build_rag() -> object:
+    from graphrag_sdk.api.main import GraphRAG
+    from graphrag_sdk.core.connection import ConnectionConfig
+    from graphrag_sdk.core.providers import LiteLLM, LiteLLMEmbedder
+
+    config = ConnectionConfig(
+        host=os.getenv("FALKOR_HOST", "localhost"),
+        port=int(os.getenv("FALKOR_PORT", "6379")),
+        username=os.getenv("FALKOR_USERNAME") or None,
+        password=os.getenv("FALKOR_PASSWORD") or None,
+        graph_name=os.getenv("GRAPHRAG_GRAPH", "graphrag"),
+    )
+    llm = LiteLLM(model_name=os.getenv("GRAPHRAG_MODEL", "gpt-4o-mini"))
+    embedder = LiteLLMEmbedder(
+        model_name=os.getenv("GRAPHRAG_EMBED_MODEL", "text-embedding-3-small")
+    )
+    return GraphRAG(connection=config, llm=llm, embedder=embedder)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="GraphRAG SDK MCP server")
+    parser.add_argument(
+        "--transport", choices=["stdio", "sse"], default="stdio",
+        help="Transport to serve over (default: stdio).",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="SSE bind host.")
+    parser.add_argument("--port", type=int, default=8080, help="SSE bind port.")
+    parser.add_argument(
+        "--log-level", default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ...).",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    from graphrag_sdk.mcp.server import GraphRAGMCPServer
+
+    rag = _build_rag()
+    server = GraphRAGMCPServer(rag)
+
+    async def _serve() -> None:
+        async with rag:  # type: ignore[attr-defined]
+            if args.transport == "sse":
+                await server.run("sse", host=args.host, port=args.port)
+            else:
+                await server.run("stdio")
+
+    asyncio.run(_serve())
+
+
+if __name__ == "__main__":
+    main()

--- a/graphrag_sdk/src/graphrag_sdk/mcp/server.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/server.py
@@ -1,0 +1,122 @@
+# GraphRAG SDK — MCP: Server (Phase 3.2)
+# Adapts the transport-agnostic GraphRAGToolset into a live MCP server
+# over stdio or SSE. The `mcp` package is an optional dependency, imported
+# lazily so the rest of the SDK works without it.
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from graphrag_sdk.mcp.tools import GraphRAGToolset
+
+logger = logging.getLogger(__name__)
+
+Transport = Literal["stdio", "sse"]
+
+
+def _require_mcp() -> Any:
+    try:
+        import mcp  # noqa: F401
+        import mcp.server  # noqa: F401
+
+        return mcp
+    except ImportError as exc:  # pragma: no cover - exercised only without extra
+        raise ImportError(
+            "The MCP server requires the `mcp` package. "
+            "Install with: pip install graphrag-sdk[mcp]"
+        ) from exc
+
+
+class GraphRAGMCPServer:
+    """MCP server exposing a GraphRAG instance as 8 tools.
+
+    Args:
+        rag: A constructed ``GraphRAG`` facade.
+        name: Server name advertised to MCP clients.
+    """
+
+    def __init__(self, rag: Any, *, name: str = "graphrag-sdk") -> None:
+        self._rag = rag
+        self._name = name
+        self._toolset = GraphRAGToolset(rag)
+
+    @property
+    def toolset(self) -> GraphRAGToolset:
+        return self._toolset
+
+    def _build_server(self) -> Any:
+        """Construct the underlying ``mcp.server.Server`` with handlers."""
+        _require_mcp()
+        from mcp import types  # type: ignore
+        from mcp.server import Server  # type: ignore
+
+        server = Server(self._name)
+        toolset = self._toolset
+
+        @server.list_tools()  # type: ignore[misc]
+        async def _list_tools() -> list[Any]:
+            return [
+                types.Tool(
+                    name=t.name,
+                    description=t.description,
+                    inputSchema=t.input_schema,
+                )
+                for t in toolset.tools
+            ]
+
+        @server.call_tool()  # type: ignore[misc]
+        async def _call_tool(name: str, arguments: dict[str, Any]) -> list[Any]:
+            tool = toolset.by_name(name)
+            if tool is None:
+                return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
+            text = await tool.handler(arguments or {})
+            return [types.TextContent(type="text", text=text)]
+
+        return server
+
+    async def run(self, transport: Transport = "stdio", **kwargs: Any) -> None:
+        """Run the server over the given transport until the client disconnects."""
+        _require_mcp()
+        server = self._build_server()
+        init_options = server.create_initialization_options()
+
+        if transport == "stdio":
+            from mcp.server.stdio import stdio_server  # type: ignore
+
+            async with stdio_server() as (read, write):
+                await server.run(read, write, init_options)
+        elif transport == "sse":
+            await self._run_sse(server, init_options, **kwargs)
+        else:  # pragma: no cover - guarded by typing
+            raise ValueError(f"Unsupported transport: {transport!r}")
+
+    async def _run_sse(
+        self,
+        server: Any,
+        init_options: Any,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 8080,
+    ) -> None:  # pragma: no cover - network server
+        import uvicorn  # type: ignore
+        from mcp.server.sse import SseServerTransport  # type: ignore
+        from starlette.applications import Starlette  # type: ignore
+        from starlette.routing import Mount, Route  # type: ignore
+
+        sse = SseServerTransport("/messages/")
+
+        async def handle_sse(request: Any) -> None:
+            async with sse.connect_sse(
+                request.scope, request.receive, request._send
+            ) as (read, write):
+                await server.run(read, write, init_options)
+
+        app = Starlette(
+            routes=[
+                Route("/sse", endpoint=handle_sse),
+                Mount("/messages/", app=sse.handle_post_message),
+            ]
+        )
+        config = uvicorn.Config(app, host=host, port=port, log_level="info")
+        await uvicorn.Server(config).serve()

--- a/graphrag_sdk/src/graphrag_sdk/mcp/server.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/server.py
@@ -69,7 +69,11 @@ class GraphRAGMCPServer:
             tool = toolset.by_name(name)
             if tool is None:
                 return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
-            text = await tool.handler(arguments or {})
+            try:
+                text = await tool.handler(arguments or {})
+            except Exception as exc:  # noqa: BLE001 - surface as tool-level error
+                logger.warning("MCP tool %s failed: %s", name, exc)
+                return [types.TextContent(type="text", text=f"Error running tool '{name}': {exc}")]
             return [types.TextContent(type="text", text=text)]
 
         return server

--- a/graphrag_sdk/src/graphrag_sdk/mcp/server.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/server.py
@@ -23,8 +23,7 @@ def _require_mcp() -> Any:
         return mcp
     except ImportError as exc:  # pragma: no cover - exercised only without extra
         raise ImportError(
-            "The MCP server requires the `mcp` package. "
-            "Install with: pip install graphrag-sdk[mcp]"
+            "The MCP server requires the `mcp` package. Install with: pip install graphrag-sdk[mcp]"
         ) from exc
 
 
@@ -107,9 +106,10 @@ class GraphRAGMCPServer:
         sse = SseServerTransport("/messages/")
 
         async def handle_sse(request: Any) -> None:
-            async with sse.connect_sse(
-                request.scope, request.receive, request._send
-            ) as (read, write):
+            async with sse.connect_sse(request.scope, request.receive, request._send) as (
+                read,
+                write,
+            ):
                 await server.run(read, write, init_options)
 
         app = Starlette(

--- a/graphrag_sdk/src/graphrag_sdk/mcp/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/tools.py
@@ -1,0 +1,218 @@
+# GraphRAG SDK — MCP: Tool definitions (Phase 3.2)
+# Transport-agnostic tool specs that wrap a GraphRAG facade. Kept free of
+# any `mcp` package import so they can be unit-tested without the optional
+# dependency installed; server.py adapts these into a live MCP server.
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+MCPHandler = Callable[[dict[str, Any]], Awaitable[str]]
+
+
+@dataclass
+class MCPTool:
+    """A single MCP tool: name, description, JSON input schema, and handler."""
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    handler: MCPHandler
+
+    def to_spec(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self.input_schema,
+        }
+
+
+def _obj(props: dict[str, Any], required: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": props,
+        "required": required or [],
+    }
+
+
+@dataclass
+class GraphRAGToolset:
+    """Builds the standard 8-tool MCP surface over a GraphRAG instance."""
+
+    rag: Any
+    tools: list[MCPTool] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.tools = self._build()
+
+    def by_name(self, name: str) -> MCPTool | None:
+        for tool in self.tools:
+            if tool.name == name:
+                return tool
+        return None
+
+    def specs(self) -> list[dict[str, Any]]:
+        return [t.to_spec() for t in self.tools]
+
+    def _build(self) -> list[MCPTool]:
+        rag = self.rag
+
+        async def ingest(args: dict[str, Any]) -> str:
+            result = await rag.ingest(
+                args["text"], document_id=args.get("document_id")
+            )
+            return _dump(
+                {
+                    "nodes_created": getattr(result, "nodes_created", None),
+                    "relationships_created": getattr(result, "relationships_created", None),
+                    "chunks_indexed": getattr(result, "chunks_indexed", None),
+                }
+            )
+
+        async def retrieve(args: dict[str, Any]) -> str:
+            result = await rag.retrieve(args["question"])
+            return _dump({"items": [i.content for i in result.items]})
+
+        async def answer(args: dict[str, Any]) -> str:
+            result = await rag.completion(args["question"])
+            return _dump({"answer": result.answer, "metadata": result.metadata})
+
+        async def cypher_query(args: dict[str, Any]) -> str:
+            from graphrag_sdk.retrieval.agentic.tools import is_read_only_cypher
+
+            cypher = args["cypher"]
+            if not is_read_only_cypher(cypher):
+                return "Error: only read-only Cypher is permitted via MCP."
+            result = await rag._graph_store.query_raw(cypher)
+            rows = list(getattr(result, "result_set", []) or [])
+            return _dump({"rows": [[_jsonable(c) for c in row] for row in rows]})
+
+        async def graph_walk(args: dict[str, Any]) -> str:
+            from graphrag_sdk.retrieval.graph_walk import DynamicGraphWalk
+
+            store = rag._graph_store
+            try:
+                weights = await store.pagerank()
+            except Exception:
+                weights = {}
+
+            async def neighbor_fn(node_id: str) -> list[tuple[str, float, str]]:
+                return await store.weighted_neighbors(node_id)
+
+            walk = DynamicGraphWalk(
+                neighbor_fn,
+                node_weights=weights,
+                beam_width=int(args.get("beam_width", 5)),
+                max_depth=int(args.get("max_depth", 3)),
+            )
+            goal = args.get("goal")
+            if goal:
+                path = await walk.bidirectional_search(args["start"], str(goal))
+                return _dump({"path": path.model_dump() if path else None})
+            paths = await walk.beam_search(args["start"])
+            return _dump({"paths": [p.model_dump() for p in paths]})
+
+        async def run_skill(args: dict[str, Any]) -> str:
+            from graphrag_sdk.skills import build_skill
+
+            skill = build_skill(args["skill"], rag._graph_store, rag.llm)
+            params = args.get("params", {}) or {}
+            result = await skill.run(None, **params)
+            return _dump(result.model_dump())
+
+        async def get_statistics(_args: dict[str, Any]) -> str:
+            return _dump(await rag.get_statistics())
+
+        async def get_ontology(_args: dict[str, Any]) -> str:
+            ontology = await rag.get_ontology()
+            return _dump(ontology.model_dump() if hasattr(ontology, "model_dump") else {})
+
+        return [
+            MCPTool(
+                "ingest",
+                "Ingest raw text into the knowledge graph.",
+                _obj(
+                    {
+                        "text": {"type": "string"},
+                        "document_id": {"type": "string"},
+                    },
+                    ["text"],
+                ),
+                ingest,
+            ),
+            MCPTool(
+                "retrieve",
+                "Retrieve graph context for a question (no generation).",
+                _obj({"question": {"type": "string"}}, ["question"]),
+                retrieve,
+            ),
+            MCPTool(
+                "answer",
+                "Full RAG pipeline: retrieve context and generate an answer.",
+                _obj({"question": {"type": "string"}}, ["question"]),
+                answer,
+            ),
+            MCPTool(
+                "cypher_query",
+                "Run a read-only Cypher query against the graph.",
+                _obj({"cypher": {"type": "string"}}, ["cypher"]),
+                cypher_query,
+            ),
+            MCPTool(
+                "graph_walk",
+                "PageRank-weighted graph walk from a start entity.",
+                _obj(
+                    {
+                        "start": {"type": "string"},
+                        "goal": {"type": "string"},
+                        "beam_width": {"type": "integer"},
+                        "max_depth": {"type": "integer"},
+                    },
+                    ["start"],
+                ),
+                graph_walk,
+            ),
+            MCPTool(
+                "run_skill",
+                "Run a high-level skill (entity_comparison, impact_analysis, "
+                "contradiction_detection, gap_analysis, timeline_reconstruction).",
+                _obj(
+                    {
+                        "skill": {"type": "string"},
+                        "params": {"type": "object"},
+                    },
+                    ["skill"],
+                ),
+                run_skill,
+            ),
+            MCPTool(
+                "get_statistics",
+                "Return node/edge counts and graph statistics.",
+                _obj({}),
+                get_statistics,
+            ),
+            MCPTool(
+                "get_ontology",
+                "Return the active ontology (entities, relations, attributes).",
+                _obj({}),
+                get_ontology,
+            ),
+        ]
+
+
+def _jsonable(value: Any) -> Any:
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _dump(obj: Any) -> str:
+    return json.dumps(obj, default=str, ensure_ascii=False)

--- a/graphrag_sdk/src/graphrag_sdk/mcp/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/tools.py
@@ -64,7 +64,7 @@ class GraphRAGToolset:
         rag = self.rag
 
         async def ingest(args: dict[str, Any]) -> str:
-            result = await rag.ingest(args["text"], document_id=args.get("document_id"))
+            result = await rag.ingest(text=args["text"], document_id=args.get("document_id"))
             return _dump(
                 {
                     "nodes_created": getattr(result, "nodes_created", None),

--- a/graphrag_sdk/src/graphrag_sdk/mcp/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/mcp/tools.py
@@ -64,9 +64,7 @@ class GraphRAGToolset:
         rag = self.rag
 
         async def ingest(args: dict[str, Any]) -> str:
-            result = await rag.ingest(
-                args["text"], document_id=args.get("document_id")
-            )
+            result = await rag.ingest(args["text"], document_id=args.get("document_id"))
             return _dump(
                 {
                     "nodes_created": getattr(result, "nodes_created", None),

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/__init__.py
@@ -1,14 +1,32 @@
 # GraphRAG SDK — Retrieval
 # Intelligent search: strategies, routing, reranking.
 
+from graphrag_sdk.retrieval.agentic import AgenticRetrieval
+from graphrag_sdk.retrieval.graph_walk import (
+    DynamicGraphWalk,
+    GraphWalkRetrieval,
+    score_path,
+)
 from graphrag_sdk.retrieval.reranking_strategies.base import RerankingStrategy
 from graphrag_sdk.retrieval.reranking_strategies.cosine import CosineReranker
 from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
 from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval
+from graphrag_sdk.retrieval.strategies.path_router import (
+    RETRIEVAL_PATHS,
+    HeuristicPathRouter,
+    LLMPathRouter,
+)
 
 __all__ = [
+    "AgenticRetrieval",
     "CosineReranker",
+    "DynamicGraphWalk",
+    "GraphWalkRetrieval",
+    "HeuristicPathRouter",
+    "LLMPathRouter",
     "MultiPathRetrieval",
+    "RETRIEVAL_PATHS",
     "RerankingStrategy",
     "RetrievalStrategy",
+    "score_path",
 ]

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/__init__.py
@@ -1,0 +1,20 @@
+# GraphRAG SDK — Agentic Retrieval (Phase 3.1)
+
+from __future__ import annotations
+
+from graphrag_sdk.retrieval.agentic.loop import AgenticRetrieval, parse_react_step
+from graphrag_sdk.retrieval.agentic.tools import (
+    Tool,
+    ToolRegistry,
+    build_default_registry,
+    is_read_only_cypher,
+)
+
+__all__ = [
+    "AgenticRetrieval",
+    "parse_react_step",
+    "Tool",
+    "ToolRegistry",
+    "build_default_registry",
+    "is_read_only_cypher",
+]

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/loop.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/loop.py
@@ -127,9 +127,7 @@ class AgenticRetrieval(RetrievalStrategy):
             parsed = parse_react_step(text)
 
             if "final_answer" in parsed:
-                trace.steps.append(
-                    AgentStep(index=step_idx, thought=parsed.get("thought", ""))
-                )
+                trace.steps.append(AgentStep(index=step_idx, thought=parsed.get("thought", "")))
                 trace.answer = parsed["final_answer"]
                 stop_reason = "final_answer"
                 ctx.log(f"Agentic loop produced final answer at step {step_idx}")

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/loop.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/loop.py
@@ -1,0 +1,182 @@
+# GraphRAG SDK — Agentic Retrieval: ReAct loop (Phase 3.1)
+# A budget-aware Thought→Action→Observation controller. Reuses existing
+# retrieval/storage/skill primitives as tools (see tools.py) and stops on
+# a Final Answer, a step cap, or an exhausted latency budget.
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import (
+    AgentStep,
+    AgentTrace,
+    RawSearchResult,
+    RetrieverResult,
+    RetrieverResultItem,
+)
+from graphrag_sdk.retrieval.agentic.prompts import render_system_prompt
+from graphrag_sdk.retrieval.agentic.tools import ToolRegistry, build_default_registry
+from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
+
+logger = logging.getLogger(__name__)
+
+_ACTION_RE = re.compile(r"Action\s*:\s*(.+)", re.IGNORECASE)
+_ACTION_INPUT_RE = re.compile(r"Action\s*Input\s*:\s*(\{.*\})", re.IGNORECASE | re.DOTALL)
+_THOUGHT_RE = re.compile(r"Thought\s*:\s*(.+)", re.IGNORECASE)
+_FINAL_RE = re.compile(r"Final\s*Answer\s*:\s*(.+)", re.IGNORECASE | re.DOTALL)
+
+
+def parse_react_step(text: str) -> dict[str, Any]:
+    """Parse one ReAct turn into thought/action/action_input/final_answer."""
+    final = _FINAL_RE.search(text)
+    if final:
+        thought = _THOUGHT_RE.search(text)
+        return {
+            "thought": thought.group(1).strip() if thought else "",
+            "final_answer": final.group(1).strip(),
+        }
+
+    thought_m = _THOUGHT_RE.search(text)
+    action_m = _ACTION_RE.search(text)
+    input_m = _ACTION_INPUT_RE.search(text)
+
+    action = ""
+    if action_m:
+        # Take only the first line of the action and strip stray input text.
+        action = action_m.group(1).splitlines()[0].strip()
+        action = re.split(r"\bAction\s*Input\b", action, flags=re.IGNORECASE)[0].strip()
+
+    action_input: dict[str, Any] = {}
+    if input_m:
+        try:
+            parsed = json.loads(input_m.group(1).strip())
+            if isinstance(parsed, dict):
+                action_input = parsed
+        except (ValueError, TypeError):
+            action_input = {}
+
+    return {
+        "thought": thought_m.group(1).splitlines()[0].strip() if thought_m else "",
+        "action": action,
+        "action_input": action_input,
+    }
+
+
+class AgenticRetrieval(RetrievalStrategy):
+    """ReAct-style agentic retrieval strategy.
+
+    Drives an LLM tool loop that searches, traverses, runs Cypher, and
+    invokes skills until it produces a Final Answer or hits the step /
+    latency budget. The collected observations become retrieval items and
+    the full reasoning trace is exposed in ``RetrieverResult.metadata``.
+
+    Args:
+        llm: LLM provider (uses ``ainvoke``).
+        registry: Tool registry. If omitted, a default registry is built
+            from ``strategy`` + ``graph_store``.
+        strategy: Inner retrieval strategy backing the ``search`` tool.
+        graph_store: GraphStore backing ``cypher``/``traverse``/skills.
+        max_steps: Hard cap on Thought/Action iterations.
+    """
+
+    def __init__(
+        self,
+        llm: Any,
+        *,
+        registry: ToolRegistry | None = None,
+        strategy: Any | None = None,
+        graph_store: Any | None = None,
+        vector_store: Any | None = None,
+        max_steps: int = 6,
+    ) -> None:
+        super().__init__(graph_store=graph_store, vector_store=vector_store)
+        if max_steps < 1:
+            raise ValueError("max_steps must be >= 1")
+        self._llm = llm
+        self._max_steps = max_steps
+        self._registry = registry or build_default_registry(
+            strategy=strategy,
+            graph_store=graph_store,
+            llm=llm,
+        )
+
+    async def _execute(self, query: str, ctx: Context, **kwargs: Any) -> RawSearchResult:
+        system = render_system_prompt(
+            tool_descriptions=self._registry.describe(),
+            tool_names=", ".join(self._registry.names()),
+        )
+        scratchpad = f"Question: {query}\n"
+        trace = AgentTrace()
+        observations: list[str] = []
+        stop_reason = "max_steps"
+
+        for step_idx in range(self._max_steps):
+            if ctx.budget_exceeded:
+                stop_reason = "budget_exceeded"
+                ctx.log("Agentic loop stopped: latency budget exhausted")
+                break
+
+            prompt = f"{system}\n\n{scratchpad}\nThought:"
+            timeout = ctx.provider_timeout_seconds(f"agentic step {step_idx}")
+            response = await self._llm.ainvoke(prompt, timeout=timeout)
+            text = response.content or ""
+            parsed = parse_react_step(text)
+
+            if "final_answer" in parsed:
+                trace.steps.append(
+                    AgentStep(index=step_idx, thought=parsed.get("thought", ""))
+                )
+                trace.answer = parsed["final_answer"]
+                stop_reason = "final_answer"
+                ctx.log(f"Agentic loop produced final answer at step {step_idx}")
+                break
+
+            action = parsed.get("action", "")
+            action_input = parsed.get("action_input", {})
+            if not action:
+                stop_reason = "no_action"
+                ctx.log("Agentic loop stopped: model emitted no action")
+                break
+
+            observation = await self._registry.run(action, action_input, ctx)
+            observations.append(observation)
+            trace.steps.append(
+                AgentStep(
+                    index=step_idx,
+                    thought=parsed.get("thought", ""),
+                    action=action,
+                    action_input=action_input,
+                    observation=observation,
+                )
+            )
+            scratchpad += (
+                f"Thought: {parsed.get('thought', '')}\n"
+                f"Action: {action}\n"
+                f"Action Input: {json.dumps(action_input)}\n"
+                f"Observation: {observation}\n"
+            )
+
+        trace.stop_reason = stop_reason
+        records: list[Any] = list(observations)
+        if trace.answer:
+            records.append(f"Answer: {trace.answer}")
+        return RawSearchResult(
+            records=records,
+            metadata={
+                "agent_trace": trace.model_dump(),
+                "stop_reason": stop_reason,
+                "num_steps": trace.num_steps,
+                "answer": trace.answer,
+            },
+        )
+
+    def _format(self, raw: RawSearchResult) -> RetrieverResult:
+        items = [
+            RetrieverResultItem(content=str(rec), metadata={"source": "agentic"})
+            for rec in raw.records
+        ]
+        return RetrieverResult(items=items, metadata=raw.metadata)

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/loop.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/loop.py
@@ -25,9 +25,23 @@ from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
 logger = logging.getLogger(__name__)
 
 _ACTION_RE = re.compile(r"Action\s*:\s*(.+)", re.IGNORECASE)
-_ACTION_INPUT_RE = re.compile(r"Action\s*Input\s*:\s*(\{.*\})", re.IGNORECASE | re.DOTALL)
+_ACTION_INPUT_RE = re.compile(r"Action\s*Input\s*:\s*(\{)", re.IGNORECASE)
 _THOUGHT_RE = re.compile(r"Thought\s*:\s*(.+)", re.IGNORECASE)
 _FINAL_RE = re.compile(r"Final\s*Answer\s*:\s*(.+)", re.IGNORECASE | re.DOTALL)
+
+
+def _parse_action_input(text: str, start: int) -> dict[str, Any]:
+    """Decode the JSON object starting at ``start`` (an opening brace).
+
+    Uses ``raw_decode`` so parsing stops at the object's matching close brace —
+    trailing prose or a hallucinated ``Observation:`` line can't corrupt the
+    arguments the way a greedy first-``{``-to-last-``}`` capture did.
+    """
+    try:
+        parsed, _ = json.JSONDecoder().raw_decode(text, start)
+    except (ValueError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def parse_react_step(text: str) -> dict[str, Any]:
@@ -52,12 +66,7 @@ def parse_react_step(text: str) -> dict[str, Any]:
 
     action_input: dict[str, Any] = {}
     if input_m:
-        try:
-            parsed = json.loads(input_m.group(1).strip())
-            if isinstance(parsed, dict):
-                action_input = parsed
-        except (ValueError, TypeError):
-            action_input = {}
+        action_input = _parse_action_input(text, input_m.start(1))
 
     return {
         "thought": thought_m.group(1).splitlines()[0].strip() if thought_m else "",

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/prompts.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/prompts.py
@@ -49,6 +49,12 @@ Rules:
 - Emit only ONE Action per step and then stop, waiting for the Observation.
 - Action Input MUST be valid JSON on a single line.
 - Prefer the fewest steps necessary. Do not invent tool names.
+- For "count", "how many", "list all", or any exhaustive enumeration, use the
+  `cypher` tool to retrieve the COMPLETE set (e.g. MATCH (p:Person) RETURN
+  p.name) rather than `search`, which only returns the top-k most relevant
+  items and cannot count reliably. Raise `max_rows` to cover everything.
+- When `search` misses breadth, retry it with larger limits (e.g.
+  max_entities / chunk_top_k / max_passages_out) before concluding.
 """
 
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/prompts.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/prompts.py
@@ -1,0 +1,60 @@
+# GraphRAG SDK — Agentic Retrieval: ReAct prompts (Phase 3.1)
+
+from __future__ import annotations
+
+GRAPH_SCHEMA_HINT = """Knowledge-graph storage model (use this when writing Cypher):
+- Entities are nodes labelled `:__Entity__` (and a type label such as `:Person`)
+  with properties `id`, `name`, and `description`.
+- Relationships between entities are ALWAYS stored as
+  `(:__Entity__)-[r:RELATES]->(:__Entity__)` with the semantic relation kept in
+  the edge's `rel_type` property (and an optional `fact`/`description`). There
+  are NO typed edges like `:WORKED_WITH`; bind the edge as `[r:RELATES]` and
+  read `r.rel_type`.
+- Source text lives in `:Chunk {text}` nodes; entities link to them via
+  `:MENTIONED_IN`.
+- Match entities by `name` (e.g. `{name: 'Charles Babbage'}`) and return scalar
+  properties such as `e.name`, `related.name`, `r.rel_type` rather than whole
+  nodes. Example query:
+  `MATCH (e:__Entity__ {name: 'Charles Babbage'})-[r:RELATES]->(related)`
+  `RETURN related.name, r.rel_type`
+- The `traverse` tool expects entity `id` values (read them from a Cypher
+  result first), not display names."""
+
+REACT_SYSTEM_PROMPT = """You are a graph retrieval agent. Answer the user's \
+question by reasoning step by step and using the available tools to gather \
+evidence from a knowledge graph.
+
+{schema_hint}
+
+Available tools:
+{tool_descriptions}
+
+Use exactly this format for each step:
+
+Thought: <your reasoning about what to do next>
+Action: <one of: {tool_names}>
+Action Input: <a single-line JSON object of arguments for the tool>
+
+After each Action you will receive:
+
+Observation: <result of the tool>
+
+Repeat Thought/Action/Action Input as needed. When you have enough evidence \
+to answer, respond with:
+
+Thought: I now have enough information.
+Final Answer: <concise answer grounded in the observations>
+
+Rules:
+- Emit only ONE Action per step and then stop, waiting for the Observation.
+- Action Input MUST be valid JSON on a single line.
+- Prefer the fewest steps necessary. Do not invent tool names.
+"""
+
+
+def render_system_prompt(tool_descriptions: str, tool_names: str) -> str:
+    return REACT_SYSTEM_PROMPT.format(
+        schema_hint=GRAPH_SCHEMA_HINT,
+        tool_descriptions=tool_descriptions,
+        tool_names=tool_names,
+    )

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
@@ -17,18 +18,13 @@ logger = logging.getLogger(__name__)
 
 ToolHandler = Callable[[dict[str, Any], Context], Awaitable[str]]
 
-# Cypher write/DDL keywords rejected by the read-only cypher tool.
-_WRITE_KEYWORDS = (
-    "create",
-    "merge",
-    "delete",
-    "set",
-    "remove",
-    "drop",
-    "detach",
-    "call dbms",
-    "call db.",
-    "load csv",
+# Cypher write/DDL keywords rejected by the read-only cypher tool. Matched on
+# word boundaries so substrings of legitimate identifiers (e.g. "recall",
+# "asset") are not falsely flagged. ``call`` blocks every stored-procedure path
+# (algo.*, db.*, dbms.*, apoc.*) since procedures can mutate the graph.
+_WRITE_KEYWORD_RE = re.compile(
+    r"\b(create|merge|delete|set|remove|drop|detach|call|load\s+csv)\b",
+    re.IGNORECASE,
 )
 
 
@@ -78,8 +74,7 @@ class ToolRegistry:
 
 def is_read_only_cypher(cypher: str) -> bool:
     """Reject Cypher that mutates the graph (agent tools are read-only)."""
-    lowered = cypher.lower()
-    return not any(kw in lowered for kw in _WRITE_KEYWORDS)
+    return _WRITE_KEYWORD_RE.search(cypher) is None
 
 
 # ── Default tool builders ────────────────────────────────────────

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
@@ -19,8 +19,16 @@ ToolHandler = Callable[[dict[str, Any], Context], Awaitable[str]]
 
 # Cypher write/DDL keywords rejected by the read-only cypher tool.
 _WRITE_KEYWORDS = (
-    "create", "merge", "delete", "set", "remove", "drop",
-    "detach", "call dbms", "call db.", "load csv",
+    "create",
+    "merge",
+    "delete",
+    "set",
+    "remove",
+    "drop",
+    "detach",
+    "call dbms",
+    "call db.",
+    "load csv",
 )
 
 
@@ -97,7 +105,7 @@ def make_search_tool(strategy: Any, *, max_chars: int | None = None) -> Tool:
 
     return Tool(
         name="search",
-        description="Semantic search of the knowledge graph. Input: {\"query\": str}.",
+        description='Semantic search of the knowledge graph. Input: {"query": str}.',
         handler=handler,
     )
 
@@ -139,8 +147,7 @@ def make_cypher_tool(graph_store: Any, *, max_rows: int = 25) -> Tool:
     return Tool(
         name="cypher",
         description=(
-            "Run a read-only Cypher query (MATCH ... RETURN ...). "
-            "Input: {\"cypher\": str}."
+            'Run a read-only Cypher query (MATCH ... RETURN ...). Input: {"cypher": str}.'
         ),
         handler=handler,
     )
@@ -190,7 +197,7 @@ def make_traverse_tool(
         name="traverse",
         description=(
             "Walk the graph from a start entity, optionally toward a goal. "
-            "Input: {\"start\": str, \"goal\"?: str}."
+            'Input: {"start": str, "goal"?: str}.'
         ),
         handler=handler,
     )

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
@@ -27,6 +27,11 @@ _WRITE_KEYWORD_RE = re.compile(
     re.IGNORECASE,
 )
 
+# String literals ('..'/".." with backslash escapes) and backtick-quoted
+# identifiers. Stripped before the keyword scan so data values like
+# 'call center' or names such as `delete_log` can't trip the write gate.
+_CYPHER_QUOTED_RE = re.compile(r"'(?:[^'\\]|\\.)*'|\"(?:[^\"\\]|\\.)*\"|`[^`]*`")
+
 
 @dataclass
 class Tool:
@@ -73,8 +78,15 @@ class ToolRegistry:
 
 
 def is_read_only_cypher(cypher: str) -> bool:
-    """Reject Cypher that mutates the graph (agent tools are read-only)."""
-    return _WRITE_KEYWORD_RE.search(cypher) is None
+    """Reject Cypher that mutates the graph (agent tools are read-only).
+
+    Quoted strings and backtick identifiers are stripped first, so write
+    keywords appearing only inside data values (``n.name = 'call center'``,
+    ``CONTAINS "delete"``) don't cause false rejections. An unterminated
+    quote leaves its remainder scanned conservatively (fail-safe).
+    """
+    scannable = _CYPHER_QUOTED_RE.sub(" ", cypher)
+    return _WRITE_KEYWORD_RE.search(scannable) is None
 
 
 # ── Default tool builders ────────────────────────────────────────

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
@@ -77,8 +77,14 @@ def is_read_only_cypher(cypher: str) -> bool:
 # ── Default tool builders ────────────────────────────────────────
 
 
-def make_search_tool(strategy: Any, *, max_chars: int = 1500) -> Tool:
-    """Vector/multi-path search over the graph, returning context snippets."""
+def make_search_tool(strategy: Any, *, max_chars: int | None = None) -> Tool:
+    """Vector/multi-path search over the graph, returning context snippets.
+
+    The underlying strategy already bounds its own output (e.g. MultiPath caps
+    passages via ``chunk_top_k`` plus entity/relationship limits), so by default
+    no character truncation is applied and the agent sees the full result.
+    Pass ``max_chars`` only to force an additional hard cap.
+    """
 
     async def handler(tool_input: dict[str, Any], ctx: Context) -> str:
         query = str(tool_input.get("query", "")).strip()
@@ -87,7 +93,7 @@ def make_search_tool(strategy: Any, *, max_chars: int = 1500) -> Tool:
         result = await strategy.search(query, ctx)
         snippets = [item.content for item in result.items]
         joined = "\n---\n".join(snippets) if snippets else "No results."
-        return joined[:max_chars]
+        return joined if max_chars is None else joined[:max_chars]
 
     return Tool(
         name="search",

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
@@ -93,14 +93,34 @@ def make_search_tool(strategy: Any, *, max_chars: int | None = None) -> Tool:
         query = str(tool_input.get("query", "")).strip()
         if not query:
             return "Error: 'query' is required."
-        result = await strategy.search(query, ctx)
+        overrides = {
+            k: tool_input[k]
+            for k in (
+                "chunk_top_k",
+                "max_entities",
+                "max_relationships",
+                "rel_top_k",
+                "max_cypher_out",
+                "max_entities_out",
+                "max_relationships_out",
+                "max_facts_out",
+                "max_passages_out",
+            )
+            if k in tool_input
+        }
+        result = await strategy.search(query, ctx, **overrides)
         snippets = [item.content for item in result.items]
         joined = "\n---\n".join(snippets) if snippets else "No results."
         return joined if max_chars is None else joined[:max_chars]
 
     return Tool(
         name="search",
-        description='Semantic search of the knowledge graph. Input: {"query": str}.',
+        description=(
+            "Semantic search of the knowledge graph. Required: {\"query\": str}. "
+            "Optional ints to widen/narrow retrieval: chunk_top_k, max_entities, "
+            "max_relationships, rel_top_k, and output caps max_entities_out, "
+            "max_relationships_out, max_facts_out, max_passages_out."
+        ),
         handler=handler,
     )
 
@@ -133,8 +153,14 @@ def make_cypher_tool(graph_store: Any, *, max_rows: int = 25) -> Tool:
             return "Error: 'cypher' is required."
         if not is_read_only_cypher(cypher):
             return "Error: only read-only Cypher (MATCH/RETURN) is permitted."
+        try:
+            rows_cap = int(tool_input.get("max_rows", max_rows))
+        except (TypeError, ValueError):
+            rows_cap = max_rows
+        if rows_cap < 1:
+            rows_cap = max_rows
         result = await graph_store.query_raw(cypher)
-        rows = list(getattr(result, "result_set", []) or [])[:max_rows]
+        rows = list(getattr(result, "result_set", []) or [])[:rows_cap]
         if not rows:
             return "No rows."
         return "\n".join(str(_format_cypher_value(r)) for r in rows)
@@ -142,7 +168,8 @@ def make_cypher_tool(graph_store: Any, *, max_rows: int = 25) -> Tool:
     return Tool(
         name="cypher",
         description=(
-            'Run a read-only Cypher query (MATCH ... RETURN ...). Input: {"cypher": str}.'
+            "Run a read-only Cypher query (MATCH ... RETURN ...). "
+            'Input: {"cypher": str, "max_rows"?: int}.'
         ),
         handler=handler,
     )
@@ -164,6 +191,16 @@ def make_traverse_tool(
             return "Error: 'start' entity id is required."
         goal = tool_input.get("goal")
 
+        def _pos_int(key: str, default: int) -> int:
+            try:
+                val = int(tool_input.get(key, default))
+            except (TypeError, ValueError):
+                return default
+            return val if val > 0 else default
+
+        bw = _pos_int("beam_width", beam_width)
+        depth = _pos_int("max_depth", max_depth)
+
         try:
             weights = await graph_store.pagerank()
         except Exception:
@@ -175,8 +212,8 @@ def make_traverse_tool(
         walk = DynamicGraphWalk(
             neighbor_fn,
             node_weights=weights,
-            beam_width=beam_width,
-            max_depth=max_depth,
+            beam_width=bw,
+            max_depth=depth,
         )
         if goal:
             path = await walk.bidirectional_search(start, str(goal), ctx=ctx)
@@ -192,7 +229,7 @@ def make_traverse_tool(
         name="traverse",
         description=(
             "Walk the graph from a start entity, optionally toward a goal. "
-            'Input: {"start": str, "goal"?: str}.'
+            'Input: {"start": str, "goal"?: str, "beam_width"?: int, "max_depth"?: int}.'
         ),
         handler=handler,
     )

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
@@ -116,7 +116,7 @@ def make_search_tool(strategy: Any, *, max_chars: int | None = None) -> Tool:
     return Tool(
         name="search",
         description=(
-            "Semantic search of the knowledge graph. Required: {\"query\": str}. "
+            'Semantic search of the knowledge graph. Required: {"query": str}. '
             "Optional ints to widen/narrow retrieval: chunk_top_k, max_entities, "
             "max_relationships, rel_top_k, and output caps max_entities_out, "
             "max_relationships_out, max_facts_out, max_passages_out."

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/agentic/tools.py
@@ -1,0 +1,228 @@
+# GraphRAG SDK — Agentic Retrieval: Tool registry (Phase 3.1)
+# Tools are thin async wrappers around existing retrieval + storage
+# primitives, exposed to the ReAct loop. They also back the skill and
+# graph-walk actions so the agent can search, traverse, run Cypher, and
+# invoke high-level skills.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+
+logger = logging.getLogger(__name__)
+
+ToolHandler = Callable[[dict[str, Any], Context], Awaitable[str]]
+
+# Cypher write/DDL keywords rejected by the read-only cypher tool.
+_WRITE_KEYWORDS = (
+    "create", "merge", "delete", "set", "remove", "drop",
+    "detach", "call dbms", "call db.", "load csv",
+)
+
+
+@dataclass
+class Tool:
+    """A single agent tool: name, description, and async handler."""
+
+    name: str
+    description: str
+    handler: ToolHandler
+
+    def schema(self) -> dict[str, str]:
+        return {"name": self.name, "description": self.description}
+
+
+class ToolRegistry:
+    """Ordered registry of agent tools."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, Tool] = {}
+
+    def register(self, tool: Tool) -> None:
+        self._tools[tool.name] = tool
+
+    def get(self, name: str) -> Tool | None:
+        return self._tools.get(name)
+
+    def names(self) -> list[str]:
+        return list(self._tools)
+
+    def describe(self) -> str:
+        return "\n".join(f"- {t.name}: {t.description}" for t in self._tools.values())
+
+    async def run(self, name: str, tool_input: dict[str, Any], ctx: Context) -> str:
+        tool = self._tools.get(name)
+        if tool is None:
+            return f"Error: unknown tool '{name}'. Valid tools: {self.names()}"
+        try:
+            return await tool.handler(tool_input, ctx)
+        except Exception as exc:
+            logger.warning("Tool %s failed: %s", name, exc)
+            return f"Error running tool '{name}': {exc}"
+
+    def __len__(self) -> int:
+        return len(self._tools)
+
+
+def is_read_only_cypher(cypher: str) -> bool:
+    """Reject Cypher that mutates the graph (agent tools are read-only)."""
+    lowered = cypher.lower()
+    return not any(kw in lowered for kw in _WRITE_KEYWORDS)
+
+
+# ── Default tool builders ────────────────────────────────────────
+
+
+def make_search_tool(strategy: Any, *, max_chars: int = 1500) -> Tool:
+    """Vector/multi-path search over the graph, returning context snippets."""
+
+    async def handler(tool_input: dict[str, Any], ctx: Context) -> str:
+        query = str(tool_input.get("query", "")).strip()
+        if not query:
+            return "Error: 'query' is required."
+        result = await strategy.search(query, ctx)
+        snippets = [item.content for item in result.items]
+        joined = "\n---\n".join(snippets) if snippets else "No results."
+        return joined[:max_chars]
+
+    return Tool(
+        name="search",
+        description="Semantic search of the knowledge graph. Input: {\"query\": str}.",
+        handler=handler,
+    )
+
+
+def _format_cypher_value(value: Any) -> Any:
+    """Render a Cypher result value readably for the LLM.
+
+    FalkorDB returns Node/Edge objects whose ``str()`` is an opaque
+    ``<... object at 0x...>``. Surface their properties instead so the
+    agent can actually read entity names, types, and facts.
+    """
+    props = getattr(value, "properties", None)
+    if isinstance(props, dict):
+        labels = getattr(value, "labels", None) or getattr(value, "relation", None)
+        readable = {k: v for k, v in props.items() if k != "embedding"}
+        if labels:
+            return {"labels": labels, **readable}
+        return readable
+    if isinstance(value, list | tuple):
+        return [_format_cypher_value(v) for v in value]
+    return value
+
+
+def make_cypher_tool(graph_store: Any, *, max_rows: int = 25) -> Tool:
+    """Run a read-only Cypher query against the graph."""
+
+    async def handler(tool_input: dict[str, Any], ctx: Context) -> str:
+        cypher = str(tool_input.get("cypher", "")).strip()
+        if not cypher:
+            return "Error: 'cypher' is required."
+        if not is_read_only_cypher(cypher):
+            return "Error: only read-only Cypher (MATCH/RETURN) is permitted."
+        result = await graph_store.query_raw(cypher)
+        rows = list(getattr(result, "result_set", []) or [])[:max_rows]
+        if not rows:
+            return "No rows."
+        return "\n".join(str(_format_cypher_value(r)) for r in rows)
+
+    return Tool(
+        name="cypher",
+        description=(
+            "Run a read-only Cypher query (MATCH ... RETURN ...). "
+            "Input: {\"cypher\": str}."
+        ),
+        handler=handler,
+    )
+
+
+def make_traverse_tool(
+    graph_store: Any,
+    *,
+    beam_width: int = 5,
+    max_depth: int = 3,
+) -> Tool:
+    """Weighted graph walk from a start entity (optionally toward a goal)."""
+
+    async def handler(tool_input: dict[str, Any], ctx: Context) -> str:
+        from graphrag_sdk.retrieval.graph_walk import DynamicGraphWalk
+
+        start = str(tool_input.get("start", "")).strip()
+        if not start:
+            return "Error: 'start' entity id is required."
+        goal = tool_input.get("goal")
+
+        try:
+            weights = await graph_store.pagerank()
+        except Exception:
+            weights = {}
+
+        async def neighbor_fn(node_id: str) -> list[tuple[str, float, str]]:
+            return await graph_store.weighted_neighbors(node_id)
+
+        walk = DynamicGraphWalk(
+            neighbor_fn,
+            node_weights=weights,
+            beam_width=beam_width,
+            max_depth=max_depth,
+        )
+        if goal:
+            path = await walk.bidirectional_search(start, str(goal), ctx=ctx)
+            if path is None:
+                return f"No path found between '{start}' and '{goal}'."
+            return " -> ".join(path.nodes)
+        paths = await walk.beam_search(start, ctx=ctx)
+        if not paths:
+            return f"No neighbors found for '{start}'."
+        return "\n".join(f"{' -> '.join(p.nodes)} (score={p.score:.3f})" for p in paths)
+
+    return Tool(
+        name="traverse",
+        description=(
+            "Walk the graph from a start entity, optionally toward a goal. "
+            "Input: {\"start\": str, \"goal\"?: str}."
+        ),
+        handler=handler,
+    )
+
+
+def make_skill_tool(skill: Any) -> Tool:
+    """Wrap a :class:`Skill` instance as an agent tool."""
+
+    async def handler(tool_input: dict[str, Any], ctx: Context) -> str:
+        result = await skill.run(ctx, **tool_input)
+        if result.summary:
+            return result.summary
+        return str(result.data)
+
+    return Tool(
+        name=skill.name,
+        description=skill.description + " Input: skill-specific JSON arguments.",
+        handler=handler,
+    )
+
+
+def build_default_registry(
+    *,
+    strategy: Any | None = None,
+    graph_store: Any | None = None,
+    llm: Any | None = None,
+    include_skills: bool = True,
+) -> ToolRegistry:
+    """Assemble the standard agent toolset from available primitives."""
+    registry = ToolRegistry()
+    if strategy is not None:
+        registry.register(make_search_tool(strategy))
+    if graph_store is not None:
+        registry.register(make_cypher_tool(graph_store))
+        registry.register(make_traverse_tool(graph_store))
+        if include_skills:
+            from graphrag_sdk.skills import SKILL_REGISTRY
+
+            for skill_cls in SKILL_REGISTRY.values():
+                registry.register(make_skill_tool(skill_cls(graph_store, llm)))
+    return registry

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/graph_walk.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/graph_walk.py
@@ -107,7 +107,9 @@ class DynamicGraphWalk:
                             nodes=list(nodes),
                             edges=list(edges),
                             score=score_path(
-                                nodes, self._weights, e_weights,
+                                nodes,
+                                self._weights,
+                                e_weights,
                                 length_penalty=self._length_penalty,
                             ),
                         )
@@ -140,7 +142,9 @@ class DynamicGraphWalk:
                                 nodes=list(nodes),
                                 edges=list(edges),
                                 score=score_path(
-                                    nodes, self._weights, e_weights,
+                                    nodes,
+                                    self._weights,
+                                    e_weights,
                                     length_penalty=self._length_penalty,
                                 ),
                             )
@@ -264,9 +268,7 @@ class DynamicGraphWalk:
         return ScoredPath(
             nodes=nodes,
             edges=edges,
-            score=score_path(
-                nodes, self._weights, weights, length_penalty=self._length_penalty
-            ),
+            score=score_path(nodes, self._weights, weights, length_penalty=self._length_penalty),
         )
 
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/graph_walk.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/graph_walk.py
@@ -192,13 +192,10 @@ class DynamicGraphWalk:
             meet = await self._expand_frontier(fwd_frontier, fwd, bwd)
             if meet is not None:
                 return self._stitch(meet, fwd, bwd)
-            fwd_frontier = [n for n in fwd if fwd[n][0] is not None or n == start]
-            fwd_frontier = list(self._latest_layer(fwd, fwd_frontier))
 
             meet = await self._expand_frontier(bwd_frontier, bwd, fwd)
             if meet is not None:
                 return self._stitch(meet, fwd, bwd)
-            bwd_frontier = list(self._latest_layer(bwd, bwd_frontier))
 
         return None
 
@@ -218,13 +215,6 @@ class DynamicGraphWalk:
                     return nbr
         frontier[:] = next_layer
         return None
-
-    @staticmethod
-    def _latest_layer(
-        side: dict[str, tuple[str | None, str, float]],
-        frontier: list[str],
-    ) -> list[str]:
-        return frontier
 
     def _stitch(
         self,

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/graph_walk.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/graph_walk.py
@@ -1,0 +1,354 @@
+# GraphRAG SDK — Retrieval: Dynamic Graph Walk (Phase 3.3)
+# PageRank-weighted traversal with beam search, bidirectional search,
+# and path scoring. The core algorithms are decoupled from FalkorDB:
+# they operate on an injected async ``neighbor_fn`` and an optional
+# node-weight map, so they can be unit-tested in memory and reused by
+# the agentic retriever (Phase 3.1) as a "traverse" action.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import (
+    RawSearchResult,
+    RetrieverResult,
+    RetrieverResultItem,
+    ScoredPath,
+)
+from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
+
+logger = logging.getLogger(__name__)
+
+# An async function: node_id -> list of (neighbor_id, edge_weight, edge_label).
+NeighborFn = Callable[[str], Awaitable[list[tuple[str, float, str]]]]
+
+
+def score_path(
+    nodes: list[str],
+    weights: dict[str, float] | None = None,
+    edge_weights: list[float] | None = None,
+    *,
+    length_penalty: float = 0.1,
+) -> float:
+    """Score a path by node importance and edge strength, minus a length penalty.
+
+    The score rewards paths that pass through important nodes (PageRank
+    weights) over strong edges, while penalising longer paths so short,
+    high-signal explanations rank first.
+    """
+    if not nodes:
+        return 0.0
+    weights = weights or {}
+    node_score = sum(weights.get(n, 0.0) for n in nodes) / len(nodes)
+    edge_score = (sum(edge_weights) / len(edge_weights)) if edge_weights else 0.0
+    hops = max(0, len(nodes) - 1)
+    return node_score + edge_score - length_penalty * hops
+
+
+class DynamicGraphWalk:
+    """Dynamic, weight-aware graph traversal.
+
+    Args:
+        neighbor_fn: Async callable returning weighted neighbors of a node.
+        node_weights: Optional PageRank-style importance per node id.
+        beam_width: Max number of partial paths kept per expansion round.
+        max_depth: Max traversal depth (hops).
+        length_penalty: Per-hop penalty applied during path scoring.
+    """
+
+    def __init__(
+        self,
+        neighbor_fn: NeighborFn,
+        *,
+        node_weights: dict[str, float] | None = None,
+        beam_width: int = 5,
+        max_depth: int = 4,
+        length_penalty: float = 0.1,
+    ) -> None:
+        if beam_width < 1:
+            raise ValueError("beam_width must be >= 1")
+        if max_depth < 1:
+            raise ValueError("max_depth must be >= 1")
+        self._neighbor_fn = neighbor_fn
+        self._weights = node_weights or {}
+        self._beam_width = beam_width
+        self._max_depth = max_depth
+        self._length_penalty = length_penalty
+
+    async def beam_search(
+        self,
+        start: str,
+        *,
+        goal: str | None = None,
+        ctx: Context | None = None,
+    ) -> list[ScoredPath]:
+        """Beam-search outward from ``start``, keeping the top-k paths each round.
+
+        If ``goal`` is given, paths reaching it are returned as soon as
+        found; otherwise the highest-scoring frontier paths are returned.
+        """
+        # Each beam entry: (path_nodes, path_edge_labels, path_edge_weights).
+        beam: list[tuple[list[str], list[str], list[float]]] = [([start], [], [])]
+        completed: list[ScoredPath] = []
+        visited: set[str] = {start}
+
+        for depth in range(self._max_depth):
+            if ctx is not None:
+                ctx.ensure_budget(f"graph walk depth {depth}")
+            candidates: list[tuple[list[str], list[str], list[float]]] = []
+            for nodes, edges, e_weights in beam:
+                tail = nodes[-1]
+                if goal is not None and tail == goal:
+                    completed.append(
+                        ScoredPath(
+                            nodes=list(nodes),
+                            edges=list(edges),
+                            score=score_path(
+                                nodes, self._weights, e_weights,
+                                length_penalty=self._length_penalty,
+                            ),
+                        )
+                    )
+                    continue
+                for nbr, weight, label in await self._neighbor_fn(tail):
+                    if nbr in nodes:
+                        continue  # no cycles within a single path
+                    candidates.append((nodes + [nbr], edges + [label], e_weights + [weight]))
+                    visited.add(nbr)
+
+            if not candidates:
+                break
+
+            # Keep the top-k candidates by current path score.
+            candidates.sort(
+                key=lambda c: score_path(
+                    c[0], self._weights, c[2], length_penalty=self._length_penalty
+                ),
+                reverse=True,
+            )
+            beam = candidates[: self._beam_width]
+
+            if goal is not None and any(c[0][-1] == goal for c in beam):
+                # Promote goal-reaching paths immediately.
+                for nodes, edges, e_weights in beam:
+                    if nodes[-1] == goal:
+                        completed.append(
+                            ScoredPath(
+                                nodes=list(nodes),
+                                edges=list(edges),
+                                score=score_path(
+                                    nodes, self._weights, e_weights,
+                                    length_penalty=self._length_penalty,
+                                ),
+                            )
+                        )
+                if completed:
+                    break
+
+        results = completed or [
+            ScoredPath(
+                nodes=nodes,
+                edges=edges,
+                score=score_path(
+                    nodes, self._weights, e_weights, length_penalty=self._length_penalty
+                ),
+            )
+            for nodes, edges, e_weights in beam
+        ]
+        results.sort(key=lambda p: p.score, reverse=True)
+        return results[: self._beam_width]
+
+    async def bidirectional_search(
+        self,
+        start: str,
+        goal: str,
+        *,
+        ctx: Context | None = None,
+    ) -> ScoredPath | None:
+        """Search from both ``start`` and ``goal``, meeting in the middle.
+
+        Returns the connecting path (oriented start→goal) or ``None`` if
+        the two frontiers never meet within ``max_depth`` hops on each side.
+        """
+        if start == goal:
+            return ScoredPath(nodes=[start], edges=[], score=score_path([start], self._weights))
+
+        # parent maps: node -> (predecessor, edge_label, edge_weight)
+        fwd: dict[str, tuple[str | None, str, float]] = {start: (None, "", 0.0)}
+        bwd: dict[str, tuple[str | None, str, float]] = {goal: (None, "", 0.0)}
+        fwd_frontier = [start]
+        bwd_frontier = [goal]
+
+        for depth in range(self._max_depth):
+            if ctx is not None:
+                ctx.ensure_budget(f"bidirectional walk depth {depth}")
+            meet = await self._expand_frontier(fwd_frontier, fwd, bwd)
+            if meet is not None:
+                return self._stitch(meet, fwd, bwd)
+            fwd_frontier = [n for n in fwd if fwd[n][0] is not None or n == start]
+            fwd_frontier = list(self._latest_layer(fwd, fwd_frontier))
+
+            meet = await self._expand_frontier(bwd_frontier, bwd, fwd)
+            if meet is not None:
+                return self._stitch(meet, fwd, bwd)
+            bwd_frontier = list(self._latest_layer(bwd, bwd_frontier))
+
+        return None
+
+    async def _expand_frontier(
+        self,
+        frontier: list[str],
+        side: dict[str, tuple[str | None, str, float]],
+        other: dict[str, tuple[str | None, str, float]],
+    ) -> str | None:
+        next_layer: list[str] = []
+        for node in frontier:
+            for nbr, weight, label in await self._neighbor_fn(node):
+                if nbr not in side:
+                    side[nbr] = (node, label, weight)
+                    next_layer.append(nbr)
+                if nbr in other:
+                    return nbr
+        frontier[:] = next_layer
+        return None
+
+    @staticmethod
+    def _latest_layer(
+        side: dict[str, tuple[str | None, str, float]],
+        frontier: list[str],
+    ) -> list[str]:
+        return frontier
+
+    def _stitch(
+        self,
+        meet: str,
+        fwd: dict[str, tuple[str | None, str, float]],
+        bwd: dict[str, tuple[str | None, str, float]],
+    ) -> ScoredPath:
+        # Walk back from meet to start via fwd parents.
+        left_nodes: list[str] = []
+        left_edges: list[str] = []
+        left_weights: list[float] = []
+        node: str | None = meet
+        while node is not None:
+            left_nodes.append(node)
+            pred, label, weight = fwd.get(node, (None, "", 0.0))
+            if pred is not None:
+                left_edges.append(label)
+                left_weights.append(weight)
+            node = pred
+        left_nodes.reverse()
+        left_edges.reverse()
+        left_weights.reverse()
+
+        # Walk forward from meet to goal via bwd parents.
+        right_nodes: list[str] = []
+        right_edges: list[str] = []
+        right_weights: list[float] = []
+        node = bwd.get(meet, (None, "", 0.0))[0]
+        cur = meet
+        while node is not None:
+            _, label, weight = bwd.get(cur, (None, "", 0.0))
+            right_nodes.append(node)
+            right_edges.append(label)
+            right_weights.append(weight)
+            cur = node
+            node = bwd.get(cur, (None, "", 0.0))[0]
+
+        nodes = left_nodes + right_nodes
+        edges = left_edges + right_edges
+        weights = left_weights + right_weights
+        return ScoredPath(
+            nodes=nodes,
+            edges=edges,
+            score=score_path(
+                nodes, self._weights, weights, length_penalty=self._length_penalty
+            ),
+        )
+
+
+class GraphWalkRetrieval(RetrievalStrategy):
+    """RetrievalStrategy wrapper around :class:`DynamicGraphWalk`.
+
+    Resolves seed entities for the query (via the injected ``seed_fn``),
+    walks outward with PageRank-weighted beam search, and returns the
+    highest-scoring paths as retrieval items.
+
+    Args:
+        graph_store: GraphStore for neighbor lookups and PageRank.
+        seed_fn: Async callable(query, ctx) -> list[str] of start node ids.
+        beam_width / max_depth / length_penalty: Walk parameters.
+        use_pagerank: When True, fetch PageRank weights from the store.
+    """
+
+    def __init__(
+        self,
+        graph_store: Any,
+        seed_fn: Callable[[str, Context], Awaitable[list[str]]],
+        *,
+        beam_width: int = 5,
+        max_depth: int = 4,
+        length_penalty: float = 0.1,
+        use_pagerank: bool = True,
+        max_paths: int = 10,
+    ) -> None:
+        super().__init__(graph_store=graph_store)
+        self._seed_fn = seed_fn
+        self._beam_width = beam_width
+        self._max_depth = max_depth
+        self._length_penalty = length_penalty
+        self._use_pagerank = use_pagerank
+        self._max_paths = max_paths
+
+    async def _execute(self, query: str, ctx: Context, **kwargs: Any) -> RawSearchResult:
+        seeds = await self._seed_fn(query, ctx)
+        if not seeds:
+            return RawSearchResult(records=[], metadata={"reason": "no seed entities"})
+
+        weights: dict[str, float] = {}
+        if self._use_pagerank:
+            try:
+                weights = await self._graph.pagerank()
+            except Exception as exc:  # pragma: no cover - defensive
+                ctx.log(f"PageRank unavailable, walking unweighted: {exc}")
+
+        async def neighbor_fn(node_id: str) -> list[tuple[str, float, str]]:
+            return await self._graph.weighted_neighbors(node_id)
+
+        walk = DynamicGraphWalk(
+            neighbor_fn,
+            node_weights=weights,
+            beam_width=self._beam_width,
+            max_depth=self._max_depth,
+            length_penalty=self._length_penalty,
+        )
+
+        all_paths: list[ScoredPath] = []
+        for seed in seeds:
+            all_paths.extend(await walk.beam_search(seed, ctx=ctx))
+        all_paths.sort(key=lambda p: p.score, reverse=True)
+        top = all_paths[: self._max_paths]
+
+        records = [
+            {
+                "path": " -> ".join(p.nodes),
+                "edges": p.edges,
+                "score": p.score,
+            }
+            for p in top
+        ]
+        return RawSearchResult(records=records, metadata={"num_paths": len(top)})
+
+    def _format(self, raw: RawSearchResult) -> RetrieverResult:
+        items = [
+            RetrieverResultItem(
+                content=str(rec["path"]),
+                score=float(rec.get("score", 0.0)),
+                metadata={"edges": rec.get("edges", [])},
+            )
+            for rec in raw.records
+        ]
+        return RetrieverResult(items=items, metadata=raw.metadata)

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/graph_walk.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/graph_walk.py
@@ -93,12 +93,18 @@ class DynamicGraphWalk:
         # Each beam entry: (path_nodes, path_edge_labels, path_edge_weights).
         beam: list[tuple[list[str], list[str], list[float]]] = [([start], [], [])]
         completed: list[ScoredPath] = []
+        # Paths whose tail cannot be extended (leaf / all neighbors already on
+        # the path). Kept so short terminal branches — e.g. a direct leaf
+        # neighbor of ``start`` — still appear in goal-less results instead of
+        # silently vanishing while deeper branches survive.
+        terminal: list[ScoredPath] = []
         visited: set[str] = {start}
 
         for depth in range(self._max_depth):
             if ctx is not None:
                 ctx.ensure_budget(f"graph walk depth {depth}")
             candidates: list[tuple[list[str], list[str], list[float]]] = []
+            dead_ends: list[tuple[list[str], list[str], list[float]]] = []
             for nodes, edges, e_weights in beam:
                 tail = nodes[-1]
                 if goal is not None and tail == goal:
@@ -115,14 +121,31 @@ class DynamicGraphWalk:
                         )
                     )
                     continue
+                extended = False
                 for nbr, weight, label in await self._neighbor_fn(tail):
                     if nbr in nodes:
                         continue  # no cycles within a single path
                     candidates.append((nodes + [nbr], edges + [label], e_weights + [weight]))
                     visited.add(nbr)
+                    extended = True
+                if not extended and len(nodes) > 1:
+                    dead_ends.append((nodes, edges, e_weights))
 
             if not candidates:
+                # Entire beam is unextendable; it already represents these
+                # paths in the final results, so don't double-count dead ends.
                 break
+
+            terminal.extend(
+                ScoredPath(
+                    nodes=list(nodes),
+                    edges=list(edges),
+                    score=score_path(
+                        nodes, self._weights, e_weights, length_penalty=self._length_penalty
+                    ),
+                )
+                for nodes, edges, e_weights in dead_ends
+            )
 
             # Keep the top-k candidates by current path score.
             candidates.sort(
@@ -152,16 +175,20 @@ class DynamicGraphWalk:
                 if completed:
                     break
 
-        results = completed or [
-            ScoredPath(
-                nodes=nodes,
-                edges=edges,
-                score=score_path(
-                    nodes, self._weights, e_weights, length_penalty=self._length_penalty
-                ),
-            )
-            for nodes, edges, e_weights in beam
-        ]
+        results = (
+            completed
+            or [
+                ScoredPath(
+                    nodes=nodes,
+                    edges=edges,
+                    score=score_path(
+                        nodes, self._weights, e_weights, length_penalty=self._length_penalty
+                    ),
+                )
+                for nodes, edges, e_weights in beam
+            ]
+            + terminal
+        )
         results.sort(key=lambda p: p.score, reverse=True)
         return results[: self._beam_width]
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/__init__.py
@@ -2,5 +2,16 @@
 
 from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
 from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval
+from graphrag_sdk.retrieval.strategies.path_router import (
+    RETRIEVAL_PATHS,
+    HeuristicPathRouter,
+    LLMPathRouter,
+)
 
-__all__ = ["RetrievalStrategy", "MultiPathRetrieval"]
+__all__ = [
+    "RetrievalStrategy",
+    "MultiPathRetrieval",
+    "RETRIEVAL_PATHS",
+    "HeuristicPathRouter",
+    "LLMPathRouter",
+]

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
@@ -184,7 +184,7 @@ async def discover_entities(
             logger.debug("Entity CONTAINS search failed: %s", exc)
 
     # Path b: Fulltext search on entity index
-    for kw in (all_keywords[:6] if use_fulltext else []):
+    for kw in all_keywords[:6] if use_fulltext else []:
         try:
             if ctx is not None:
                 ctx.ensure_budget("entity fulltext search")

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py
@@ -77,12 +77,18 @@ async def discover_entities(
     llm_kw: list[str],
     all_keywords: list[str],
     ctx: Context | None = None,
+    *,
+    use_cypher: bool = True,
+    use_fulltext: bool = True,
 ) -> tuple[dict[str, dict], dict[str, str]]:
     """2-path entity discovery.
 
     Paths:
-    a: Cypher CONTAINS on entity names
-    b: Fulltext search on entity index
+    a: Cypher CONTAINS on entity names (gated by ``use_cypher``)
+    b: Fulltext search on entity index (gated by ``use_fulltext``)
+
+    ``use_cypher`` / ``use_fulltext`` let a path router skip a sub-path when
+    it is irrelevant to the question. Both default to ``True`` (run both).
 
     Returns:
         found: dict of entity_id -> {name, description}
@@ -111,7 +117,7 @@ async def discover_entities(
         seen_kw.add(k_low)
         kw_batch.append(kw)
 
-    if kw_batch:
+    if use_cypher and kw_batch:
         # Pass a1: exact-name matches, capped per keyword. Inserted first
         # so exact matches land at the head of `found` and survive the
         # downstream max_entities / result_assembly caps.
@@ -178,7 +184,7 @@ async def discover_entities(
             logger.debug("Entity CONTAINS search failed: %s", exc)
 
     # Path b: Fulltext search on entity index
-    for kw in all_keywords[:6]:
+    for kw in (all_keywords[:6] if use_fulltext else []):
         try:
             if ctx is not None:
                 ctx.ensure_budget("entity fulltext search")

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
@@ -282,6 +282,15 @@ class MultiPathRetrieval(RetrievalStrategy):
             except Exception as exc:  # noqa: BLE001
                 logger.debug("Path router failed (%s); running all paths", exc)
                 plan = all_paths()
+            # Expansion traverses from discovered entities, so a plan that
+            # selects it without any seed-producing path would always return
+            # zero relationships. Guarantee a seed source.
+            if "expansion" in plan and not plan & {
+                "entity_cypher",
+                "entity_fulltext",
+                "relates",
+            }:
+                plan.add("entity_cypher")
             ctx.log(f"MultiPath plan: {sorted(plan)}")
 
         # 3. RELATES vector search + Text-to-Cypher (parallel when enabled)

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
@@ -232,17 +232,28 @@ class MultiPathRetrieval(RetrievalStrategy):
                 return default
             return val if val > 0 else default
 
+        def _nonneg_int(key: str, default: int) -> int:
+            # Output caps allow 0 ("omit this section entirely" — see
+            # result_assembly.assemble_raw_result); only negatives/garbage
+            # fall back to the default.
+            val = kwargs.get(key, default)
+            try:
+                val = int(val)
+            except (TypeError, ValueError):
+                return default
+            return val if val >= 0 else default
+
         chunk_top_k = _pos_int("chunk_top_k", self._chunk_top_k)
         max_entities = _pos_int("max_entities", self._max_entities)
         max_relationships = _pos_int("max_relationships", self._max_relationships)
         rel_top_k = _pos_int("rel_top_k", self._rel_top_k)
 
         # Final-context display caps (agent-tunable; default to prior values).
-        max_cypher_out = _pos_int("max_cypher_out", 20)
-        max_entities_out = _pos_int("max_entities_out", 25)
-        max_relationships_out = _pos_int("max_relationships_out", 20)
-        max_facts_out = _pos_int("max_facts_out", 15)
-        max_passages_out = _pos_int("max_passages_out", 15)
+        max_cypher_out = _nonneg_int("max_cypher_out", 20)
+        max_entities_out = _nonneg_int("max_entities_out", 25)
+        max_relationships_out = _nonneg_int("max_relationships_out", 20)
+        max_facts_out = _nonneg_int("max_facts_out", 15)
+        max_passages_out = _nonneg_int("max_passages_out", 15)
 
         # 1. Extract keywords
         ctx.ensure_budget("MultiPath keyword extraction")

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
@@ -36,6 +36,10 @@ from graphrag_sdk.retrieval.strategies.entity_discovery import (
 from graphrag_sdk.retrieval.strategies.relationship_expansion import (
     expand_relationships,
 )
+from graphrag_sdk.retrieval.strategies.path_router import (
+    RETRIEVAL_PATHS,
+    all_paths,
+)
 from graphrag_sdk.retrieval.strategies.result_assembly import (
     assemble_raw_result,
     cosine_sim,
@@ -176,6 +180,7 @@ class MultiPathRetrieval(RetrievalStrategy):
         rel_top_k: int = 15,  # Matched to chunk_top_k for balanced fact/passage coverage
         keyword_limit: int = 10,  # Fulltext search keyword budget from query decomposition
         enable_cypher: bool = False,  # Text-to-Cypher path (experimental, off by default)
+        router: Any | None = None,  # Optional path router (agentic path selection)
         ontology: Ontology | None = None,  # forwarded to Cypher generation when enable_cypher
         schema: Ontology | None = None,  # DEPRECATED: use ``ontology=`` instead
     ) -> None:
@@ -206,6 +211,7 @@ class MultiPathRetrieval(RetrievalStrategy):
         self._rel_top_k = rel_top_k
         self._keyword_limit = keyword_limit
         self._enable_cypher = enable_cypher
+        self._router = router
         self._ontology = ontology
 
     # -- Template Method hook --
@@ -229,22 +235,48 @@ class MultiPathRetrieval(RetrievalStrategy):
             timeout=ctx.provider_timeout_seconds("MultiPath question embedding"),
         )
 
+        # 2b. Plan which retrieval paths to run. Without a router this is
+        # "all paths" (unchanged behavior). With a router, an LLM/heuristic
+        # prunes to the paths the question actually needs; on any failure or
+        # empty plan we fall back to all paths so recall is never lost.
+        plan: set[str] = all_paths()
+        if self._router is not None:
+            try:
+                planned = await self._router.plan(query, ctx)
+                plan = set(planned) & set(RETRIEVAL_PATHS) or all_paths()
+            except LatencyBudgetExceededError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Path router failed (%s); running all paths", exc)
+                plan = all_paths()
+            ctx.log(f"MultiPath plan: {sorted(plan)}")
+
         # 3. RELATES vector search + Text-to-Cypher (parallel when enabled)
+        run_relates = "relates" in plan
+        fact_strings_scored: list[tuple[str, float]] = []
+        rel_entities: dict[str, dict] = {}
+        cypher_facts: list = []
+        cypher_entities: dict[str, dict] = {}
         if self._enable_cypher:
-            results = await asyncio.gather(
-                search_relates_edges(self._vector, query_vector, self._rel_top_k, ctx=ctx),
+            coros = [
                 execute_cypher_retrieval(
                     self._graph, self._llm, query, ontology=self._ontology, ctx=ctx
-                ),
-                return_exceptions=True,
-            )
-            fact_strings_scored, rel_entities = _unpack_gather_result(results[0], ([], {}))
-            cypher_facts, cypher_entities = _unpack_gather_result(results[1], ([], {}))
-        else:
+                )
+            ]
+            if run_relates:
+                coros.insert(
+                    0, search_relates_edges(self._vector, query_vector, self._rel_top_k, ctx=ctx)
+                )
+            results = await asyncio.gather(*coros, return_exceptions=True)
+            if run_relates:
+                fact_strings_scored, rel_entities = _unpack_gather_result(results[0], ([], {}))
+                cypher_facts, cypher_entities = _unpack_gather_result(results[1], ([], {}))
+            else:
+                cypher_facts, cypher_entities = _unpack_gather_result(results[0], ([], {}))
+        elif run_relates:
             fact_strings_scored, rel_entities = await search_relates_edges(
                 self._vector, query_vector, self._rel_top_k, ctx=ctx
             )
-            cypher_facts, cypher_entities = [], {}
 
         # Filter RELATES vector facts by relevance score
         fact_strings = filter_facts_by_relevance(fact_strings_scored)
@@ -256,9 +288,20 @@ class MultiPathRetrieval(RetrievalStrategy):
             + (f", {len(cypher_facts)} cypher results" if cypher_facts else "")
         )
         # 4. Entity discovery (2 paths) + merge rel_entities + cypher_entities
-        found_entities, entity_sources = await discover_entities(
-            self._graph, self._vector, llm_kw, all_keywords, ctx=ctx
-        )
+        use_entity_cypher = "entity_cypher" in plan
+        use_entity_fulltext = "entity_fulltext" in plan
+        if use_entity_cypher or use_entity_fulltext:
+            found_entities, entity_sources = await discover_entities(
+                self._graph,
+                self._vector,
+                llm_kw,
+                all_keywords,
+                ctx=ctx,
+                use_cypher=use_entity_cypher,
+                use_fulltext=use_entity_fulltext,
+            )
+        else:
+            found_entities, entity_sources = {}, {}
         for eid, einfo in rel_entities.items():
             if eid not in found_entities:
                 found_entities[eid] = einfo
@@ -284,21 +327,27 @@ class MultiPathRetrieval(RetrievalStrategy):
                 )
         # 5. Relationship expansion
         entity_list = list(found_entities.items())[: self._max_entities]
-        relationship_strings = await expand_relationships(
-            self._graph, entity_list, self._max_relationships, ctx=ctx
-        )
+        if "expansion" in plan:
+            relationship_strings = await expand_relationships(
+                self._graph, entity_list, self._max_relationships, ctx=ctx
+            )
+        else:
+            relationship_strings = []
         ctx.log(f"MultiPath [5/9]: {len(relationship_strings)} relationships")
         # 6. Chunk retrieval (4 paths)
-        candidate_chunks, chunk_sources, chunk_embeddings = await retrieve_chunks(
-            self._vector,
-            self._graph,
-            query,
-            query_vector,
-            llm_kw,
-            simple_kw,
-            entity_list,
-            ctx=ctx,
-        )
+        if "chunks" in plan:
+            candidate_chunks, chunk_sources, chunk_embeddings = await retrieve_chunks(
+                self._vector,
+                self._graph,
+                query,
+                query_vector,
+                llm_kw,
+                simple_kw,
+                entity_list,
+                ctx=ctx,
+            )
+        else:
+            candidate_chunks, chunk_sources, chunk_embeddings = {}, {}, {}
         ctx.log(
             f"MultiPath [6/9]: {len(candidate_chunks)} candidate chunks "
             f"({len(chunk_embeddings)} with stored embeddings)"

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
@@ -222,6 +222,28 @@ class MultiPathRetrieval(RetrievalStrategy):
         ctx: Context,
         **kwargs: Any,
     ) -> RawSearchResult:
+        # 0. Resolve per-call overrides. Defaults preserve normal-flow
+        # behavior; the agentic flow may pass kwargs to widen selection.
+        def _pos_int(key: str, default: int) -> int:
+            val = kwargs.get(key, default)
+            try:
+                val = int(val)
+            except (TypeError, ValueError):
+                return default
+            return val if val > 0 else default
+
+        chunk_top_k = _pos_int("chunk_top_k", self._chunk_top_k)
+        max_entities = _pos_int("max_entities", self._max_entities)
+        max_relationships = _pos_int("max_relationships", self._max_relationships)
+        rel_top_k = _pos_int("rel_top_k", self._rel_top_k)
+
+        # Final-context display caps (agent-tunable; default to prior values).
+        max_cypher_out = _pos_int("max_cypher_out", 20)
+        max_entities_out = _pos_int("max_entities_out", 25)
+        max_relationships_out = _pos_int("max_relationships_out", 20)
+        max_facts_out = _pos_int("max_facts_out", 15)
+        max_passages_out = _pos_int("max_passages_out", 15)
+
         # 1. Extract keywords
         ctx.ensure_budget("MultiPath keyword extraction")
         simple_kw, llm_kw = await self._extract_keywords(query, ctx)
@@ -265,7 +287,7 @@ class MultiPathRetrieval(RetrievalStrategy):
             ]
             if run_relates:
                 coros.insert(
-                    0, search_relates_edges(self._vector, query_vector, self._rel_top_k, ctx=ctx)
+                    0, search_relates_edges(self._vector, query_vector, rel_top_k, ctx=ctx)
                 )
             results = await asyncio.gather(*coros, return_exceptions=True)
             if run_relates:
@@ -275,7 +297,7 @@ class MultiPathRetrieval(RetrievalStrategy):
                 cypher_facts, cypher_entities = _unpack_gather_result(results[0], ([], {}))
         elif run_relates:
             fact_strings_scored, rel_entities = await search_relates_edges(
-                self._vector, query_vector, self._rel_top_k, ctx=ctx
+                self._vector, query_vector, rel_top_k, ctx=ctx
             )
 
         # Filter RELATES vector facts by relevance score
@@ -326,10 +348,10 @@ class MultiPathRetrieval(RetrievalStrategy):
                     f"({len(found_entities)} total)"
                 )
         # 5. Relationship expansion
-        entity_list = list(found_entities.items())[: self._max_entities]
+        entity_list = list(found_entities.items())[:max_entities]
         if "expansion" in plan:
             relationship_strings = await expand_relationships(
-                self._graph, entity_list, self._max_relationships, ctx=ctx
+                self._graph, entity_list, max_relationships, ctx=ctx
             )
         else:
             relationship_strings = []
@@ -363,7 +385,7 @@ class MultiPathRetrieval(RetrievalStrategy):
             self._embedder,
             query_vector,
             candidate_chunks,
-            self._chunk_top_k,
+            chunk_top_k,
             stored_embeddings=chunk_embeddings,
             ctx=ctx,
         )
@@ -389,6 +411,11 @@ class MultiPathRetrieval(RetrievalStrategy):
             source_passages,
             q_type_hint,
             cypher_results=cypher_facts if cypher_facts else None,
+            max_cypher=max_cypher_out,
+            max_entities=max_entities_out,
+            max_relationships=max_relationships_out,
+            max_facts=max_facts_out,
+            max_passages=max_passages_out,
         )
 
     def _format(self, raw: RawSearchResult) -> RetrieverResult:

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py
@@ -33,12 +33,12 @@ from graphrag_sdk.retrieval.strategies.entity_discovery import (
     is_enumeration_query,
     search_relates_edges,
 )
-from graphrag_sdk.retrieval.strategies.relationship_expansion import (
-    expand_relationships,
-)
 from graphrag_sdk.retrieval.strategies.path_router import (
     RETRIEVAL_PATHS,
     all_paths,
+)
+from graphrag_sdk.retrieval.strategies.relationship_expansion import (
+    expand_relationships,
 )
 from graphrag_sdk.retrieval.strategies.result_assembly import (
     assemble_raw_result,
@@ -336,7 +336,7 @@ class MultiPathRetrieval(RetrievalStrategy):
         ctx.log(f"MultiPath [5/9]: {len(relationship_strings)} relationships")
         # 6. Chunk retrieval (4 paths)
         if "chunks" in plan:
-            candidate_chunks, chunk_sources, chunk_embeddings = await retrieve_chunks(
+            candidate_chunks, _chunk_sources, chunk_embeddings = await retrieve_chunks(
                 self._vector,
                 self._graph,
                 query,
@@ -347,7 +347,7 @@ class MultiPathRetrieval(RetrievalStrategy):
                 ctx=ctx,
             )
         else:
-            candidate_chunks, chunk_sources, chunk_embeddings = {}, {}, {}
+            candidate_chunks, _chunk_sources, chunk_embeddings = {}, {}, {}
         ctx.log(
             f"MultiPath [6/9]: {len(candidate_chunks)} candidate chunks "
             f"({len(chunk_embeddings)} with stored embeddings)"

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
@@ -32,6 +32,7 @@ _PATH_GUIDE = (
     "- entity_cypher: the question names a specific entity / proper noun exactly.\n"
     "- entity_fulltext: fuzzy or partial entity names, typos, multi-word names.\n"
     "- expansion: 'how are X and Y connected', relationships, neighbors, paths.\n"
+    "  (needs entity seeds — pick it together with an entity path or relates)\n"
     "- chunks: needs supporting passages / quotes / detailed source text."
 )
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
@@ -64,7 +64,11 @@ class HeuristicPathRouter:
         q = (query or "").lower()
         plan: set[str] = {"relates", "chunks"}
         # Relationship / connection questions → traversal.
-        if re.search(r"\b(connect|related|relationship|between|link|neighbor|path|how (?:are|is|do))\b", q):
+        rel_pattern = (
+            r"\b(connect|related|relationship|between|link|neighbor"
+            r"|path|how (?:are|is|do))\b"
+        )
+        if re.search(rel_pattern, q):
             plan |= {"expansion", "entity_cypher"}
         # Quoted or capitalized proper nouns in the original query → name match.
         if '"' in query or "'" in query or re.search(r"\b[A-Z][a-z]+\b", query or ""):

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
@@ -19,11 +19,11 @@ logger = logging.getLogger(__name__)
 
 # The five gateable retrieval paths of MultiPathRetrieval.
 RETRIEVAL_PATHS: tuple[str, ...] = (
-    "relates",          # RELATES edge vector search (facts + seed entities)
-    "entity_cypher",    # entity discovery via Cypher exact/CONTAINS name match
+    "relates",  # RELATES edge vector search (facts + seed entities)
+    "entity_cypher",  # entity discovery via Cypher exact/CONTAINS name match
     "entity_fulltext",  # entity discovery via fulltext index
-    "expansion",        # 1-hop/2-hop relationship expansion
-    "chunks",           # chunk retrieval (fulltext + vector + MENTIONED_IN + 2-hop)
+    "expansion",  # 1-hop/2-hop relationship expansion
+    "chunks",  # chunk retrieval (fulltext + vector + MENTIONED_IN + 2-hop)
 )
 _PATH_SET: frozenset[str] = frozenset(RETRIEVAL_PATHS)
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
@@ -1,0 +1,110 @@
+# GraphRAG SDK — Retrieval: Path Router (agentic path selection)
+#
+# A lightweight planner that decides *which* of MultiPathRetrieval's
+# retrieval paths to run for a given question, instead of always running
+# all of them. One cheap LLM call (or a heuristic) returns a subset; the
+# strategy skips the rest. Falls back to "all paths" whenever the plan is
+# empty or the router errors, so recall is never silently lost.
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.exceptions import LatencyBudgetExceededError
+
+logger = logging.getLogger(__name__)
+
+# The five gateable retrieval paths of MultiPathRetrieval.
+RETRIEVAL_PATHS: tuple[str, ...] = (
+    "relates",          # RELATES edge vector search (facts + seed entities)
+    "entity_cypher",    # entity discovery via Cypher exact/CONTAINS name match
+    "entity_fulltext",  # entity discovery via fulltext index
+    "expansion",        # 1-hop/2-hop relationship expansion
+    "chunks",           # chunk retrieval (fulltext + vector + MENTIONED_IN + 2-hop)
+)
+_PATH_SET: frozenset[str] = frozenset(RETRIEVAL_PATHS)
+
+_PATH_GUIDE = (
+    "- relates: semantic/fact questions, paraphrases, 'what is', 'tell me about'.\n"
+    "- entity_cypher: the question names a specific entity / proper noun exactly.\n"
+    "- entity_fulltext: fuzzy or partial entity names, typos, multi-word names.\n"
+    "- expansion: 'how are X and Y connected', relationships, neighbors, paths.\n"
+    "- chunks: needs supporting passages / quotes / detailed source text."
+)
+
+
+def all_paths() -> set[str]:
+    """Return the full path set (the default, unrouted behavior)."""
+    return set(RETRIEVAL_PATHS)
+
+
+def parse_paths(text: str) -> set[str]:
+    """Parse a model/heuristic response into a validated set of path ids.
+
+    Accepts comma/space/newline separated tokens; ignores anything that is
+    not a known path. Returns an empty set when nothing valid is found (the
+    caller is expected to fall back to ``all_paths()``).
+    """
+    tokens = re.split(r"[\s,]+", (text or "").strip().lower())
+    return {t for t in tokens if t in _PATH_SET}
+
+
+class HeuristicPathRouter:
+    """Zero-cost router: picks paths from cheap question features.
+
+    Useful when you want path pruning without an extra LLM call. Always
+    keeps at least ``relates`` + ``chunks`` so open-ended questions still
+    get semantic recall.
+    """
+
+    async def plan(self, query: str, ctx: Context | None = None) -> set[str]:
+        q = (query or "").lower()
+        plan: set[str] = {"relates", "chunks"}
+        # Relationship / connection questions → traversal.
+        if re.search(r"\b(connect|related|relationship|between|link|neighbor|path|how (?:are|is|do))\b", q):
+            plan |= {"expansion", "entity_cypher"}
+        # Quoted or capitalized proper nouns in the original query → name match.
+        if '"' in query or "'" in query or re.search(r"\b[A-Z][a-z]+\b", query or ""):
+            plan |= {"entity_cypher", "entity_fulltext"}
+        return plan & _PATH_SET or all_paths()
+
+
+class LLMPathRouter:
+    """LLM-backed router: one small call selects the paths to run.
+
+    Args:
+        llm: provider exposing ``ainvoke(prompt, timeout=...)``.
+    """
+
+    def __init__(self, llm: Any) -> None:
+        self._llm = llm
+
+    async def plan(self, query: str, ctx: Context | None = None) -> set[str]:
+        ctx = ctx or Context()
+        prompt = (
+            "You are a retrieval planner for a knowledge-graph RAG system. "
+            "Given a question, choose ONLY the retrieval paths needed to answer "
+            "it well — usually 1 to 3, not all. Return a comma-separated list of "
+            "path ids from this set, nothing else.\n\n"
+            f"Paths:\n{_PATH_GUIDE}\n\n"
+            f"Question: {query}\n\nPaths:"
+        )
+        try:
+            ctx.ensure_budget("path router LLM call")
+            response = await self._llm.ainvoke(
+                prompt,
+                timeout=ctx.provider_timeout_seconds("path router LLM call"),
+            )
+            plan = parse_paths(getattr(response, "content", "") or "")
+            if plan:
+                ctx.log(f"PathRouter: selected {sorted(plan)}")
+                return plan
+            logger.debug("PathRouter: empty/unparseable plan, using all paths")
+        except LatencyBudgetExceededError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("PathRouter LLM call failed (%s); using all paths", exc)
+        return all_paths()

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/path_router.py
@@ -72,7 +72,12 @@ class HeuristicPathRouter:
         if re.search(rel_pattern, q):
             plan |= {"expansion", "entity_cypher"}
         # Quoted or capitalized proper nouns in the original query → name match.
-        if '"' in query or "'" in query or re.search(r"\b[A-Z][a-z]+\b", query or ""):
+        # Ignore the sentence-cased leading word ("What", "Who", "How"...) —
+        # only a capitalized token *after* the first word signals a real name,
+        # otherwise the entity paths fire on virtually every question and the
+        # router never prunes.
+        rest = query.split(maxsplit=1)[1] if len(query.split(maxsplit=1)) > 1 else ""
+        if '"' in query or "'" in query or re.search(r"\b[A-Z][a-z]+\b", rest):
             plan |= {"entity_cypher", "entity_fulltext"}
         return plan & _PATH_SET or all_paths()
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/result_assembly.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/result_assembly.py
@@ -159,11 +159,20 @@ def assemble_raw_result(
     source_passages: list[str],
     q_type_hint: str = "",
     cypher_results: list[str] | None = None,
+    *,
+    max_cypher: int = 20,
+    max_entities: int = 25,
+    max_relationships: int = 20,
+    max_facts: int = 15,
+    max_passages: int = 15,
 ) -> RawSearchResult:
     """Build structured RawSearchResult with section records.
 
     ``cypher_results`` are placed in their own section and are NOT
     subject to cosine reranking — they go directly to the final LLM.
+
+    The ``max_*`` caps bound how much of each section reaches the LLM;
+    callers (e.g. the agentic flow) may raise them per query.
     """
     records: list[dict[str, Any]] = []
 
@@ -182,7 +191,7 @@ def assemble_raw_result(
             {
                 "section": "cypher_results",
                 "content": "## Graph Query Results\n"
-                + "\n".join(f"- {r}" for r in cypher_results[:20]),
+                + "\n".join(f"- {r}" for r in cypher_results[:max_cypher]),
             }
         )
 
@@ -199,7 +208,7 @@ def assemble_raw_result(
         records.append(
             {
                 "section": "entities",
-                "content": "## Key Entities\n" + "\n".join(entity_lines[:25]),
+                "content": "## Key Entities\n" + "\n".join(entity_lines[:max_entities]),
             }
         )
 
@@ -209,7 +218,7 @@ def assemble_raw_result(
             {
                 "section": "relationships",
                 "content": "## Entity Relationships\n"
-                + "\n".join(f"- {r}" for r in relationship_strings[:20]),
+                + "\n".join(f"- {r}" for r in relationship_strings[:max_relationships]),
             }
         )
 
@@ -219,7 +228,7 @@ def assemble_raw_result(
             {
                 "section": "facts",
                 "content": "## Knowledge Graph Facts\n"
-                + "\n".join(f"- {f}" for f in fact_strings[:15]),
+                + "\n".join(f"- {f}" for f in fact_strings[:max_facts]),
             }
         )
 
@@ -228,7 +237,7 @@ def assemble_raw_result(
         records.append(
             {
                 "section": "passages",
-                "content": "## Source Document Passages\n" + "\n---\n".join(source_passages[:15]),
+                "content": "## Source Document Passages\n" + "\n---\n".join(source_passages[:max_passages]),
             }
         )
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/result_assembly.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/result_assembly.py
@@ -176,6 +176,14 @@ def assemble_raw_result(
     """
     records: list[dict[str, Any]] = []
 
+    # Negative caps would slice from the end; clamp so callers can only ever
+    # narrow a section (0 = omit it entirely), never reorder/truncate-from-tail.
+    max_cypher = max(0, max_cypher)
+    max_entities = max(0, max_entities)
+    max_relationships = max(0, max_relationships)
+    max_facts = max(0, max_facts)
+    max_passages = max(0, max_passages)
+
     # Question-type hint (prepended so LLM sees it first)
     if q_type_hint:
         records.append(
@@ -186,12 +194,12 @@ def assemble_raw_result(
         )
 
     # Cypher Query Results (direct to LLM — not reranked)
-    if cypher_results:
+    capped_cypher = (cypher_results or [])[:max_cypher]
+    if capped_cypher:
         records.append(
             {
                 "section": "cypher_results",
-                "content": "## Graph Query Results\n"
-                + "\n".join(f"- {r}" for r in cypher_results[:max_cypher]),
+                "content": "## Graph Query Results\n" + "\n".join(f"- {r}" for r in capped_cypher),
             }
         )
 
@@ -204,41 +212,43 @@ def assemble_raw_result(
             seen_names.add(name.lower())
             desc = einfo.get("description", "")
             entity_lines.append(f"- {name}: {desc}" if desc else f"- {name}")
-    if entity_lines:
+    capped_entities = entity_lines[:max_entities]
+    if capped_entities:
         records.append(
             {
                 "section": "entities",
-                "content": "## Key Entities\n" + "\n".join(entity_lines[:max_entities]),
+                "content": "## Key Entities\n" + "\n".join(capped_entities),
             }
         )
 
     # Relationship section
-    if relationship_strings:
+    capped_relationships = relationship_strings[:max_relationships]
+    if capped_relationships:
         records.append(
             {
                 "section": "relationships",
                 "content": "## Entity Relationships\n"
-                + "\n".join(f"- {r}" for r in relationship_strings[:max_relationships]),
+                + "\n".join(f"- {r}" for r in capped_relationships),
             }
         )
 
     # Knowledge Graph Facts section (from RELATES edge vector search)
-    if fact_strings:
+    capped_facts = fact_strings[:max_facts]
+    if capped_facts:
         records.append(
             {
                 "section": "facts",
-                "content": "## Knowledge Graph Facts\n"
-                + "\n".join(f"- {f}" for f in fact_strings[:max_facts]),
+                "content": "## Knowledge Graph Facts\n" + "\n".join(f"- {f}" for f in capped_facts),
             }
         )
 
     # Passages section
-    if source_passages:
+    capped_passages = source_passages[:max_passages]
+    if capped_passages:
         records.append(
             {
                 "section": "passages",
-                "content": "## Source Document Passages\n"
-                + "\n---\n".join(source_passages[:max_passages]),
+                "content": "## Source Document Passages\n" + "\n---\n".join(capped_passages),
             }
         )
 

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/result_assembly.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/result_assembly.py
@@ -237,7 +237,8 @@ def assemble_raw_result(
         records.append(
             {
                 "section": "passages",
-                "content": "## Source Document Passages\n" + "\n---\n".join(source_passages[:max_passages]),
+                "content": "## Source Document Passages\n"
+                + "\n---\n".join(source_passages[:max_passages]),
             }
         )
 

--- a/graphrag_sdk/src/graphrag_sdk/skills/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/__init__.py
@@ -1,0 +1,48 @@
+# GraphRAG SDK — Skills (Phase 3.4)
+# High-level reasoning skills composed from storage + provider primitives.
+# Each skill is callable directly, exposed as an agentic-retrieval action,
+# and registered as an MCP tool.
+
+from __future__ import annotations
+
+from graphrag_sdk.skills.base import Skill
+from graphrag_sdk.skills.contradiction_detection import ContradictionDetectionSkill
+from graphrag_sdk.skills.entity_comparison import EntityComparisonSkill
+from graphrag_sdk.skills.gap_analysis import GapAnalysisSkill
+from graphrag_sdk.skills.impact_analysis import ImpactAnalysisSkill
+from graphrag_sdk.skills.timeline_reconstruction import TimelineReconstructionSkill
+
+#: Registry of all built-in skill classes, keyed by stable name.
+SKILL_REGISTRY: dict[str, type[Skill]] = {
+    EntityComparisonSkill.name: EntityComparisonSkill,
+    ImpactAnalysisSkill.name: ImpactAnalysisSkill,
+    ContradictionDetectionSkill.name: ContradictionDetectionSkill,
+    GapAnalysisSkill.name: GapAnalysisSkill,
+    TimelineReconstructionSkill.name: TimelineReconstructionSkill,
+}
+
+
+def build_skill(name: str, graph_store: object, llm: object | None = None) -> Skill:
+    """Instantiate a registered skill by name.
+
+    Raises ``KeyError`` with the list of valid names when ``name`` is unknown.
+    """
+    try:
+        skill_cls = SKILL_REGISTRY[name]
+    except KeyError:
+        raise KeyError(
+            f"Unknown skill '{name}'. Available: {sorted(SKILL_REGISTRY)}"
+        ) from None
+    return skill_cls(graph_store, llm)
+
+
+__all__ = [
+    "Skill",
+    "SKILL_REGISTRY",
+    "build_skill",
+    "EntityComparisonSkill",
+    "ImpactAnalysisSkill",
+    "ContradictionDetectionSkill",
+    "GapAnalysisSkill",
+    "TimelineReconstructionSkill",
+]

--- a/graphrag_sdk/src/graphrag_sdk/skills/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/__init__.py
@@ -30,9 +30,7 @@ def build_skill(name: str, graph_store: object, llm: object | None = None) -> Sk
     try:
         skill_cls = SKILL_REGISTRY[name]
     except KeyError:
-        raise KeyError(
-            f"Unknown skill '{name}'. Available: {sorted(SKILL_REGISTRY)}"
-        ) from None
+        raise KeyError(f"Unknown skill '{name}'. Available: {sorted(SKILL_REGISTRY)}") from None
     return skill_cls(graph_store, llm)
 
 

--- a/graphrag_sdk/src/graphrag_sdk/skills/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/base.py
@@ -1,0 +1,65 @@
+# GraphRAG SDK — Skills: Base (Phase 3.4)
+# A Skill is a composable, high-level reasoning unit built on top of the
+# storage + provider primitives. Skills are surfaced three ways: called
+# directly, as agentic-retrieval actions (Phase 3.1), and as MCP tools
+# (Phase 3.2).
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import SkillResult
+
+logger = logging.getLogger(__name__)
+
+
+class Skill(ABC):
+    """Abstract base class for high-level graph reasoning skills.
+
+    Args:
+        graph_store: Graph data access object (provides ``query_raw``,
+            ``weighted_neighbors``, ``get_connected_entities``).
+        llm: Optional LLM provider for natural-language synthesis. When
+            ``None``, skills return their structured findings without a
+            generated summary.
+    """
+
+    #: Stable identifier used by registries, the agent, and MCP.
+    name: str = "skill"
+    #: Human-readable description used in tool schemas.
+    description: str = ""
+
+    def __init__(self, graph_store: Any, llm: Any | None = None) -> None:
+        self._graph = graph_store
+        self._llm = llm
+
+    @abstractmethod
+    async def run(self, ctx: Context | None = None, **params: Any) -> SkillResult:
+        """Execute the skill and return a structured :class:`SkillResult`."""
+        ...
+
+    # ── Shared helpers ────────────────────────────────────────────
+
+    async def _rows(self, cypher: str, params: dict[str, Any] | None = None) -> list[list[Any]]:
+        """Run a Cypher query and return its raw ``result_set`` rows."""
+        try:
+            result = await self._graph.query_raw(cypher, params or {})
+            return list(getattr(result, "result_set", []) or [])
+        except Exception as exc:
+            logger.warning("Skill %s query failed: %s", self.name, exc)
+            return []
+
+    async def _summarize(self, ctx: Context | None, prompt: str) -> str:
+        """Best-effort LLM summary; returns ``""`` when no LLM is configured."""
+        if self._llm is None:
+            return ""
+        try:
+            timeout = ctx.provider_timeout_seconds(f"skill {self.name} summary") if ctx else None
+            resp = await self._llm.ainvoke(prompt, timeout=timeout)
+            return (resp.content or "").strip()
+        except Exception as exc:
+            logger.warning("Skill %s summary failed: %s", self.name, exc)
+            return ""

--- a/graphrag_sdk/src/graphrag_sdk/skills/base.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/base.py
@@ -39,7 +39,7 @@ class Skill(ABC):
     @abstractmethod
     async def run(self, ctx: Context | None = None, **params: Any) -> SkillResult:
         """Execute the skill and return a structured :class:`SkillResult`."""
-        ...
+        raise NotImplementedError("Subclasses must implement 'run'.")
 
     # ── Shared helpers ────────────────────────────────────────────
 

--- a/graphrag_sdk/src/graphrag_sdk/skills/contradiction_detection.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/contradiction_detection.py
@@ -31,7 +31,7 @@ class ContradictionDetectionSkill(Skill):
 
         rows = await self._rows(
             "MATCH (e:__Entity__ {id: $id})-[r]-(m:__Entity__) "
-            "RETURN type(r) AS rel, m.id AS other, "
+            "RETURN coalesce(r.rel_type, type(r)) AS rel, m.id AS other, "
             "coalesce(r.description, '') AS desc "
             f"LIMIT {limit}",
             {"id": entity},

--- a/graphrag_sdk/src/graphrag_sdk/skills/contradiction_detection.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/contradiction_detection.py
@@ -1,0 +1,82 @@
+# GraphRAG SDK — Skills: Contradiction Detection (Phase 3.4)
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import SkillResult
+from graphrag_sdk.skills.base import Skill
+
+
+class ContradictionDetectionSkill(Skill):
+    """Detect conflicting facts about an entity in the knowledge graph.
+
+    Gathers the relationships and descriptions attached to an entity and
+    asks the LLM to flag mutually inconsistent statements. Without an LLM
+    it returns the collected facts for external inspection.
+    """
+
+    name = "contradiction_detection"
+    description = (
+        "Find contradictory or mutually inconsistent facts about an entity "
+        "in the graph."
+    )
+
+    async def run(self, ctx: Context | None = None, **params: Any) -> SkillResult:
+        entity = params.get("entity")
+        if not entity:
+            raise ValueError("contradiction_detection requires 'entity'")
+        limit = int(params.get("limit", 50))
+
+        rows = await self._rows(
+            "MATCH (e:__Entity__ {id: $id})-[r]-(m:__Entity__) "
+            "RETURN type(r) AS rel, m.id AS other, "
+            "coalesce(r.description, '') AS desc "
+            f"LIMIT {limit}",
+            {"id": entity},
+        )
+        facts = [
+            {"relation": r[0], "other": r[1], "description": r[2] if len(r) > 2 else ""}
+            for r in rows
+            if r
+        ]
+
+        contradictions: list[dict[str, Any]] = []
+        summary = ""
+        if self._llm is not None and facts:
+            prompt = (
+                f"Here are facts about entity '{entity}':\n"
+                + "\n".join(
+                    f"- {f['relation']} {f['other']}: {f['description']}" for f in facts
+                )
+                + "\n\nIdentify any pairs of facts that contradict each other. "
+                'Respond as JSON: {"contradictions": [{"a": "...", "b": "...", '
+                '"reason": "..."}], "summary": "..."}'
+            )
+            raw = await self._summarize(ctx, prompt)
+            parsed = _safe_json(raw)
+            if isinstance(parsed, dict):
+                contradictions = parsed.get("contradictions", []) or []
+                summary = parsed.get("summary", "") or ""
+
+        data = {
+            "entity": entity,
+            "facts_examined": len(facts),
+            "contradictions": contradictions,
+        }
+        return SkillResult(skill=self.name, summary=summary, data=data, sources=[entity])
+
+
+def _safe_json(text: str) -> Any:
+    if not text:
+        return None
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        return json.loads(text[start : end + 1])
+    except (ValueError, TypeError):
+        return None

--- a/graphrag_sdk/src/graphrag_sdk/skills/contradiction_detection.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/contradiction_detection.py
@@ -19,10 +19,7 @@ class ContradictionDetectionSkill(Skill):
     """
 
     name = "contradiction_detection"
-    description = (
-        "Find contradictory or mutually inconsistent facts about an entity "
-        "in the graph."
-    )
+    description = "Find contradictory or mutually inconsistent facts about an entity in the graph."
 
     async def run(self, ctx: Context | None = None, **params: Any) -> SkillResult:
         entity = params.get("entity")
@@ -48,9 +45,7 @@ class ContradictionDetectionSkill(Skill):
         if self._llm is not None and facts:
             prompt = (
                 f"Here are facts about entity '{entity}':\n"
-                + "\n".join(
-                    f"- {f['relation']} {f['other']}: {f['description']}" for f in facts
-                )
+                + "\n".join(f"- {f['relation']} {f['other']}: {f['description']}" for f in facts)
                 + "\n\nIdentify any pairs of facts that contradict each other. "
                 'Respond as JSON: {"contradictions": [{"a": "...", "b": "...", '
                 '"reason": "..."}], "summary": "..."}'

--- a/graphrag_sdk/src/graphrag_sdk/skills/contradiction_detection.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/contradiction_detection.py
@@ -26,6 +26,8 @@ class ContradictionDetectionSkill(Skill):
         if not entity:
             raise ValueError("contradiction_detection requires 'entity'")
         limit = int(params.get("limit", 50))
+        if limit < 1:
+            raise ValueError("contradiction_detection 'limit' must be >= 1")
 
         rows = await self._rows(
             "MATCH (e:__Entity__ {id: $id})-[r]-(m:__Entity__) "

--- a/graphrag_sdk/src/graphrag_sdk/skills/entity_comparison.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/entity_comparison.py
@@ -1,0 +1,82 @@
+# GraphRAG SDK — Skills: Entity Comparison (Phase 3.4)
+
+from __future__ import annotations
+
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import SkillResult
+from graphrag_sdk.skills.base import Skill
+
+
+class EntityComparisonSkill(Skill):
+    """Compare two entities by their properties and graph neighborhoods."""
+
+    name = "entity_comparison"
+    description = (
+        "Compare two entities: their attributes, shared neighbors, and "
+        "what makes each distinct."
+    )
+
+    async def run(self, ctx: Context | None = None, **params: Any) -> SkillResult:
+        entity_a = params.get("entity_a")
+        entity_b = params.get("entity_b")
+        if not entity_a or not entity_b:
+            raise ValueError("entity_comparison requires 'entity_a' and 'entity_b'")
+
+        props_a = await self._properties(entity_a)
+        props_b = await self._properties(entity_b)
+        nbrs_a = await self._neighbor_ids(entity_a)
+        nbrs_b = await self._neighbor_ids(entity_b)
+
+        shared = sorted(nbrs_a & nbrs_b)
+        only_a = sorted(nbrs_a - nbrs_b)
+        only_b = sorted(nbrs_b - nbrs_a)
+        shared_keys = sorted(set(props_a) & set(props_b))
+        differing = {
+            k: {"a": props_a.get(k), "b": props_b.get(k)}
+            for k in shared_keys
+            if props_a.get(k) != props_b.get(k)
+        }
+
+        data = {
+            "entity_a": entity_a,
+            "entity_b": entity_b,
+            "shared_neighbors": shared,
+            "neighbors_only_a": only_a,
+            "neighbors_only_b": only_b,
+            "differing_attributes": differing,
+        }
+        summary = await self._summarize(
+            ctx,
+            f"Compare entity '{entity_a}' and '{entity_b}'. "
+            f"Shared connections: {shared}. Unique to {entity_a}: {only_a}. "
+            f"Unique to {entity_b}: {only_b}. Differing attributes: {differing}. "
+            "Write a concise comparison.",
+        )
+        return SkillResult(
+            skill=self.name,
+            summary=summary,
+            data=data,
+            sources=[entity_a, entity_b],
+        )
+
+    async def _properties(self, entity_id: str) -> dict[str, Any]:
+        rows = await self._rows(
+            "MATCH (e:__Entity__ {id: $id}) RETURN properties(e) AS props",
+            {"id": entity_id},
+        )
+        if rows and rows[0]:
+            return dict(rows[0][0] or {})
+        return {}
+
+    async def _neighbor_ids(self, entity_id: str) -> set[str]:
+        try:
+            neighbors = await self._graph.weighted_neighbors(entity_id)
+            return {n[0] for n in neighbors}
+        except Exception:
+            rows = await self._rows(
+                "MATCH (e:__Entity__ {id: $id})-[]-(m:__Entity__) RETURN DISTINCT m.id",
+                {"id": entity_id},
+            )
+            return {r[0] for r in rows if r and r[0] is not None}

--- a/graphrag_sdk/src/graphrag_sdk/skills/entity_comparison.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/entity_comparison.py
@@ -14,8 +14,7 @@ class EntityComparisonSkill(Skill):
 
     name = "entity_comparison"
     description = (
-        "Compare two entities: their attributes, shared neighbors, and "
-        "what makes each distinct."
+        "Compare two entities: their attributes, shared neighbors, and what makes each distinct."
     )
 
     async def run(self, ctx: Context | None = None, **params: Any) -> SkillResult:

--- a/graphrag_sdk/src/graphrag_sdk/skills/gap_analysis.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/gap_analysis.py
@@ -1,0 +1,57 @@
+# GraphRAG SDK — Skills: Gap Analysis (Phase 3.4)
+
+from __future__ import annotations
+
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import SkillResult
+from graphrag_sdk.skills.base import Skill
+
+
+class GapAnalysisSkill(Skill):
+    """Surface sparse or missing areas of the knowledge graph.
+
+    Flags entities with no relationships (isolated nodes) and entity
+    labels that are underrepresented, so users can target ingestion or
+    backfill where the graph is thin.
+    """
+
+    name = "gap_analysis"
+    description = (
+        "Identify gaps in the knowledge graph: isolated entities and "
+        "sparsely populated entity types."
+    )
+
+    async def run(self, ctx: Context | None = None, **params: Any) -> SkillResult:
+        min_instances = int(params.get("min_instances", 2))
+        limit = int(params.get("limit", 50))
+
+        isolated_rows = await self._rows(
+            "MATCH (e:__Entity__) WHERE NOT (e)-[]-(:__Entity__) "
+            f"RETURN e.id AS id LIMIT {limit}"
+        )
+        isolated = [r[0] for r in isolated_rows if r and r[0] is not None]
+
+        label_rows = await self._rows(
+            "MATCH (e:__Entity__) "
+            "WITH [l IN labels(e) WHERE l <> '__Entity__'][0] AS label "
+            "RETURN label, count(*) AS n ORDER BY n ASC"
+        )
+        sparse_labels = [
+            {"label": r[0], "count": int(r[1])}
+            for r in label_rows
+            if r and r[0] is not None and int(r[1]) < min_instances
+        ]
+
+        data = {
+            "isolated_entities": isolated,
+            "num_isolated": len(isolated),
+            "sparse_labels": sparse_labels,
+        }
+        summary = await self._summarize(
+            ctx,
+            f"The graph has {len(isolated)} isolated entities and these "
+            f"sparse types: {sparse_labels}. Suggest where to focus ingestion.",
+        )
+        return SkillResult(skill=self.name, summary=summary, data=data, sources=isolated[:10])

--- a/graphrag_sdk/src/graphrag_sdk/skills/gap_analysis.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/gap_analysis.py
@@ -28,8 +28,7 @@ class GapAnalysisSkill(Skill):
         limit = int(params.get("limit", 50))
 
         isolated_rows = await self._rows(
-            "MATCH (e:__Entity__) WHERE NOT (e)-[]-(:__Entity__) "
-            f"RETURN e.id AS id LIMIT {limit}"
+            f"MATCH (e:__Entity__) WHERE NOT (e)-[]-(:__Entity__) RETURN e.id AS id LIMIT {limit}"
         )
         isolated = [r[0] for r in isolated_rows if r and r[0] is not None]
 

--- a/graphrag_sdk/src/graphrag_sdk/skills/impact_analysis.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/impact_analysis.py
@@ -1,0 +1,72 @@
+# GraphRAG SDK — Skills: Impact Analysis (Phase 3.4)
+
+from __future__ import annotations
+
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import SkillResult
+from graphrag_sdk.retrieval.graph_walk import DynamicGraphWalk
+from graphrag_sdk.skills.base import Skill
+
+
+class ImpactAnalysisSkill(Skill):
+    """Estimate what a change to an entity ripples into.
+
+    Walks outward from the target entity (weighted beam search) and ranks
+    reachable entities by proximity and path score — the closer and more
+    strongly connected, the higher the estimated impact.
+    """
+
+    name = "impact_analysis"
+    description = (
+        "Estimate the downstream impact of changing an entity by walking "
+        "its outgoing graph neighborhood."
+    )
+
+    async def run(self, ctx: Context | None = None, **params: Any) -> SkillResult:
+        entity = params.get("entity")
+        if not entity:
+            raise ValueError("impact_analysis requires 'entity'")
+        max_depth = int(params.get("max_depth", 3))
+        beam_width = int(params.get("beam_width", 8))
+
+        try:
+            weights = await self._graph.pagerank()
+        except Exception:
+            weights = {}
+
+        async def neighbor_fn(node_id: str) -> list[tuple[str, float, str]]:
+            return await self._graph.weighted_neighbors(node_id)
+
+        walk = DynamicGraphWalk(
+            neighbor_fn,
+            node_weights=weights,
+            beam_width=beam_width,
+            max_depth=max_depth,
+        )
+        paths = await walk.beam_search(entity, ctx=ctx)
+
+        impacted: dict[str, dict[str, Any]] = {}
+        for path in paths:
+            for hop, node in enumerate(path.nodes[1:], start=1):
+                existing = impacted.get(node)
+                if existing is None or path.score > existing["score"]:
+                    impacted[node] = {
+                        "distance": hop,
+                        "score": path.score,
+                        "via": path.nodes,
+                    }
+        ranked = sorted(
+            ({"entity": k, **v} for k, v in impacted.items()),
+            key=lambda d: (d["distance"], -d["score"]),
+        )
+
+        data = {"entity": entity, "impacted": ranked, "num_impacted": len(ranked)}
+        summary = await self._summarize(
+            ctx,
+            f"Changing entity '{entity}' may affect these connected entities "
+            f"(closest first): {[r['entity'] for r in ranked[:15]]}. "
+            "Summarize the likely impact.",
+        )
+        return SkillResult(skill=self.name, summary=summary, data=data, sources=[entity])

--- a/graphrag_sdk/src/graphrag_sdk/skills/impact_analysis.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/impact_analysis.py
@@ -51,12 +51,18 @@ class ImpactAnalysisSkill(Skill):
         for path in paths:
             for hop, node in enumerate(path.nodes[1:], start=1):
                 existing = impacted.get(node)
-                if existing is None or path.score > existing["score"]:
+                if existing is None:
                     impacted[node] = {
                         "distance": hop,
                         "score": path.score,
                         "via": path.nodes,
                     }
+                    continue
+                if hop < existing["distance"]:
+                    existing["distance"] = hop
+                    existing["via"] = path.nodes
+                if path.score > existing["score"]:
+                    existing["score"] = path.score
         ranked = sorted(
             ({"entity": k, **v} for k, v in impacted.items()),
             key=lambda d: (d["distance"], -d["score"]),

--- a/graphrag_sdk/src/graphrag_sdk/skills/impact_analysis.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/impact_analysis.py
@@ -51,18 +51,20 @@ class ImpactAnalysisSkill(Skill):
         for path in paths:
             for hop, node in enumerate(path.nodes[1:], start=1):
                 existing = impacted.get(node)
-                if existing is None:
+                # Keep distance/score/via as one coherent record from the best
+                # path: shortest hop first, then highest score at equal hops.
+                # Updating score independently produced mismatched pairs (a
+                # score belonging to a different path than `via`).
+                if (
+                    existing is None
+                    or hop < existing["distance"]
+                    or (hop == existing["distance"] and path.score > existing["score"])
+                ):
                     impacted[node] = {
                         "distance": hop,
                         "score": path.score,
                         "via": path.nodes,
                     }
-                    continue
-                if hop < existing["distance"]:
-                    existing["distance"] = hop
-                    existing["via"] = path.nodes
-                if path.score > existing["score"]:
-                    existing["score"] = path.score
         ranked = sorted(
             ({"entity": k, **v} for k, v in impacted.items()),
             key=lambda d: (d["distance"], -d["score"]),

--- a/graphrag_sdk/src/graphrag_sdk/skills/timeline_reconstruction.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/timeline_reconstruction.py
@@ -31,15 +31,9 @@ class TimelineReconstructionSkill(Skill):
         limit = int(params.get("limit", 100))
 
         if label:
-            cypher = (
-                f"MATCH (e:{label}) RETURN e.id AS id, properties(e) AS props "
-                f"LIMIT {limit}"
-            )
+            cypher = f"MATCH (e:{label}) RETURN e.id AS id, properties(e) AS props LIMIT {limit}"
         else:
-            cypher = (
-                "MATCH (e:__Entity__) RETURN e.id AS id, properties(e) AS props "
-                f"LIMIT {limit}"
-            )
+            cypher = f"MATCH (e:__Entity__) RETURN e.id AS id, properties(e) AS props LIMIT {limit}"
         rows = await self._rows(cypher)
 
         events: list[dict[str, Any]] = []
@@ -50,9 +44,7 @@ class TimelineReconstructionSkill(Skill):
             props = dict(row[1] or {}) if len(row) > 1 else {}
             sort_key = _extract_date(props)
             if sort_key is not None:
-                events.append(
-                    {"entity": entity_id, "date": sort_key[1], "sort": sort_key[0]}
-                )
+                events.append({"entity": entity_id, "date": sort_key[1], "sort": sort_key[0]})
 
         events.sort(key=lambda e: e["sort"])
         timeline = [{"entity": e["entity"], "date": e["date"]} for e in events]

--- a/graphrag_sdk/src/graphrag_sdk/skills/timeline_reconstruction.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/timeline_reconstruction.py
@@ -1,0 +1,89 @@
+# GraphRAG SDK — Skills: Timeline Reconstruction (Phase 3.4)
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import SkillResult
+from graphrag_sdk.skills.base import Skill
+
+_DATE_KEYS = ("date", "year", "time", "timestamp", "when", "created", "start", "end")
+_YEAR_RE = re.compile(r"(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?")
+
+
+class TimelineReconstructionSkill(Skill):
+    """Reconstruct a chronological timeline of entities/events.
+
+    Collects entities that carry a temporal attribute, sorts them by the
+    parsed date, and optionally narrates the sequence with the LLM.
+    """
+
+    name = "timeline_reconstruction"
+    description = (
+        "Reconstruct a chronological timeline from entities that carry "
+        "temporal attributes (dates, years)."
+    )
+
+    async def run(self, ctx: Context | None = None, **params: Any) -> SkillResult:
+        label = params.get("label")
+        limit = int(params.get("limit", 100))
+
+        if label:
+            cypher = (
+                f"MATCH (e:{label}) RETURN e.id AS id, properties(e) AS props "
+                f"LIMIT {limit}"
+            )
+        else:
+            cypher = (
+                "MATCH (e:__Entity__) RETURN e.id AS id, properties(e) AS props "
+                f"LIMIT {limit}"
+            )
+        rows = await self._rows(cypher)
+
+        events: list[dict[str, Any]] = []
+        for row in rows:
+            if not row:
+                continue
+            entity_id = row[0]
+            props = dict(row[1] or {}) if len(row) > 1 else {}
+            sort_key = _extract_date(props)
+            if sort_key is not None:
+                events.append(
+                    {"entity": entity_id, "date": sort_key[1], "sort": sort_key[0]}
+                )
+
+        events.sort(key=lambda e: e["sort"])
+        timeline = [{"entity": e["entity"], "date": e["date"]} for e in events]
+
+        data = {"timeline": timeline, "num_events": len(timeline)}
+        summary = await self._summarize(
+            ctx,
+            "Reconstruct the timeline from these dated events: "
+            f"{timeline[:30]}. Narrate the chronological sequence.",
+        )
+        return SkillResult(
+            skill=self.name,
+            summary=summary,
+            data=data,
+            sources=[e["entity"] for e in timeline[:10]],
+        )
+
+
+def _extract_date(props: dict[str, Any]) -> tuple[tuple[int, int, int], str] | None:
+    """Find a temporal value in an entity's properties and parse it.
+
+    Returns ``((year, month, day), raw_string)`` or ``None``.
+    """
+    for key, value in props.items():
+        if value is None:
+            continue
+        if any(token in key.lower() for token in _DATE_KEYS):
+            match = _YEAR_RE.search(str(value))
+            if match:
+                year = int(match.group(1))
+                month = int(match.group(2)) if match.group(2) else 0
+                day = int(match.group(3)) if match.group(3) else 0
+                return (year, month, day), str(value)
+    return None

--- a/graphrag_sdk/src/graphrag_sdk/skills/timeline_reconstruction.py
+++ b/graphrag_sdk/src/graphrag_sdk/skills/timeline_reconstruction.py
@@ -8,6 +8,7 @@ from typing import Any
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import SkillResult
 from graphrag_sdk.skills.base import Skill
+from graphrag_sdk.utils.cypher import sanitize_cypher_label
 
 _DATE_KEYS = ("date", "year", "time", "timestamp", "when", "created", "start", "end")
 _YEAR_RE = re.compile(r"(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?")
@@ -31,7 +32,10 @@ class TimelineReconstructionSkill(Skill):
         limit = int(params.get("limit", 100))
 
         if label:
-            cypher = f"MATCH (e:{label}) RETURN e.id AS id, properties(e) AS props LIMIT {limit}"
+            safe_label = sanitize_cypher_label(label)
+            cypher = (
+                f"MATCH (e:`{safe_label}`) RETURN e.id AS id, properties(e) AS props LIMIT {limit}"
+            )
         else:
             cypher = f"MATCH (e:__Entity__) RETURN e.id AS id, properties(e) AS props LIMIT {limit}"
         rows = await self._rows(cypher)

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -377,6 +377,10 @@ class GraphStore:
         procedure is unavailable (e.g. older FalkorDB) so callers can fall
         back to an unweighted walk.
         """
+        if not entity_label.isidentifier():
+            raise ValueError(f"Invalid entity_label for pagerank: {entity_label!r}")
+        if relationship_type is not None and not relationship_type.isidentifier():
+            raise ValueError(f"Invalid relationship_type for pagerank: {relationship_type!r}")
         rel = f"'{relationship_type}'" if relationship_type else "NULL"
         query = (
             f"CALL algo.pageRank('{entity_label}', {rel}) "

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -393,7 +393,6 @@ class GraphStore:
             logger.warning(f"pagerank unavailable: {exc}")
             return {}
 
-
     # ── Statistics ────────────────────────────────────────────────
 
     async def get_statistics(self) -> dict[str, Any]:

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -331,6 +331,69 @@ class GraphStore:
         """
         return await self._conn.query(cypher, params)
 
+    # ── Graph Walk (Phase 3.3) ────────────────────────────────────
+
+    async def weighted_neighbors(
+        self,
+        node_id: str,
+        *,
+        limit: int = 50,
+    ) -> list[tuple[str, float, str]]:
+        """Return weighted neighbors of an entity for dynamic graph walks.
+
+        Each tuple is ``(neighbor_id, edge_weight, edge_label)``. Edge
+        weight falls back to ``1.0`` when the relationship has no stored
+        ``weight`` property.
+        """
+        query = (
+            "MATCH (n:__Entity__ {id: $node_id})-[r]-(m:__Entity__) "
+            "RETURN m.id AS id, type(r) AS label, "
+            "coalesce(r.weight, 1.0) AS weight "
+            f"LIMIT {int(limit)}"
+        )
+        try:
+            result = await self._conn.query(query, {"node_id": node_id})
+            neighbors: list[tuple[str, float, str]] = []
+            for row in result.result_set:
+                nbr_id = row[0]
+                label = row[1] if len(row) > 1 else ""
+                weight = float(row[2]) if len(row) > 2 and row[2] is not None else 1.0
+                if nbr_id is not None:
+                    neighbors.append((nbr_id, weight, label or ""))
+            return neighbors
+        except Exception as exc:
+            logger.warning(f"weighted_neighbors failed for {node_id}: {exc}")
+            return []
+
+    async def pagerank(
+        self,
+        *,
+        entity_label: str = "__Entity__",
+        relationship_type: str | None = None,
+    ) -> dict[str, float]:
+        """Compute PageRank importance per entity via FalkorDB's algo procedure.
+
+        Returns a ``{entity_id: score}`` map. Returns an empty map when the
+        procedure is unavailable (e.g. older FalkorDB) so callers can fall
+        back to an unweighted walk.
+        """
+        rel = f"'{relationship_type}'" if relationship_type else "NULL"
+        query = (
+            f"CALL algo.pageRank('{entity_label}', {rel}) "
+            "YIELD node, score RETURN node.id AS id, score AS score"
+        )
+        try:
+            result = await self._conn.query(query)
+            scores: dict[str, float] = {}
+            for row in result.result_set:
+                if row[0] is not None:
+                    scores[row[0]] = float(row[1]) if row[1] is not None else 0.0
+            return scores
+        except Exception as exc:
+            logger.warning(f"pagerank unavailable: {exc}")
+            return {}
+
+
     # ── Statistics ────────────────────────────────────────────────
 
     async def get_statistics(self) -> dict[str, Any]:

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -347,7 +347,7 @@ class GraphStore:
         """
         query = (
             "MATCH (n:__Entity__ {id: $node_id})-[r]-(m:__Entity__) "
-            "RETURN m.id AS id, type(r) AS label, "
+            "RETURN m.id AS id, coalesce(r.rel_type, type(r)) AS label, "
             "coalesce(r.weight, 1.0) AS weight "
             f"LIMIT {int(limit)}"
         )

--- a/graphrag_sdk/tests/test_agentic_retrieval.py
+++ b/graphrag_sdk/tests/test_agentic_retrieval.py
@@ -1,0 +1,134 @@
+"""Tests for retrieval/agentic — ReAct loop and tools (Phase 3.1)."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import RetrieverResult, RetrieverResultItem
+from graphrag_sdk.retrieval.agentic import (
+    AgenticRetrieval,
+    ToolRegistry,
+    build_default_registry,
+    is_read_only_cypher,
+    parse_react_step,
+)
+from graphrag_sdk.retrieval.agentic.tools import Tool, make_search_tool
+
+
+class ScriptedLLM:
+    """LLM returning a fixed list of ReAct turns in order."""
+
+    def __init__(self, turns: list[str]):
+        self._turns = turns
+        self._i = 0
+        self.model_name = "scripted"
+
+    async def ainvoke(self, prompt: str, **kwargs: Any):
+        from graphrag_sdk.core.models import LLMResponse
+
+        text = self._turns[min(self._i, len(self._turns) - 1)]
+        self._i += 1
+        return LLMResponse(content=text)
+
+
+class FakeStrategy:
+    async def search(self, query: str, ctx: Context) -> RetrieverResult:
+        return RetrieverResult(
+            items=[RetrieverResultItem(content="Alice works at Acme Corp.")]
+        )
+
+
+class TestParseReactStep:
+    def test_parses_action_and_input(self):
+        text = 'Thought: search now\nAction: search\nAction Input: {"query": "alice"}'
+        parsed = parse_react_step(text)
+        assert parsed["action"] == "search"
+        assert parsed["action_input"] == {"query": "alice"}
+
+    def test_parses_final_answer(self):
+        parsed = parse_react_step("Thought: done\nFinal Answer: 42")
+        assert parsed["final_answer"] == "42"
+
+    def test_malformed_json_input_is_empty(self):
+        parsed = parse_react_step("Action: search\nAction Input: {not json}")
+        assert parsed["action"] == "search"
+        assert parsed["action_input"] == {}
+
+
+class TestReadOnlyCypher:
+    def test_allows_match(self):
+        assert is_read_only_cypher("MATCH (n) RETURN n")
+
+    @pytest.mark.parametrize(
+        "cypher",
+        ["CREATE (n)", "MATCH (n) DELETE n", "MERGE (n)", "MATCH (n) SET n.x = 1"],
+    )
+    def test_rejects_writes(self, cypher: str):
+        assert not is_read_only_cypher(cypher)
+
+
+class TestToolRegistry:
+    async def test_unknown_tool_returns_error(self, ctx: Context):
+        reg = ToolRegistry()
+        out = await reg.run("nope", {}, ctx)
+        assert "unknown tool" in out.lower()
+
+    async def test_handler_exception_is_caught(self, ctx: Context):
+        async def boom(inp: dict, ctx: Context) -> str:
+            raise RuntimeError("kaboom")
+
+        reg = ToolRegistry()
+        reg.register(Tool("boom", "desc", boom))
+        out = await reg.run("boom", {}, ctx)
+        assert "kaboom" in out
+
+    async def test_search_tool_returns_snippets(self, ctx: Context):
+        tool = make_search_tool(FakeStrategy())
+        out = await tool.handler({"query": "alice"}, ctx)
+        assert "Acme" in out
+
+    def test_default_registry_only_search_without_store(self):
+        reg = build_default_registry(strategy=FakeStrategy(), graph_store=None)
+        assert reg.names() == ["search"]
+
+
+class TestAgenticRetrieval:
+    async def test_loop_runs_tool_then_answers(self, ctx: Context):
+        llm = ScriptedLLM([
+            'Thought: search\nAction: search\nAction Input: {"query": "alice"}',
+            "Thought: I now have enough information.\nFinal Answer: Alice works at Acme.",
+        ])
+        agent = AgenticRetrieval(llm, strategy=FakeStrategy(), max_steps=4)
+        result = await agent.search("where does alice work?", ctx)
+        assert result.metadata["stop_reason"] == "final_answer"
+        assert "Acme" in result.metadata["answer"]
+        assert result.metadata["num_steps"] >= 1
+        assert any("Acme" in item.content for item in result.items)
+
+    async def test_stops_on_exhausted_budget(self):
+        llm = ScriptedLLM(["Action: search\nAction Input: {}"])
+        agent = AgenticRetrieval(llm, strategy=FakeStrategy(), max_steps=4)
+        ctx = Context(latency_budget_ms=0.0)
+        result = await agent.search("q", ctx)
+        assert result.metadata["stop_reason"] == "budget_exceeded"
+        assert result.metadata["num_steps"] == 0
+
+    async def test_stops_when_no_action(self, ctx: Context):
+        llm = ScriptedLLM(["Thought: hmm, nothing to do here."])
+        agent = AgenticRetrieval(llm, strategy=FakeStrategy(), max_steps=3)
+        result = await agent.search("q", ctx)
+        assert result.metadata["stop_reason"] == "no_action"
+
+    async def test_respects_max_steps(self, ctx: Context):
+        # Always emits an action, never a final answer → should hit the cap.
+        llm = ScriptedLLM(['Action: search\nAction Input: {"query": "x"}'])
+        agent = AgenticRetrieval(llm, strategy=FakeStrategy(), max_steps=2)
+        result = await agent.search("q", ctx)
+        assert result.metadata["stop_reason"] == "max_steps"
+        assert result.metadata["num_steps"] == 2
+
+    def test_invalid_max_steps(self):
+        with pytest.raises(ValueError):
+            AgenticRetrieval(ScriptedLLM([]), max_steps=0)

--- a/graphrag_sdk/tests/test_graph_walk.py
+++ b/graphrag_sdk/tests/test_graph_walk.py
@@ -1,0 +1,143 @@
+"""Tests for retrieval/graph_walk.py — DynamicGraphWalk (Phase 3.3)."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import ScoredPath
+from graphrag_sdk.retrieval.graph_walk import (
+    DynamicGraphWalk,
+    GraphWalkRetrieval,
+    score_path,
+)
+
+
+def make_neighbor_fn(adj: dict[str, list[tuple[str, float, str]]]):
+    async def neighbor_fn(node_id: str) -> list[tuple[str, float, str]]:
+        return adj.get(node_id, [])
+
+    return neighbor_fn
+
+
+class TestScorePath:
+    def test_empty_path_scores_zero(self):
+        assert score_path([]) == 0.0
+
+    def test_length_penalty_prefers_short_paths(self):
+        weights = {"a": 1.0, "b": 1.0, "c": 1.0}
+        short = score_path(["a", "b"], weights, [1.0], length_penalty=0.5)
+        long = score_path(["a", "b", "c"], weights, [1.0, 1.0], length_penalty=0.5)
+        assert short > long
+
+    def test_node_weights_increase_score(self):
+        high = score_path(["a", "b"], {"a": 5.0, "b": 5.0}, [1.0])
+        low = score_path(["a", "b"], {"a": 0.1, "b": 0.1}, [1.0])
+        assert high > low
+
+
+class TestBeamSearch:
+    async def test_beam_width_caps_results(self, ctx: Context):
+        adj = {"start": [(f"n{i}", 1.0, "REL") for i in range(20)]}
+        walk = DynamicGraphWalk(make_neighbor_fn(adj), beam_width=3, max_depth=2)
+        paths = await walk.beam_search("start", ctx=ctx)
+        assert len(paths) <= 3
+        assert all(isinstance(p, ScoredPath) for p in paths)
+
+    async def test_reaches_goal(self, ctx: Context):
+        adj = {
+            "a": [("b", 1.0, "R")],
+            "b": [("c", 1.0, "R")],
+            "c": [("d", 1.0, "R")],
+        }
+        walk = DynamicGraphWalk(make_neighbor_fn(adj), beam_width=5, max_depth=5)
+        paths = await walk.beam_search("a", goal="d", ctx=ctx)
+        assert paths
+        assert paths[0].nodes[0] == "a"
+        assert paths[0].nodes[-1] == "d"
+
+    async def test_no_cycles_within_path(self, ctx: Context):
+        adj = {"a": [("b", 1.0, "R")], "b": [("a", 1.0, "R")]}
+        walk = DynamicGraphWalk(make_neighbor_fn(adj), beam_width=5, max_depth=4)
+        paths = await walk.beam_search("a", ctx=ctx)
+        for p in paths:
+            assert len(p.nodes) == len(set(p.nodes))
+
+    async def test_higher_weighted_path_ranks_first(self, ctx: Context):
+        adj = {"start": [("hi", 1.0, "R"), ("lo", 1.0, "R")]}
+        weights = {"hi": 10.0, "lo": 0.0}
+        walk = DynamicGraphWalk(
+            make_neighbor_fn(adj), node_weights=weights, beam_width=2, max_depth=1
+        )
+        paths = await walk.beam_search("start", ctx=ctx)
+        assert paths[0].nodes[-1] == "hi"
+
+    def test_invalid_params_rejected(self):
+        with pytest.raises(ValueError):
+            DynamicGraphWalk(make_neighbor_fn({}), beam_width=0)
+        with pytest.raises(ValueError):
+            DynamicGraphWalk(make_neighbor_fn({}), max_depth=0)
+
+
+class TestBidirectionalSearch:
+    async def test_same_start_and_goal(self, ctx: Context):
+        walk = DynamicGraphWalk(make_neighbor_fn({}), max_depth=3)
+        path = await walk.bidirectional_search("a", "a", ctx=ctx)
+        assert path is not None
+        assert path.nodes == ["a"]
+
+    async def test_finds_connecting_path(self, ctx: Context):
+        adj = {
+            "a": [("b", 1.0, "R")],
+            "b": [("a", 1.0, "R"), ("c", 1.0, "R")],
+            "c": [("b", 1.0, "R")],
+        }
+        walk = DynamicGraphWalk(make_neighbor_fn(adj), max_depth=4)
+        path = await walk.bidirectional_search("a", "c", ctx=ctx)
+        assert path is not None
+        assert path.nodes[0] == "a"
+        assert path.nodes[-1] == "c"
+        assert "b" in path.nodes
+
+    async def test_returns_none_when_disconnected(self, ctx: Context):
+        adj = {"a": [("b", 1.0, "R")], "b": [("a", 1.0, "R")], "x": [("y", 1.0, "R")]}
+        walk = DynamicGraphWalk(make_neighbor_fn(adj), max_depth=3)
+        path = await walk.bidirectional_search("a", "x", ctx=ctx)
+        assert path is None
+
+
+class FakeWalkStore:
+    def __init__(self, adj: dict[str, list[tuple[str, float, str]]], weights=None):
+        self._adj = adj
+        self._weights = weights or {}
+
+    async def weighted_neighbors(self, node_id: str, *, limit: int = 50):
+        return self._adj.get(node_id, [])
+
+    async def pagerank(self, **kwargs: Any):
+        return self._weights
+
+
+class TestGraphWalkRetrieval:
+    async def test_returns_paths_as_items(self, ctx: Context):
+        adj = {"alice": [("acme", 1.0, "WORKS_AT")], "acme": [("bob", 1.0, "WORKS_AT")]}
+        store = FakeWalkStore(adj)
+
+        async def seed_fn(query: str, ctx: Context) -> list[str]:
+            return ["alice"]
+
+        strat = GraphWalkRetrieval(store, seed_fn, max_depth=2, use_pagerank=False)
+        result = await strat.search("who works with alice", ctx)
+        assert result.items
+        assert "alice" in result.items[0].content
+
+    async def test_no_seeds_returns_empty(self, ctx: Context):
+        store = FakeWalkStore({})
+
+        async def seed_fn(query: str, ctx: Context) -> list[str]:
+            return []
+
+        strat = GraphWalkRetrieval(store, seed_fn)
+        result = await strat.search("q", ctx)
+        assert result.items == []

--- a/graphrag_sdk/tests/test_mcp_tools.py
+++ b/graphrag_sdk/tests/test_mcp_tools.py
@@ -1,0 +1,132 @@
+"""Tests for mcp/tools.py — GraphRAGToolset (Phase 3.2)."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from graphrag_sdk.core.models import RagResult, RetrieverResult, RetrieverResultItem
+from graphrag_sdk.mcp.tools import GraphRAGToolset
+
+
+class FakeResult:
+    def __init__(self, rows):
+        self.result_set = rows
+
+
+class FakeGraphStore:
+    def __init__(self):
+        self.last_cypher: str | None = None
+
+    async def query_raw(self, cypher: str, params: dict | None = None):
+        self.last_cypher = cypher
+        return FakeResult([["alice", 1]])
+
+    async def pagerank(self, **kwargs: Any):
+        return {}
+
+    async def weighted_neighbors(self, node_id: str, *, limit: int = 50):
+        return [("acme", 1.0, "WORKS_AT")]
+
+
+class FakeRAG:
+    def __init__(self):
+        self._graph_store = FakeGraphStore()
+        self.llm = None
+
+    async def ingest(self, text: str, document_id: str | None = None):
+        class R:
+            nodes_created = 3
+            relationships_created = 2
+            chunks_indexed = 1
+
+        return R()
+
+    async def retrieve(self, question: str):
+        return RetrieverResult(items=[RetrieverResultItem(content="ctx snippet")])
+
+    async def completion(self, question: str):
+        return RagResult(answer="the answer", metadata={"model": "fake"})
+
+    async def get_statistics(self):
+        return {"node_count": 5, "edge_count": 4}
+
+    async def get_ontology(self):
+        class FakeOntology:
+            def model_dump(self):
+                return {"entities": []}
+
+        return FakeOntology()
+
+
+@pytest.fixture
+def toolset() -> GraphRAGToolset:
+    return GraphRAGToolset(FakeRAG())
+
+
+class TestToolset:
+    def test_exposes_eight_tools(self, toolset: GraphRAGToolset):
+        assert len(toolset.tools) == 8
+
+    def test_tool_names(self, toolset: GraphRAGToolset):
+        names = {t.name for t in toolset.tools}
+        assert names == {
+            "ingest",
+            "retrieve",
+            "answer",
+            "cypher_query",
+            "graph_walk",
+            "run_skill",
+            "get_statistics",
+            "get_ontology",
+        }
+
+    def test_specs_have_schema(self, toolset: GraphRAGToolset):
+        for spec in toolset.specs():
+            assert "name" in spec
+            assert "description" in spec
+            assert spec["inputSchema"]["type"] == "object"
+
+    def test_by_name_unknown_is_none(self, toolset: GraphRAGToolset):
+        assert toolset.by_name("missing") is None
+
+
+class TestHandlers:
+    async def test_ingest(self, toolset: GraphRAGToolset):
+        out = await toolset.by_name("ingest").handler({"text": "hi"})
+        assert json.loads(out)["nodes_created"] == 3
+
+    async def test_retrieve(self, toolset: GraphRAGToolset):
+        out = await toolset.by_name("retrieve").handler({"question": "q"})
+        assert "ctx snippet" in json.loads(out)["items"]
+
+    async def test_answer(self, toolset: GraphRAGToolset):
+        out = await toolset.by_name("answer").handler({"question": "q"})
+        assert json.loads(out)["answer"] == "the answer"
+
+    async def test_cypher_query_read_only_passes(self, toolset: GraphRAGToolset):
+        out = await toolset.by_name("cypher_query").handler(
+            {"cypher": "MATCH (n) RETURN n"}
+        )
+        assert "rows" in json.loads(out)
+
+    async def test_cypher_query_rejects_writes(self, toolset: GraphRAGToolset):
+        out = await toolset.by_name("cypher_query").handler(
+            {"cypher": "MATCH (n) DELETE n"}
+        )
+        assert "read-only" in out
+
+    async def test_graph_walk(self, toolset: GraphRAGToolset):
+        out = await toolset.by_name("graph_walk").handler({"start": "alice"})
+        assert "paths" in json.loads(out)
+
+    async def test_get_statistics(self, toolset: GraphRAGToolset):
+        out = await toolset.by_name("get_statistics").handler({})
+        assert json.loads(out)["node_count"] == 5
+
+    async def test_run_skill(self, toolset: GraphRAGToolset):
+        out = await toolset.by_name("run_skill").handler(
+            {"skill": "gap_analysis", "params": {}}
+        )
+        assert json.loads(out)["skill"] == "gap_analysis"

--- a/graphrag_sdk/tests/test_mcp_tools.py
+++ b/graphrag_sdk/tests/test_mcp_tools.py
@@ -1,4 +1,5 @@
 """Tests for mcp/tools.py — GraphRAGToolset (Phase 3.2)."""
+
 from __future__ import annotations
 
 import json
@@ -35,7 +36,7 @@ class FakeRAG:
         self._graph_store = FakeGraphStore()
         self.llm = None
 
-    async def ingest(self, text: str, document_id: str | None = None):
+    async def ingest(self, source=None, *, text: str, document_id: str | None = None):
         class R:
             nodes_created = 3
             relationships_created = 2
@@ -106,15 +107,11 @@ class TestHandlers:
         assert json.loads(out)["answer"] == "the answer"
 
     async def test_cypher_query_read_only_passes(self, toolset: GraphRAGToolset):
-        out = await toolset.by_name("cypher_query").handler(
-            {"cypher": "MATCH (n) RETURN n"}
-        )
+        out = await toolset.by_name("cypher_query").handler({"cypher": "MATCH (n) RETURN n"})
         assert "rows" in json.loads(out)
 
     async def test_cypher_query_rejects_writes(self, toolset: GraphRAGToolset):
-        out = await toolset.by_name("cypher_query").handler(
-            {"cypher": "MATCH (n) DELETE n"}
-        )
+        out = await toolset.by_name("cypher_query").handler({"cypher": "MATCH (n) DELETE n"})
         assert "read-only" in out
 
     async def test_graph_walk(self, toolset: GraphRAGToolset):
@@ -126,7 +123,5 @@ class TestHandlers:
         assert json.loads(out)["node_count"] == 5
 
     async def test_run_skill(self, toolset: GraphRAGToolset):
-        out = await toolset.by_name("run_skill").handler(
-            {"skill": "gap_analysis", "params": {}}
-        )
+        out = await toolset.by_name("run_skill").handler({"skill": "gap_analysis", "params": {}})
         assert json.loads(out)["skill"] == "gap_analysis"

--- a/graphrag_sdk/tests/test_path_router.py
+++ b/graphrag_sdk/tests/test_path_router.py
@@ -1,0 +1,231 @@
+"""Tests for retrieval/strategies/path_router.py and MultiPath path gating."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.exceptions import LatencyBudgetExceededError
+from graphrag_sdk.retrieval.strategies import multi_path as mp_module
+from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval
+from graphrag_sdk.retrieval.strategies.path_router import (
+    RETRIEVAL_PATHS,
+    HeuristicPathRouter,
+    LLMPathRouter,
+    all_paths,
+    parse_paths,
+)
+
+from .conftest import MockEmbedder, MockLLM
+
+
+# -- parse_paths / all_paths --
+
+
+class TestParsePaths:
+    def test_parses_comma_separated(self):
+        assert parse_paths("relates, chunks") == {"relates", "chunks"}
+
+    def test_parses_mixed_separators_and_case(self):
+        assert parse_paths("RELATES\nexpansion  chunks") == {
+            "relates",
+            "expansion",
+            "chunks",
+        }
+
+    def test_drops_unknown_tokens(self):
+        assert parse_paths("relates, bogus, foo") == {"relates"}
+
+    def test_empty_input_returns_empty_set(self):
+        assert parse_paths("") == set()
+        assert parse_paths("   ") == set()
+
+    def test_all_paths_is_full_set(self):
+        assert all_paths() == set(RETRIEVAL_PATHS)
+        assert len(RETRIEVAL_PATHS) == 5
+
+
+# -- LLMPathRouter --
+
+
+class TestLLMPathRouter:
+    async def test_returns_parsed_subset(self):
+        router = LLMPathRouter(MockLLM(responses=["relates, expansion"]))
+        plan = await router.plan("How are Alice and Bob connected?")
+        assert plan == {"relates", "expansion"}
+
+    async def test_empty_response_falls_back_to_all(self):
+        router = LLMPathRouter(MockLLM(responses=[""]))
+        plan = await router.plan("Who is Alice?")
+        assert plan == all_paths()
+
+    async def test_garbage_response_falls_back_to_all(self):
+        router = LLMPathRouter(MockLLM(responses=["banana, foo, bar"]))
+        plan = await router.plan("Who is Alice?")
+        assert plan == all_paths()
+
+    async def test_llm_exception_falls_back_to_all(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(side_effect=RuntimeError("boom"))
+        router = LLMPathRouter(llm)
+        plan = await router.plan("Who is Alice?")
+        assert plan == all_paths()
+
+    async def test_latency_budget_exceeded_propagates(self):
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock(side_effect=LatencyBudgetExceededError("slow"))
+        router = LLMPathRouter(llm)
+        with pytest.raises(LatencyBudgetExceededError):
+            await router.plan("Who is Alice?")
+
+
+# -- HeuristicPathRouter --
+
+
+class TestHeuristicPathRouter:
+    async def test_always_includes_relates_and_chunks(self):
+        plan = await HeuristicPathRouter().plan("xyz")
+        assert {"relates", "chunks"} <= plan
+
+    async def test_connection_query_adds_expansion(self):
+        plan = await HeuristicPathRouter().plan(
+            "how are Alice and Bob connected?"
+        )
+        assert "expansion" in plan
+
+    async def test_proper_noun_adds_entity_paths(self):
+        plan = await HeuristicPathRouter().plan("Tell me about Alice")
+        assert {"entity_cypher", "entity_fulltext"} <= plan
+
+
+# -- MultiPath gating --
+
+
+def _make_strategy(router=None):
+    graph = MagicMock()
+    graph.query_raw = AsyncMock(return_value=MagicMock(result_set=[]))
+    vector = MagicMock()
+    vector.search_chunks = AsyncMock(return_value=[])
+    vector.search_entities = AsyncMock(return_value=[])
+    vector.search_relationships = AsyncMock(return_value=[])
+    vector.fulltext_search_chunks = AsyncMock(return_value=[])
+    vector.fulltext_search_entities = AsyncMock(return_value=[])
+    return MultiPathRetrieval(
+        graph_store=graph,
+        vector_store=vector,
+        embedder=MockEmbedder(dimension=8),
+        llm=MockLLM(responses=["Alice"]),
+        router=router,
+    )
+
+
+class _FixedRouter:
+    def __init__(self, paths):
+        self._paths = set(paths)
+
+    async def plan(self, query, ctx=None):
+        return self._paths
+
+
+class TestMultiPathGating:
+    async def test_router_prunes_paths(self, monkeypatch):
+        calls = {}
+        for name in (
+            "search_relates_edges",
+            "discover_entities",
+            "expand_relationships",
+            "retrieve_chunks",
+        ):
+            calls[name] = MagicMock()
+
+        async def _relates(*a, **k):
+            calls["search_relates_edges"]()
+            return [], {}
+
+        async def _discover(*a, **k):
+            calls["discover_entities"]()
+            return {}, {}
+
+        async def _expand(*a, **k):
+            calls["expand_relationships"]()
+            return []
+
+        async def _chunks(*a, **k):
+            calls["retrieve_chunks"]()
+            return {}, {}, {}
+
+        monkeypatch.setattr(mp_module, "search_relates_edges", _relates)
+        monkeypatch.setattr(mp_module, "discover_entities", _discover)
+        monkeypatch.setattr(mp_module, "expand_relationships", _expand)
+        monkeypatch.setattr(mp_module, "retrieve_chunks", _chunks)
+
+        strategy = _make_strategy(router=_FixedRouter({"relates"}))
+        await strategy.search("Who is Alice?")
+
+        assert calls["search_relates_edges"].called
+        assert not calls["discover_entities"].called
+        assert not calls["expand_relationships"].called
+        assert not calls["retrieve_chunks"].called
+
+    async def test_no_router_runs_all_paths(self, monkeypatch):
+        called = set()
+
+        async def _relates(*a, **k):
+            called.add("relates")
+            return [], {}
+
+        async def _discover(*a, **k):
+            called.add("discover")
+            return {}, {}
+
+        async def _expand(*a, **k):
+            called.add("expand")
+            return []
+
+        async def _chunks(*a, **k):
+            called.add("chunks")
+            return {}, {}, {}
+
+        monkeypatch.setattr(mp_module, "search_relates_edges", _relates)
+        monkeypatch.setattr(mp_module, "discover_entities", _discover)
+        monkeypatch.setattr(mp_module, "expand_relationships", _expand)
+        monkeypatch.setattr(mp_module, "retrieve_chunks", _chunks)
+
+        strategy = _make_strategy(router=None)
+        await strategy.search("Who is Alice?")
+
+        assert called == {"relates", "discover", "expand", "chunks"}
+
+    async def test_router_failure_falls_back_to_all_paths(self, monkeypatch):
+        called = set()
+
+        async def _relates(*a, **k):
+            called.add("relates")
+            return [], {}
+
+        async def _discover(*a, **k):
+            called.add("discover")
+            return {}, {}
+
+        async def _expand(*a, **k):
+            called.add("expand")
+            return []
+
+        async def _chunks(*a, **k):
+            called.add("chunks")
+            return {}, {}, {}
+
+        monkeypatch.setattr(mp_module, "search_relates_edges", _relates)
+        monkeypatch.setattr(mp_module, "discover_entities", _discover)
+        monkeypatch.setattr(mp_module, "expand_relationships", _expand)
+        monkeypatch.setattr(mp_module, "retrieve_chunks", _chunks)
+
+        class _BoomRouter:
+            async def plan(self, query, ctx=None):
+                raise RuntimeError("router down")
+
+        strategy = _make_strategy(router=_BoomRouter())
+        await strategy.search("Who is Alice?")
+
+        assert called == {"relates", "discover", "expand", "chunks"}

--- a/graphrag_sdk/tests/test_path_router.py
+++ b/graphrag_sdk/tests/test_path_router.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.exceptions import LatencyBudgetExceededError
 from graphrag_sdk.retrieval.strategies import multi_path as mp_module
 from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval
@@ -18,7 +17,6 @@ from graphrag_sdk.retrieval.strategies.path_router import (
 )
 
 from .conftest import MockEmbedder, MockLLM
-
 
 # -- parse_paths / all_paths --
 

--- a/graphrag_sdk/tests/test_skills.py
+++ b/graphrag_sdk/tests/test_skills.py
@@ -1,0 +1,179 @@
+"""Tests for the skills library (Phase 3.4)."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import LLMResponse, SkillResult
+from graphrag_sdk.skills import (
+    SKILL_REGISTRY,
+    ContradictionDetectionSkill,
+    EntityComparisonSkill,
+    GapAnalysisSkill,
+    ImpactAnalysisSkill,
+    TimelineReconstructionSkill,
+    build_skill,
+)
+
+
+class FakeResult:
+    def __init__(self, rows: list[list[Any]]):
+        self.result_set = rows
+
+
+class FakeGraphStore:
+    """Routes Cypher queries to canned result sets by substring match."""
+
+    def __init__(self, *, query_map=None, neighbors=None, pagerank=None):
+        self._query_map = query_map or {}
+        self._neighbors = neighbors or {}
+        self._pagerank = pagerank or {}
+        self.queries: list[str] = []
+
+    async def query_raw(self, cypher: str, params: dict | None = None):
+        self.queries.append(cypher)
+        for needle, rows in self._query_map.items():
+            if needle in cypher:
+                return FakeResult(rows)
+        return FakeResult([])
+
+    async def weighted_neighbors(self, node_id: str, *, limit: int = 50):
+        return self._neighbors.get(node_id, [])
+
+    async def pagerank(self, **kwargs: Any):
+        return self._pagerank
+
+
+class FakeLLM:
+    def __init__(self, content: str):
+        self._content = content
+
+    async def ainvoke(self, prompt: str, **kwargs: Any) -> LLMResponse:
+        return LLMResponse(content=self._content)
+
+
+class TestRegistry:
+    def test_all_five_skills_registered(self):
+        assert set(SKILL_REGISTRY) == {
+            "entity_comparison",
+            "impact_analysis",
+            "contradiction_detection",
+            "gap_analysis",
+            "timeline_reconstruction",
+        }
+
+    def test_build_unknown_skill_raises(self):
+        with pytest.raises(KeyError):
+            build_skill("nope", FakeGraphStore())
+
+    def test_build_known_skill(self):
+        skill = build_skill("gap_analysis", FakeGraphStore())
+        assert isinstance(skill, GapAnalysisSkill)
+
+
+class TestEntityComparison:
+    async def test_compares_neighbors_and_attributes(self, ctx: Context):
+        store = FakeGraphStore(
+            query_map={
+                "properties(e)": [[{"name": "Alice", "role": "eng"}]],
+            },
+            neighbors={
+                "alice": [("acme", 1.0, "WORKS_AT"), ("bob", 1.0, "KNOWS")],
+                "carol": [("acme", 1.0, "WORKS_AT"), ("dan", 1.0, "KNOWS")],
+            },
+        )
+        skill = EntityComparisonSkill(store)
+        result = await skill.run(ctx, entity_a="alice", entity_b="carol")
+        assert isinstance(result, SkillResult)
+        assert "acme" in result.data["shared_neighbors"]
+        assert "bob" in result.data["neighbors_only_a"]
+        assert "dan" in result.data["neighbors_only_b"]
+
+    async def test_requires_both_entities(self, ctx: Context):
+        skill = EntityComparisonSkill(FakeGraphStore())
+        with pytest.raises(ValueError):
+            await skill.run(ctx, entity_a="alice")
+
+
+class TestImpactAnalysis:
+    async def test_ranks_impacted_by_distance(self, ctx: Context):
+        store = FakeGraphStore(
+            neighbors={
+                "root": [("near", 1.0, "R")],
+                "near": [("far", 1.0, "R")],
+            }
+        )
+        skill = ImpactAnalysisSkill(store)
+        result = await skill.run(ctx, entity="root", max_depth=3)
+        impacted = {r["entity"]: r["distance"] for r in result.data["impacted"]}
+        assert impacted.get("near") == 1
+        assert impacted.get("far") == 2
+
+    async def test_requires_entity(self, ctx: Context):
+        skill = ImpactAnalysisSkill(FakeGraphStore())
+        with pytest.raises(ValueError):
+            await skill.run(ctx)
+
+
+class TestContradictionDetection:
+    async def test_parses_llm_contradictions(self, ctx: Context):
+        store = FakeGraphStore(
+            query_map={
+                "-[r]-(m:__Entity__)": [["BORN_IN", "Paris", "born in Paris"],
+                                        ["BORN_IN", "London", "born in London"]],
+            }
+        )
+        llm = FakeLLM(
+            '{"contradictions": [{"a": "Paris", "b": "London", '
+            '"reason": "two birthplaces"}], "summary": "conflict found"}'
+        )
+        skill = ContradictionDetectionSkill(store, llm)
+        result = await skill.run(ctx, entity="person")
+        assert result.data["facts_examined"] == 2
+        assert result.data["contradictions"][0]["reason"] == "two birthplaces"
+        assert result.summary == "conflict found"
+
+    async def test_no_llm_returns_facts_only(self, ctx: Context):
+        store = FakeGraphStore(
+            query_map={"-[r]-(m:__Entity__)": [["KNOWS", "bob", ""]]}
+        )
+        skill = ContradictionDetectionSkill(store, None)
+        result = await skill.run(ctx, entity="alice")
+        assert result.data["contradictions"] == []
+        assert result.data["facts_examined"] == 1
+
+
+class TestGapAnalysis:
+    async def test_reports_isolated_and_sparse(self, ctx: Context):
+        store = FakeGraphStore(
+            query_map={
+                "NOT (e)-[]-(:__Entity__)": [["lonely1"], ["lonely2"]],
+                "count(*) AS n": [["Rare", 1], ["Common", 50]],
+            }
+        )
+        skill = GapAnalysisSkill(store)
+        result = await skill.run(ctx, min_instances=2)
+        assert result.data["num_isolated"] == 2
+        labels = {s["label"] for s in result.data["sparse_labels"]}
+        assert "Rare" in labels
+        assert "Common" not in labels
+
+
+class TestTimelineReconstruction:
+    async def test_orders_events_by_date(self, ctx: Context):
+        store = FakeGraphStore(
+            query_map={
+                "properties(e)": [
+                    ["e2", {"name": "Second", "date": "2020-05-01"}],
+                    ["e1", {"name": "First", "year": "1999"}],
+                    ["e3", {"name": "NoDate", "color": "red"}],
+                ],
+            }
+        )
+        skill = TimelineReconstructionSkill(store)
+        result = await skill.run(ctx)
+        order = [e["entity"] for e in result.data["timeline"]]
+        assert order == ["e1", "e2"]
+        assert result.data["num_events"] == 2


### PR DESCRIPTION
## Summary

Phase-3 work adding **agentic retrieval** on top of the existing MultiPath pipeline, plus supporting graph algorithms, a skills framework, an MCP server, and a new **agentic path router**.

Split into 10 focused commits (dependency-ordered; every commit is importable, exports are wired last).

## What's included

- **core models** — `AgentStep`, `AgentTrace`, `ScoredPath`, `SkillResult`.
- **storage** — `GraphStore.pagerank()` and `weighted_neighbors()`.
- **graph-walk** — `DynamicGraphWalk` (beam + bidirectional) and `GraphWalkRetrieval`.
- **agentic loop** — `AgenticRetrieval`, a ReAct loop where the LLM picks tools (`search`, `cypher`, `traverse`, + skills) via a guard-railed `ToolRegistry`.
- **skills** — `Skill` base + registry and 5 built-ins (entity_comparison, impact_analysis, contradiction_detection, gap_analysis, timeline_reconstruction).
- **api** — `GraphRAG.run_skill(name, **params)`.
- **mcp** — MCP server exposing retrieval + skills, `graphrag-mcp` console script, optional `[mcp]` extra.
- **path router** — opt-in agentic selection of which of MultiPath's 5 paths (`relates`, `entity_cypher`, `entity_fulltext`, `expansion`, `chunks`) to run per question. `LLMPathRouter` + `HeuristicPathRouter`, with all-paths fallback on empty/error/timeout so recall is never lost. Default behavior unchanged.
- **exports** — Phase-3 public API re-exported from `graphrag_sdk`.

## Testing

New unit tests: `test_graph_walk.py`, `test_agentic_retrieval.py`, `test_skills.py`, `test_mcp_tools.py`, `test_path_router.py`.

Full suite: **1083 passed, 29 skipped** (1 pre-existing, unrelated LiteLLM timing test failure; no provider code touched here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Model Context Protocol (MCP) support: `graphrag-mcp` CLI plus an MCP server with stdio and SSE transports.
  * Introduced agentic (ReAct-style) retrieval with a tool registry and stricter read-only Cypher handling.
  * Added graph-walk retrieval with weighted path scoring (beam and bidirectional search).
  * Implemented retrieval path routing and plan-driven MultiPathRetrieval stage gating.
  * Added skills framework, built-in skills, top-level `run_skill()` support, and expanded SDK exports.
* **Bug Fixes**
  * Added configurable non-negative result caps via updated result assembly (`max_*` limits).
* **Tests**
  * Added new test coverage for agentic retrieval, graph walk, MCP tools, path routing, and built-in skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->