### PR TITLE
feat(ingestion): agentic per-document strategy selection

### DIFF
--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -246,7 +246,7 @@ stats = await rag.finalize()
 
 ## Agentic Strategy Selection (`auto=True`)
 
-By default `ingest()` uses fixed strategies (see [Configuration Quick Reference](#configuration-quick-reference)). Pass `auto=True` to let a **planner** inspect a sample of each document and pick the chunker, entity-extraction backend, and resolver *per document* — the ingestion-side analogue of retrieval's path router.
+By default `ingest()` uses fixed strategies (see [Configuration Quick Reference](#configuration-quick-reference)). Pass `auto=True` to let a **planner** inspect a sample of each document and pick the chunker, entity-extraction backend, and resolver *per document* — the ingestion-side analogue of retrieval-side routing.
 
 ```python
 # LLM planner (default): one small call decides the strategies per document

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -244,6 +244,49 @@ stats = await rag.finalize()
 
 ---
 
+## Agentic Strategy Selection (`auto=True`)
+
+By default `ingest()` uses fixed strategies (see [Configuration Quick Reference](#configuration-quick-reference)). Pass `auto=True` to let a **planner** inspect a sample of each document and pick the chunker, entity-extraction backend, and resolver *per document* — the ingestion-side analogue of retrieval's path router.
+
+```python
+# LLM planner (default): one small call decides the strategies per document
+await rag.ingest(source="handbook.md", auto=True)
+
+# Zero-cost heuristic planner instead of an LLM call
+from graphrag_sdk import HeuristicIngestionPlanner
+await rag.ingest(source="handbook.md", auto=True, planner=HeuristicIngestionPlanner())
+
+# Explicit strategies always win — the planner only fills the rest
+await rag.ingest(source="handbook.md", auto=True, resolver=ExactMatchResolution())
+```
+
+**What the planner may pick:**
+
+| Component | Options |
+|-----------|---------|
+| Chunker | `sentence` (default), `fixed`, `structural`, `contextual` |
+| Extractor backend | `gliner` (default), `llm` |
+| Resolver | `exact` (default), `description_merge`, `semantic`, `llm_verified` |
+
+The planner may also tune parameters inside the chosen strategy (e.g. `max_tokens`, `threshold`); all values are coerced and clamped to safe ranges, so the model can never produce an unsafe config.
+
+**Safety guarantees:**
+
+- **Explicit wins** — any `chunker` / `extractor` / `resolver` you pass is kept as-is; the planner only fills the ones left unset.
+- **Never silently broken** — an empty/invalid plan or any planner error falls back to the default strategies (`sentence` / `gliner` / `exact`), reproducing today's behavior.
+- **Opt-in** — `auto=False` is the default; nothing changes unless you enable it.
+
+Two planners ship in the SDK:
+
+| Planner | Cost | How it decides |
+|---------|------|----------------|
+| `LLMIngestionPlanner` (default when `auto=True`) | One small LLM call per document | Guided prompt over a document sample |
+| `HeuristicIngestionPlanner` | Zero (no LLM call) | Cheap document features (structure cues, length) |
+
+**Code:** [`ingestion_planner.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py) · wired into `GraphRAG.ingest()` in [`api/main.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/api/main.py).
+
+---
+
 ## Configuration Quick Reference
 
 ### Chunking
@@ -286,6 +329,7 @@ stats = await rag.finalize()
 |------|-----------------|
 | [`pipeline.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/pipeline.py) | The 9-step pipeline orchestrator |
 | [`api/main.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/api/main.py) | `GraphRAG.ingest()` and `finalize()` — user-facing API |
+| [`ingestion_planner.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py) | Agentic strategy selection (`auto=True`) — LLM/heuristic planners |
 | [`loaders/text_loader.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/text_loader.py) | TextLoader implementation |
 | [`loaders/pdf_loader.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/pdf_loader.py) | PdfLoader implementation |
 | [`chunking_strategies/fixed_size.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/fixed_size.py) | FixedSizeChunking implementation |

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -275,6 +275,7 @@ The planner may also tune parameters inside the chosen strategy (e.g. `max_token
 - **Explicit wins** — any `chunker` / `extractor` / `resolver` you pass is kept as-is; the planner only fills the ones left unset.
 - **Never silently broken** — an empty/invalid plan or any planner error falls back to the default strategies (`sentence` / `gliner` / `exact`), reproducing today's behavior.
 - **Opt-in** — `auto=False` is the default; nothing changes unless you enable it.
+- **Bounded blast radius on malicious content** — the `LLMIngestionPlanner` prompt includes a sample of the document itself, so adversarial document content could in principle try to steer the planner's choice. The worst case is still just one of the known-safe strategy ids with clamped parameters (see `PARAM_SPECS`) — it can never select an arbitrary/unsafe strategy or an out-of-range parameter value.
 
 Two planners ship in the SDK:
 

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -98,6 +98,7 @@ from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
 from graphrag_sdk.ingestion.ingestion_planner import (
     HeuristicIngestionPlanner,
     IngestionPlan,
+    IngestionPlanner,
     LLMIngestionPlanner,
     build_ingestion_strategies,
 )
@@ -206,6 +207,7 @@ __all__ = [
     "SemanticResolution",
     "HeuristicIngestionPlanner",
     "IngestionPlan",
+    "IngestionPlanner",
     "LLMIngestionPlanner",
     "build_ingestion_strategies",
     # Retrieval

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -95,6 +95,12 @@ from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
 from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
     GraphExtraction,
 )
+from graphrag_sdk.ingestion.ingestion_planner import (
+    HeuristicIngestionPlanner,
+    IngestionPlan,
+    LLMIngestionPlanner,
+    build_ingestion_strategies,
+)
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
 from graphrag_sdk.ingestion.pipeline import IngestionPipeline
 from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
@@ -198,6 +204,10 @@ __all__ = [
     "ExactMatchResolution",
     "LLMVerifiedResolution",
     "SemanticResolution",
+    "HeuristicIngestionPlanner",
+    "IngestionPlan",
+    "LLMIngestionPlanner",
+    "build_ingestion_strategies",
     # Retrieval
     "CosineReranker",
     "MultiPathRetrieval",

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -1581,6 +1581,7 @@ class GraphRAG:
             chunker, extractor, resolver = await self._plan_ingestion_strategies(
                 text=text,
                 source=source,
+                loader=loader,
                 chunker=chunker,
                 extractor=extractor,
                 resolver=resolver,
@@ -1774,6 +1775,7 @@ class GraphRAG:
         *,
         text: str | None,
         source: str | None,
+        loader: LoaderStrategy | None = None,
         chunker: ChunkingStrategy | None,
         extractor: ExtractionStrategy | None,
         resolver: ResolutionStrategy | None,
@@ -1787,26 +1789,45 @@ class GraphRAG:
         """Run the ingestion planner and fill in unspecified strategies.
 
         Returns the (chunker, extractor, resolver) triple to use. Any slot the
-        caller passed explicitly is returned unchanged. Planner failures degrade
-        to leaving the slot as ``None`` (the pipeline then applies its own
-        defaults), so this never raises on a bad/slow planner.
+        caller passed explicitly is returned unchanged. A missing/invalid plan
+        or any planner/build failure degrades to leaving the slot as ``None``
+        (the pipeline then applies its own defaults), so this never raises on a
+        bad/slow planner.
         """
+        # In file mode the raw text isn't loaded yet, so give the planner a real
+        # content sample (best-effort) rather than only the file path — many
+        # documents' extensions carry no structural signal. A load failure just
+        # falls through to path-only planning.
+        sample_text = text
+        if sample_text is None and source is not None and loader is not None:
+            try:
+                loaded = await loader.load(source, ctx or Context())
+                sample_text = loaded.text
+            except LatencyBudgetExceededError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Planner content-sample load failed (%s); planning from path", exc)
+
         active = planner or LLMIngestionPlanner(self.llm)
         try:
-            plan = await active.plan(text, source=source, ctx=ctx)
+            plan = await active.plan(sample_text, source=source, ctx=ctx)
+            if plan is None:
+                raise ValueError("planner returned no plan")
+            entity_types = (
+                [e.label for e in self.ontology.entities] if self.ontology.entities else None
+            )
+            built_chunker, built_extractor, built_resolver = build_ingestion_strategies(
+                plan,
+                llm=self.llm,
+                embedder=self.embedder,
+                entity_types=entity_types,
+            )
         except LatencyBudgetExceededError:
             raise
         except Exception as exc:  # noqa: BLE001
             logger.debug("Ingestion planner failed (%s); using defaults", exc)
             return chunker, extractor, resolver
 
-        entity_types = [e.label for e in self.ontology.entities] if self.ontology.entities else None
-        built_chunker, built_extractor, built_resolver = build_ingestion_strategies(
-            plan,
-            llm=self.llm,
-            embedder=self.embedder,
-            entity_types=entity_types,
-        )
         return (
             chunker if chunker is not None else built_chunker,
             extractor if extractor is not None else built_extractor,
@@ -3169,6 +3190,8 @@ class GraphRAG:
         chunker: ChunkingStrategy | None = None,
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
+        auto: bool = False,
+        planner: Any | None = None,
         ctx: Context | None = None,
     ) -> IngestionResult: ...
 
@@ -3181,6 +3204,8 @@ class GraphRAG:
         chunker: ChunkingStrategy | None = None,
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
+        auto: bool = False,
+        planner: Any | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> list[IngestionResult | Exception]: ...
@@ -3195,6 +3220,8 @@ class GraphRAG:
         chunker: ChunkingStrategy | None = None,
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
+        auto: bool = False,
+        planner: Any | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> IngestionResult | list[IngestionResult | Exception]:
@@ -3211,6 +3238,8 @@ class GraphRAG:
                 chunker=chunker,
                 extractor=extractor,
                 resolver=resolver,
+                auto=auto,
+                planner=planner,
                 max_concurrency=max_concurrency,
                 ctx=ctx,
             )

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -29,6 +29,7 @@ from graphrag_sdk.core.models import (
     ChatMessage,
     DeleteDocumentResult,
     DocumentInfo,
+    DocumentOutput,
     Entity,
     FinalizeResult,
     GraphNode,
@@ -66,6 +67,7 @@ from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
     _coerce_attribute_value,
 )
 from graphrag_sdk.ingestion.ingestion_planner import (
+    IngestionPlanner,
     LLMIngestionPlanner,
     build_ingestion_strategies,
 )
@@ -1281,7 +1283,7 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         auto: bool = False,
-        planner: Any | None = None,
+        planner: IngestionPlanner | None = None,
         ctx: Context | None = None,
     ) -> IngestionResult: ...
 
@@ -1295,7 +1297,7 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         auto: bool = False,
-        planner: Any | None = None,
+        planner: IngestionPlanner | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> list[IngestionResult | Exception]: ...
@@ -1311,7 +1313,7 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         auto: bool = False,
-        planner: Any | None = None,
+        planner: IngestionPlanner | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> IngestionResult | list[IngestionResult | Exception]:
@@ -1346,7 +1348,7 @@ class GraphRAG:
         Agentic strategy selection (``auto=True``):
             When ``auto=True``, an ingestion planner inspects a sample of the
             document and picks the chunker, entity-extraction backend, and
-            resolver per document (mirroring retrieval's path router). It only
+            resolver per document (mirroring retrieval-side routing). It only
             fills in strategies you did *not* pass explicitly — an explicit
             ``chunker``/``extractor``/``resolver`` always wins. By default the
             planner is LLM-backed (one small call); pass a custom ``planner``
@@ -1507,7 +1509,7 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         auto: bool = False,
-        planner: Any | None = None,
+        planner: IngestionPlanner | None = None,
         ctx: Context | None = None,
         _skip_post: bool = False,
     ) -> IngestionResult:
@@ -1577,16 +1579,19 @@ class GraphRAG:
         # strategies the caller did not pass explicitly. Explicit overrides
         # always win; planner errors fall back to the per-strategy defaults
         # below (build via `or ...`), so behavior is never silently lost.
+        preloaded_document: DocumentOutput | None = None
         if auto and (chunker is None or extractor is None or resolver is None):
-            chunker, extractor, resolver = await self._plan_ingestion_strategies(
-                text=text,
-                source=source,
-                loader=loader,
-                chunker=chunker,
-                extractor=extractor,
-                resolver=resolver,
-                planner=planner,
-                ctx=ctx,
+            chunker, extractor, resolver, preloaded_document = (
+                await self._plan_ingestion_strategies(
+                    text=text,
+                    source=source,
+                    loader=loader,
+                    chunker=chunker,
+                    extractor=extractor,
+                    resolver=resolver,
+                    planner=planner,
+                    ctx=ctx,
+                )
             )
 
         pipeline = IngestionPipeline(
@@ -1599,7 +1604,15 @@ class GraphRAG:
             ontology=self._global_ontology,
         )
 
-        result = await pipeline.run(source, ctx, text=text, document_info=doc_info)
+        # Reuse the planner's file-mode content sample instead of loading the
+        # source a second time (the planner already loaded it in full to
+        # build that sample) — matters most for expensive loaders (PDFs).
+        if preloaded_document is not None and text is None:
+            result = await pipeline.run(
+                source, ctx, document_info=doc_info, preloaded_document=preloaded_document
+            )
+        else:
+            result = await pipeline.run(source, ctx, text=text, document_info=doc_info)
 
         if not _skip_post:
             # Post-ingestion: create indices only.
@@ -1622,7 +1635,7 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         auto: bool = False,
-        planner: Any | None = None,
+        planner: IngestionPlanner | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> list[IngestionResult | Exception]:
@@ -1779,30 +1792,40 @@ class GraphRAG:
         chunker: ChunkingStrategy | None,
         extractor: ExtractionStrategy | None,
         resolver: ResolutionStrategy | None,
-        planner: Any | None,
+        planner: IngestionPlanner | None,
         ctx: Context | None,
     ) -> tuple[
         ChunkingStrategy | None,
         ExtractionStrategy | None,
         ResolutionStrategy | None,
+        DocumentOutput | None,
     ]:
         """Run the ingestion planner and fill in unspecified strategies.
 
-        Returns the (chunker, extractor, resolver) triple to use. Any slot the
-        caller passed explicitly is returned unchanged. A missing/invalid plan
-        or any planner/build failure degrades to leaving the slot as ``None``
-        (the pipeline then applies its own defaults), so this never raises on a
-        bad/slow planner.
+        Returns the ``(chunker, extractor, resolver, preloaded_document)``
+        tuple to use. Any strategy slot the caller passed explicitly is
+        returned unchanged. A missing/invalid plan or any planner/build
+        failure degrades to leaving the slot as ``None`` (the pipeline then
+        applies its own defaults), so this never raises on a bad/slow planner.
+
+        ``preloaded_document`` is the full ``DocumentOutput`` this method
+        loaded (file mode only) to build the planner's content sample, if
+        any. The caller should pass it on to ``IngestionPipeline.run()`` as
+        ``preloaded_document=`` so the file is not loaded a second time.
         """
         # In file mode the raw text isn't loaded yet, so give the planner a real
         # content sample (best-effort) rather than only the file path — many
         # documents' extensions carry no structural signal. A load failure just
-        # falls through to path-only planning.
+        # falls through to path-only planning. The loaded document is returned
+        # to the caller so `_ingest_single` can reuse it instead of loading
+        # the source a second time via the pipeline.
         sample_text = text
+        preloaded_document: DocumentOutput | None = None
         if sample_text is None and source is not None and loader is not None:
             try:
                 loaded = await loader.load(source, ctx or Context())
                 sample_text = loaded.text
+                preloaded_document = loaded
             except LatencyBudgetExceededError:
                 raise
             except Exception as exc:  # noqa: BLE001
@@ -1826,12 +1849,13 @@ class GraphRAG:
             raise
         except Exception as exc:  # noqa: BLE001
             logger.debug("Ingestion planner failed (%s); using defaults", exc)
-            return chunker, extractor, resolver
+            return chunker, extractor, resolver, preloaded_document
 
         return (
             chunker if chunker is not None else built_chunker,
             extractor if extractor is not None else built_extractor,
             resolver if resolver is not None else built_resolver,
+            preloaded_document,
         )
 
     @staticmethod
@@ -3191,7 +3215,7 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         auto: bool = False,
-        planner: Any | None = None,
+        planner: IngestionPlanner | None = None,
         ctx: Context | None = None,
     ) -> IngestionResult: ...
 
@@ -3205,7 +3229,7 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         auto: bool = False,
-        planner: Any | None = None,
+        planner: IngestionPlanner | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> list[IngestionResult | Exception]: ...
@@ -3221,7 +3245,7 @@ class GraphRAG:
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
         auto: bool = False,
-        planner: Any | None = None,
+        planner: IngestionPlanner | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> IngestionResult | list[IngestionResult | Exception]:

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -1800,11 +1800,7 @@ class GraphRAG:
             logger.debug("Ingestion planner failed (%s); using defaults", exc)
             return chunker, extractor, resolver
 
-        entity_types = (
-            [e.label for e in self.ontology.entities]
-            if self.ontology.entities
-            else None
-        )
+        entity_types = [e.label for e in self.ontology.entities] if self.ontology.entities else None
         built_chunker, built_extractor, built_resolver = build_ingestion_strategies(
             plan,
             llm=self.llm,

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -65,6 +65,10 @@ from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
     GraphExtraction,
     _coerce_attribute_value,
 )
+from graphrag_sdk.ingestion.ingestion_planner import (
+    LLMIngestionPlanner,
+    build_ingestion_strategies,
+)
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
 from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
 from graphrag_sdk.ingestion.loaders.pdf_loader import PdfLoader
@@ -1276,6 +1280,8 @@ class GraphRAG:
         chunker: ChunkingStrategy | None = None,
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
+        auto: bool = False,
+        planner: Any | None = None,
         ctx: Context | None = None,
     ) -> IngestionResult: ...
 
@@ -1288,6 +1294,8 @@ class GraphRAG:
         chunker: ChunkingStrategy | None = None,
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
+        auto: bool = False,
+        planner: Any | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> list[IngestionResult | Exception]: ...
@@ -1302,6 +1310,8 @@ class GraphRAG:
         chunker: ChunkingStrategy | None = None,
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
+        auto: bool = False,
+        planner: Any | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> IngestionResult | list[IngestionResult | Exception]:
@@ -1333,6 +1343,17 @@ class GraphRAG:
         - Extractor: GraphExtraction with configured LLM
         - Resolver: ExactMatchResolution
 
+        Agentic strategy selection (``auto=True``):
+            When ``auto=True``, an ingestion planner inspects a sample of the
+            document and picks the chunker, entity-extraction backend, and
+            resolver per document (mirroring retrieval's path router). It only
+            fills in strategies you did *not* pass explicitly — an explicit
+            ``chunker``/``extractor``/``resolver`` always wins. By default the
+            planner is LLM-backed (one small call); pass a custom ``planner``
+            (e.g. ``HeuristicIngestionPlanner()``) for a zero-cost heuristic.
+            On an empty/invalid plan or planner error it falls back to the
+            defaults above, so behavior is never silently lost.
+
         Args:
             source: File path (or list of paths) — file mode only.
             text: Raw text — text mode only.
@@ -1345,6 +1366,11 @@ class GraphRAG:
             chunker: Custom chunking strategy.
             extractor: Custom extraction strategy.
             resolver: Custom resolution strategy.
+            auto: Enable agentic per-document strategy selection for any
+                strategy left unspecified.
+            planner: Optional planner instance (``LLMIngestionPlanner`` /
+                ``HeuristicIngestionPlanner``). Defaults to an LLM planner when
+                ``auto=True``. Ignored when ``auto=False``.
             max_concurrency: Max parallel ingestions (list source only).
             ctx: Execution context.
 
@@ -1401,6 +1427,8 @@ class GraphRAG:
                 chunker=chunker,
                 extractor=extractor,
                 resolver=resolver,
+                auto=auto,
+                planner=planner,
                 max_concurrency=max_concurrency,
                 ctx=ctx,
             )
@@ -1418,6 +1446,8 @@ class GraphRAG:
             chunker=chunker,
             extractor=extractor,
             resolver=resolver,
+            auto=auto,
+            planner=planner,
             ctx=ctx,
         )
 
@@ -1476,6 +1506,8 @@ class GraphRAG:
         chunker: ChunkingStrategy | None = None,
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
+        auto: bool = False,
+        planner: Any | None = None,
         ctx: Context | None = None,
         _skip_post: bool = False,
     ) -> IngestionResult:
@@ -1541,6 +1573,21 @@ class GraphRAG:
         # extraction work is done.
         await self._ensure_ontology_initialized()
 
+        # Agentic strategy selection: when auto=True, ask a planner to pick the
+        # strategies the caller did not pass explicitly. Explicit overrides
+        # always win; planner errors fall back to the per-strategy defaults
+        # below (build via `or ...`), so behavior is never silently lost.
+        if auto and (chunker is None or extractor is None or resolver is None):
+            chunker, extractor, resolver = await self._plan_ingestion_strategies(
+                text=text,
+                source=source,
+                chunker=chunker,
+                extractor=extractor,
+                resolver=resolver,
+                planner=planner,
+                ctx=ctx,
+            )
+
         pipeline = IngestionPipeline(
             loader=loader or TextLoader(),
             chunker=chunker or SentenceTokenCapChunking(),
@@ -1573,6 +1620,8 @@ class GraphRAG:
         chunker: ChunkingStrategy | None = None,
         extractor: ExtractionStrategy | None = None,
         resolver: ResolutionStrategy | None = None,
+        auto: bool = False,
+        planner: Any | None = None,
         max_concurrency: int = 3,
         ctx: Context | None = None,
     ) -> list[IngestionResult | Exception]:
@@ -1602,6 +1651,8 @@ class GraphRAG:
                         chunker=chunker,
                         extractor=extractor,
                         resolver=resolver,
+                        auto=auto,
+                        planner=planner,
                         ctx=parent_ctx.child(),
                         _skip_post=True,
                     )
@@ -1716,6 +1767,54 @@ class GraphRAG:
         return GraphExtraction(
             llm=self.llm,
             entity_types=entity_types,
+        )
+
+    async def _plan_ingestion_strategies(
+        self,
+        *,
+        text: str | None,
+        source: str | None,
+        chunker: ChunkingStrategy | None,
+        extractor: ExtractionStrategy | None,
+        resolver: ResolutionStrategy | None,
+        planner: Any | None,
+        ctx: Context | None,
+    ) -> tuple[
+        ChunkingStrategy | None,
+        ExtractionStrategy | None,
+        ResolutionStrategy | None,
+    ]:
+        """Run the ingestion planner and fill in unspecified strategies.
+
+        Returns the (chunker, extractor, resolver) triple to use. Any slot the
+        caller passed explicitly is returned unchanged. Planner failures degrade
+        to leaving the slot as ``None`` (the pipeline then applies its own
+        defaults), so this never raises on a bad/slow planner.
+        """
+        active = planner or LLMIngestionPlanner(self.llm)
+        try:
+            plan = await active.plan(text, source=source, ctx=ctx)
+        except LatencyBudgetExceededError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Ingestion planner failed (%s); using defaults", exc)
+            return chunker, extractor, resolver
+
+        entity_types = (
+            [e.label for e in self.ontology.entities]
+            if self.ontology.entities
+            else None
+        )
+        built_chunker, built_extractor, built_resolver = build_ingestion_strategies(
+            plan,
+            llm=self.llm,
+            embedder=self.embedder,
+            entity_types=entity_types,
+        )
+        return (
+            chunker if chunker is not None else built_chunker,
+            extractor if extractor is not None else built_extractor,
+            resolver if resolver is not None else built_resolver,
         )
 
     @staticmethod

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/__init__.py
@@ -4,6 +4,12 @@
 from graphrag_sdk.ingestion.chunking_strategies.base import ChunkingStrategy
 from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
 from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import GraphExtraction
+from graphrag_sdk.ingestion.ingestion_planner import (
+    HeuristicIngestionPlanner,
+    IngestionPlan,
+    LLMIngestionPlanner,
+    build_ingestion_strategies,
+)
 from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
 from graphrag_sdk.ingestion.pipeline import IngestionPipeline
 from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
@@ -12,7 +18,11 @@ __all__ = [
     "ChunkingStrategy",
     "ExtractionStrategy",
     "GraphExtraction",
+    "HeuristicIngestionPlanner",
+    "IngestionPlan",
     "IngestionPipeline",
+    "LLMIngestionPlanner",
     "LoaderStrategy",
     "ResolutionStrategy",
+    "build_ingestion_strategies",
 ]

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/__init__.py
@@ -7,6 +7,7 @@ from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import GraphE
 from graphrag_sdk.ingestion.ingestion_planner import (
     HeuristicIngestionPlanner,
     IngestionPlan,
+    IngestionPlanner,
     LLMIngestionPlanner,
     build_ingestion_strategies,
 )
@@ -21,6 +22,7 @@ __all__ = [
     "HeuristicIngestionPlanner",
     "IngestionPlan",
     "IngestionPipeline",
+    "IngestionPlanner",
     "LLMIngestionPlanner",
     "LoaderStrategy",
     "ResolutionStrategy",

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
@@ -8,9 +8,9 @@
 # plan is empty/invalid or the planner errors, so ingestion behavior is never
 # silently broken.
 #
-# This mirrors retrieval's PathRouter (graphrag_sdk/retrieval/strategies/
-# path_router.py): same "heuristic or one small LLM call, always safe-fallback"
-# shape, applied to the ingestion side of the pipeline.
+# This is analogous to retrieval-side routing: a small planner (heuristic or
+# LLM) chooses ingestion strategies per document, with safe defaults on
+# failure — applied here to the ingestion side of the pipeline.
 
 from __future__ import annotations
 
@@ -377,8 +377,8 @@ class LLMIngestionPlanner:
 
     Args:
         llm: provider exposing ``ainvoke(prompt, timeout=...)`` and returning
-            an object with a ``.content`` string (same interface the retrieval
-            PathRouter uses).
+            an object with a ``.content`` string (the common LLM interface
+            used across the SDK).
     """
 
     def __init__(self, llm: Any) -> None:

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
@@ -164,6 +164,41 @@ def clamp_params(component: str, strategy: str, raw: dict[str, Any] | None) -> d
     return out
 
 
+_GUIDE = (
+    "chunker — how the document is split:\n"
+    "  - sentence: sentence-aware, token-capped. Safe default for prose.\n"
+    "  - fixed: fixed-size character windows. Use for uniform/unstructured text.\n"
+    "  - structural: respect document structure (headings/lists/sections).\n"
+    "    Use for Markdown / HTML / clearly structured documents.\n"
+    "  - contextual: sentence chunks + an LLM-written context prefix per chunk.\n"
+    "    Best recall on dense/technical docs, but costs extra LLM calls.\n"
+    "extractor — how entities are found inside each chunk:\n"
+    "  - gliner: fast local NER model. Cheap default.\n"
+    "  - llm: LLM-based NER. Better on niche/ambiguous entities, costs more.\n"
+    "resolver — how duplicate entities are merged:\n"
+    "  - exact: merge by exact normalized name. Cheap default.\n"
+    "  - description_merge: also combine/summarize descriptions of merged nodes.\n"
+    "  - semantic: merge by embedding similarity (catches paraphrased names).\n"
+    "  - llm_verified: semantic candidates, then LLM confirms each merge.\n"
+    "\n"
+    "You MAY also tune parameters inside each chosen strategy (omit to keep the\n"
+    "safe default; out-of-range values are clamped):\n"
+    "  - sentence/structural/contextual: max_tokens (64-2048, def 512),\n"
+    "    overlap_sentences (0-10, def 2). Smaller chunks for dense facts;\n"
+    "    larger for narrative.\n"
+    "  - fixed: chunk_size (100-8000, def 1000), chunk_overlap (0-2000, def 100).\n"
+    "  - gliner/llm extractor: threshold (0.1-0.95, def 0.75). Lower = more\n"
+    "    recall/noise; higher = more precision.\n"
+    "  - description_merge: force_summary_threshold (1-50, def 3),\n"
+    "    max_summary_tokens (50-2000, def 500).\n"
+    "  - semantic: similarity_threshold (0.5-0.999, def 0.95),\n"
+    "    ann_top_k (5-200, def 50).\n"
+    "  - llm_verified: hard_threshold (0.5-0.999, def 0.95),\n"
+    "    soft_threshold (0.3-0.98, def 0.80, must stay below hard),\n"
+    "    ann_top_k (5-200, def 50), max_llm_pairs (10-5000, def 500).\n"
+)
+
+
 @dataclass(frozen=True)
 class IngestionPlan:
     """A validated decision about which ingestion strategies to use.
@@ -264,6 +299,107 @@ def parse_plan(text: str) -> IngestionPlan | None:
         extractor_params=params.get("extractor_params", {}),
         resolver_params=params.get("resolver_params", {}),
     )
+
+
+def _sample(text: str | None, source: str | None, limit: int = 1500) -> str:
+    """Build the document signal the planner reasons over.
+
+    Prefers a leading slice of the actual content; in file mode (no text yet)
+    falls back to the file name/extension so structural cues (``.md`` etc.)
+    are still available.
+    """
+    if text:
+        head = text[:limit]
+        suffix = " …[truncated]" if len(text) > limit else ""
+        return f"(source: {source or 'text'})\n{head}{suffix}"
+    return f"(file: {source or 'unknown'} — content not yet loaded)"
+
+
+class HeuristicIngestionPlanner:
+    """Zero-cost planner: picks strategies from cheap document features.
+
+    Useful when you want adaptive ingestion without an extra LLM call. Keeps to
+    the cheap, local options (never selects ``contextual``/``llm``/``semantic``
+    that would add cost) — it only upgrades the chunker when the document looks
+    structured.
+    """
+
+    async def plan(
+        self,
+        text: str | None,
+        *,
+        source: str | None = None,
+        ctx: Context | None = None,
+    ) -> IngestionPlan:
+        chunker = DEFAULT_CHUNKER
+        src = (source or "").lower()
+        looks_structured = src.endswith((".md", ".markdown", ".html", ".htm"))
+        if not looks_structured and text:
+            # Markdown-ish headings or list bullets in the body.
+            if re.search(r"(?m)^\s{0,3}#{1,6}\s|\n\s*[-*]\s+\S", text):
+                looks_structured = True
+        if looks_structured:
+            chunker = "structural"
+        return IngestionPlan(
+            chunker=chunker,
+            extractor=DEFAULT_EXTRACTOR,
+            resolver=DEFAULT_RESOLVER,
+            reason="heuristic",
+        )
+
+
+class LLMIngestionPlanner:
+    """LLM-backed planner: one small call selects the ingestion strategies.
+
+    Args:
+        llm: provider exposing ``ainvoke(prompt, timeout=...)`` and returning
+            an object with a ``.content`` string (same interface the retrieval
+            PathRouter uses).
+    """
+
+    def __init__(self, llm: Any) -> None:
+        self._llm = llm
+
+    async def plan(
+        self,
+        text: str | None,
+        *,
+        source: str | None = None,
+        ctx: Context | None = None,
+    ) -> IngestionPlan:
+        ctx = ctx or Context()
+        prompt = (
+            "You are an ingestion planner for a knowledge-graph RAG system. "
+            "Given a sample of a document, choose the best ingestion strategies "
+            "for building a graph from it. Prefer the cheap default unless the "
+            "document clearly benefits from a richer option.\n\n"
+            f"Options:\n{_GUIDE}\n"
+            "Respond with ONLY a JSON object of the form "
+            '{"chunker": "...", "extractor": "...", "resolver": "...", '
+            '"reason": "...", "chunker_params": {}, "extractor_params": {}, '
+            '"resolver_params": {}} and nothing else. Include a *_params object '
+            "only for parameters you want to change from the default.\n\n"
+            f"Document sample:\n{_sample(text, source)}\n\nJSON:"
+        )
+        try:
+            ctx.ensure_budget("ingestion planner LLM call")
+            response = await self._llm.ainvoke(
+                prompt,
+                timeout=ctx.provider_timeout_seconds("ingestion planner LLM call"),
+            )
+            plan = parse_plan(getattr(response, "content", "") or "")
+            if plan is not None:
+                ctx.log(
+                    f"IngestionPlanner: chunker={plan.chunker} "
+                    f"extractor={plan.extractor} resolver={plan.resolver}"
+                )
+                return plan
+            logger.debug("IngestionPlanner: empty/unparseable plan, using defaults")
+        except LatencyBudgetExceededError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("IngestionPlanner LLM call failed (%s); using defaults", exc)
+        return default_plan()
 
 
 def build_chunker(

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
@@ -18,7 +18,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.exceptions import LatencyBudgetExceededError
@@ -319,6 +319,24 @@ def _sample(text: str | None, source: str | None, limit: int = 1500) -> str:
         suffix = " …[truncated]" if len(text) > limit else ""
         return f"(source: {source or 'text'})\n{head}{suffix}"
     return f"(file: {source or 'unknown'} — content not yet loaded)"
+
+
+@runtime_checkable
+class IngestionPlanner(Protocol):
+    """The shape a custom ``planner=`` argument must implement.
+
+    ``HeuristicIngestionPlanner`` and ``LLMIngestionPlanner`` both satisfy
+    this protocol; documents the contract for anyone plugging in their own
+    planner without forcing a common base class.
+    """
+
+    async def plan(
+        self,
+        text: str | None,
+        *,
+        source: str | None = None,
+        ctx: Context | None = None,
+    ) -> IngestionPlan | None: ...
 
 
 class HeuristicIngestionPlanner:

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
@@ -1,0 +1,266 @@
+# GraphRAG SDK — Ingestion: Strategy Planner (agentic strategy selection)
+#
+# A lightweight planner that decides *which* ingestion strategies to use for a
+# given document — the chunker, the entity-extraction backend, and the entity
+# resolver — instead of always using the fixed defaults. One cheap LLM call (or
+# a heuristic) inspects a sample of the document and returns a plan; the
+# pipeline builds the chosen strategies. Falls back to the defaults whenever the
+# plan is empty/invalid or the planner errors, so ingestion behavior is never
+# silently broken.
+#
+# This mirrors retrieval's PathRouter (graphrag_sdk/retrieval/strategies/
+# path_router.py): same "heuristic or one small LLM call, always safe-fallback"
+# shape, applied to the ingestion side of the pipeline.
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.exceptions import LatencyBudgetExceededError
+from graphrag_sdk.ingestion.chunking_strategies.contextual_chunking import (
+    ContextualChunking,
+)
+from graphrag_sdk.ingestion.chunking_strategies.fixed_size import FixedSizeChunking
+from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
+    SentenceTokenCapChunking,
+)
+from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import (
+    StructuralChunking,
+)
+from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
+    GLiNERExtractor,
+    LLMExtractor,
+)
+from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
+    GraphExtraction,
+)
+from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
+from graphrag_sdk.ingestion.resolution_strategies.description_merge import (
+    DescriptionMergeResolution,
+)
+from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+    ExactMatchResolution,
+)
+from graphrag_sdk.ingestion.resolution_strategies.llm_verified_resolution import (
+    LLMVerifiedResolution,
+)
+from graphrag_sdk.ingestion.resolution_strategies.semantic_resolution import (
+    SemanticResolution,
+)
+
+logger = logging.getLogger(__name__)
+
+# ── The agent-selectable options ───────────────────────────────────────────
+# "callable" chunking is intentionally excluded: it wraps a user-supplied
+# function, which an LLM cannot synthesize. Everything else maps 1:1 to a
+# concrete strategy the builder can instantiate from just an llm/embedder.
+CHUNKERS: tuple[str, ...] = ("sentence", "fixed", "structural", "contextual")
+EXTRACTORS: tuple[str, ...] = ("gliner", "llm")
+RESOLVERS: tuple[str, ...] = ("exact", "description_merge", "semantic", "llm_verified")
+
+_CHUNKER_SET = frozenset(CHUNKERS)
+_EXTRACTOR_SET = frozenset(EXTRACTORS)
+_RESOLVER_SET = frozenset(RESOLVERS)
+
+# Defaults — kept in lock-step with GraphRAG.ingest()'s defaults so that a plan
+# that omits a field (or the whole planner falling back) reproduces today's
+# behavior exactly.
+DEFAULT_CHUNKER = "sentence"
+DEFAULT_EXTRACTOR = "gliner"
+DEFAULT_RESOLVER = "exact"
+
+# ── Tunable parameters per strategy ─────────────────────────────────────────
+# The agent may also pick the *values* inside the chosen strategy, not just the
+# strategy id. Each entry is (kind, lo, hi, default); values are coerced and
+# clamped to [lo, hi] before use, so the model can never produce an unsafe
+# config. A param the model omits is simply left to the constructor default.
+PARAM_SPECS: dict[str, dict[str, dict[str, tuple[str, float, float, float]]]] = {
+    "chunker": {
+        "sentence": {
+            "max_tokens": ("int", 64, 2048, 512),
+            "overlap_sentences": ("int", 0, 10, 2),
+        },
+        "structural": {
+            "max_tokens": ("int", 64, 2048, 512),
+            "overlap_sentences": ("int", 0, 10, 2),
+        },
+        "contextual": {
+            "max_tokens": ("int", 64, 2048, 512),
+            "overlap_sentences": ("int", 0, 10, 2),
+        },
+        "fixed": {
+            "chunk_size": ("int", 100, 8000, 1000),
+            "chunk_overlap": ("int", 0, 2000, 100),
+        },
+    },
+    "extractor": {
+        "gliner": {"threshold": ("float", 0.1, 0.95, 0.75)},
+        "llm": {"threshold": ("float", 0.1, 0.95, 0.75)},
+    },
+    "resolver": {
+        "exact": {},
+        "description_merge": {
+            "force_summary_threshold": ("int", 1, 50, 3),
+            "max_summary_tokens": ("int", 50, 2000, 500),
+        },
+        "semantic": {
+            "similarity_threshold": ("float", 0.5, 0.999, 0.95),
+            "ann_top_k": ("int", 5, 200, 50),
+            "force_summary_threshold": ("int", 1, 50, 3),
+            "max_summary_tokens": ("int", 50, 2000, 500),
+        },
+        "llm_verified": {
+            "hard_threshold": ("float", 0.5, 0.999, 0.95),
+            "soft_threshold": ("float", 0.3, 0.98, 0.80),
+            "ann_top_k": ("int", 5, 200, 50),
+            "max_llm_pairs": ("int", 10, 5000, 500),
+        },
+    },
+}
+
+
+def clamp_params(component: str, strategy: str, raw: dict[str, Any] | None) -> dict[str, Any]:
+    """Coerce + clamp a raw param dict against ``PARAM_SPECS``.
+
+    Only keys defined for ``(component, strategy)`` survive; each is coerced to
+    its declared kind and clamped to ``[lo, hi]``. Unparseable values are
+    dropped (the constructor default then applies). Cross-field constraints are
+    enforced so the resulting kwargs can never make a constructor raise:
+
+    - fixed chunker: ``chunk_overlap`` is forced below ``chunk_size``.
+    - llm_verified resolver: ``hard_threshold`` must stay above
+      ``soft_threshold``; if the pair inverts, both are dropped to defaults.
+    """
+    spec = PARAM_SPECS.get(component, {}).get(strategy, {})
+    if not spec or not isinstance(raw, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key, (kind, lo, hi, _default) in spec.items():
+        if key not in raw:
+            continue
+        try:
+            val: float = int(raw[key]) if kind == "int" else float(raw[key])
+        except (TypeError, ValueError):
+            continue
+        out[key] = max(lo, min(hi, val))
+        if kind == "int":
+            out[key] = int(out[key])
+
+    # Cross-field guards.
+    if strategy == "fixed" and "chunk_overlap" in out:
+        size = out.get("chunk_size", 1000)
+        if out["chunk_overlap"] >= size:
+            out["chunk_overlap"] = max(0, int(size) - 1)
+    if strategy == "llm_verified" and "hard_threshold" in out and "soft_threshold" in out:
+        if out["hard_threshold"] <= out["soft_threshold"]:
+            out.pop("hard_threshold", None)
+            out.pop("soft_threshold", None)
+    return out
+
+
+@dataclass(frozen=True)
+class IngestionPlan:
+    """A validated decision about which ingestion strategies to use.
+
+    Each field is one of the option ids above. ``reason`` is a short,
+    free-text rationale (from the LLM, or a heuristic tag) kept only for
+    logging/observability.
+    """
+
+    chunker: str = DEFAULT_CHUNKER
+    extractor: str = DEFAULT_EXTRACTOR
+    resolver: str = DEFAULT_RESOLVER
+    reason: str = ""
+    chunker_params: dict[str, Any] = field(default_factory=dict)
+    extractor_params: dict[str, Any] = field(default_factory=dict)
+    resolver_params: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.chunker not in _CHUNKER_SET:
+            raise ValueError(f"unknown chunker {self.chunker!r}")
+        if self.extractor not in _EXTRACTOR_SET:
+            raise ValueError(f"unknown extractor {self.extractor!r}")
+        if self.resolver not in _RESOLVER_SET:
+            raise ValueError(f"unknown resolver {self.resolver!r}")
+        # Clamp any supplied params to safe ranges so a hand- or LLM-built plan
+        # can never carry an out-of-range value into a constructor.
+        object.__setattr__(
+            self, "chunker_params", clamp_params("chunker", self.chunker, self.chunker_params)
+        )
+        object.__setattr__(
+            self,
+            "extractor_params",
+            clamp_params("extractor", self.extractor, self.extractor_params),
+        )
+        object.__setattr__(
+            self, "resolver_params", clamp_params("resolver", self.resolver, self.resolver_params)
+        )
+
+
+def default_plan() -> IngestionPlan:
+    """The plan that reproduces GraphRAG.ingest()'s default strategies."""
+    return IngestionPlan()
+
+
+def parse_plan(text: str) -> IngestionPlan | None:
+    """Parse a model response into a validated :class:`IngestionPlan`.
+
+    Accepts either a JSON object (``{"chunker": ..., "extractor": ...}``) or
+    loose ``key: value`` / ``key=value`` lines. Unknown or missing fields fall
+    back to the corresponding default, so a partial response still yields a
+    usable plan. Returns ``None`` only when nothing recognizable is found, in
+    which case the caller should use :func:`default_plan`.
+    """
+    raw = (text or "").strip()
+    if not raw:
+        return None
+
+    fields: dict[str, str] = {}
+    params: dict[str, dict[str, Any]] = {}
+
+    # First try strict JSON (possibly wrapped in ```json fences).
+    fenced = re.search(r"\{.*\}", raw, re.DOTALL)
+    if fenced:
+        try:
+            obj = json.loads(fenced.group(0))
+            if isinstance(obj, dict):
+                for k in ("chunker", "extractor", "resolver", "reason"):
+                    v = obj.get(k)
+                    if isinstance(v, str):
+                        fields[k] = v.strip().lower() if k != "reason" else v.strip()
+                for k in ("chunker_params", "extractor_params", "resolver_params"):
+                    v = obj.get(k)
+                    if isinstance(v, dict):
+                        params[k] = v
+        except (ValueError, TypeError):
+            pass
+
+    # Fall back to / augment with key:value scraping.
+    if not {"chunker", "extractor", "resolver"} & fields.keys():
+        for key in ("chunker", "extractor", "resolver"):
+            m = re.search(rf"\b{key}\b\s*[:=]\s*([a-z_]+)", raw, re.IGNORECASE)
+            if m:
+                fields[key] = m.group(1).strip().lower()
+
+    chunker = fields.get("chunker", "")
+    extractor = fields.get("extractor", "")
+    resolver = fields.get("resolver", "")
+
+    if not (chunker in _CHUNKER_SET or extractor in _EXTRACTOR_SET or resolver in _RESOLVER_SET):
+        return None
+
+    return IngestionPlan(
+        chunker=chunker if chunker in _CHUNKER_SET else DEFAULT_CHUNKER,
+        extractor=extractor if extractor in _EXTRACTOR_SET else DEFAULT_EXTRACTOR,
+        resolver=resolver if resolver in _RESOLVER_SET else DEFAULT_RESOLVER,
+        reason=fields.get("reason", ""),
+        chunker_params=params.get("chunker_params", {}),
+        extractor_params=params.get("extractor_params", {}),
+        resolver_params=params.get("resolver_params", {}),
+    )

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
@@ -198,7 +198,8 @@ _GUIDE = (
     "  - description_merge: force_summary_threshold (1-50, def 3),\n"
     "    max_summary_tokens (50-2000, def 500).\n"
     "  - semantic: similarity_threshold (0.5-0.999, def 0.95),\n"
-    "    ann_top_k (5-200, def 50).\n"
+    "    ann_top_k (5-200, def 50), force_summary_threshold (1-50, def 3),\n"
+    "    max_summary_tokens (50-2000, def 500).\n"
     "  - llm_verified: hard_threshold (0.5-0.999, def 0.95),\n"
     "    soft_threshold (0.3-0.98, def 0.80, must stay below hard),\n"
     "    ann_top_k (5-200, def 50), max_llm_pairs (10-5000, def 500).\n"
@@ -433,6 +434,10 @@ def build_chunker(
     params: dict[str, Any] | None = None,
 ) -> SentenceTokenCapChunking | FixedSizeChunking | StructuralChunking | ContextualChunking:
     """Instantiate the chunker named by an :class:`IngestionPlan`."""
+    # Re-clamping here is intentional/idempotent, not redundant: `params` may
+    # come straight from a caller-built IngestionPlan (already clamped in
+    # __post_init__) or from a hand-assembled dict passed directly to this
+    # builder function, which has not gone through that path.
     kw = clamp_params("chunker", name, params)
     if name == "fixed":
         return FixedSizeChunking(**kw)

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
@@ -274,7 +274,7 @@ def parse_plan(text: str) -> IngestionPlan | None:
                     if isinstance(v, dict):
                         params[k] = v
         except (ValueError, TypeError):
-            pass
+            logger.debug("Planner output was not valid JSON; falling back to key:value parsing")
 
     # Fall back to / augment with key:value scraping.
     if not {"chunker", "extractor", "resolver"} & fields.keys():

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
@@ -264,3 +264,79 @@ def parse_plan(text: str) -> IngestionPlan | None:
         extractor_params=params.get("extractor_params", {}),
         resolver_params=params.get("resolver_params", {}),
     )
+
+
+def build_chunker(
+    name: str,
+    *,
+    llm: Any | None = None,
+    params: dict[str, Any] | None = None,
+) -> SentenceTokenCapChunking | FixedSizeChunking | StructuralChunking | ContextualChunking:
+    """Instantiate the chunker named by an :class:`IngestionPlan`."""
+    kw = clamp_params("chunker", name, params)
+    if name == "fixed":
+        return FixedSizeChunking(**kw)
+    if name == "structural":
+        return StructuralChunking(**kw)
+    if name == "contextual":
+        if llm is None:
+            raise ValueError("contextual chunker requires an llm")
+        return ContextualChunking(llm=llm, **kw)
+    return SentenceTokenCapChunking(**kw)
+
+
+def build_extractor(
+    name: str,
+    *,
+    llm: Any,
+    entity_types: list[str] | None = None,
+    params: dict[str, Any] | None = None,
+) -> ExtractionStrategy:
+    """Instantiate a GraphExtraction with the named entity-extraction backend."""
+    kw = clamp_params("extractor", name, params)
+    entity_extractor = LLMExtractor(llm=llm, **kw) if name == "llm" else GLiNERExtractor(**kw)
+    return GraphExtraction(
+        llm=llm,
+        entity_extractor=entity_extractor,
+        entity_types=entity_types,
+    )
+
+
+def build_resolver(
+    name: str,
+    *,
+    llm: Any | None = None,
+    embedder: Any | None = None,
+    params: dict[str, Any] | None = None,
+) -> ResolutionStrategy:
+    """Instantiate the resolver named by an :class:`IngestionPlan`."""
+    kw = clamp_params("resolver", name, params)
+    if name == "description_merge":
+        return DescriptionMergeResolution(llm=llm, **kw)
+    if name == "semantic":
+        return SemanticResolution(llm=llm, embedder=embedder, **kw)
+    if name == "llm_verified":
+        return LLMVerifiedResolution(llm=llm, embedder=embedder, **kw)
+    return ExactMatchResolution()
+
+
+def build_ingestion_strategies(
+    plan: IngestionPlan,
+    *,
+    llm: Any,
+    embedder: Any | None = None,
+    entity_types: list[str] | None = None,
+) -> tuple[Any, ExtractionStrategy, ResolutionStrategy]:
+    """Build concrete ``(chunker, extractor, resolver)`` from a plan.
+
+    The planner only ever decides *which* strategy; this factory turns those
+    ids into instances wired with the caller's ``llm``/``embedder``. Kept
+    separate from the planner so the decision stays pure and testable.
+    """
+    return (
+        build_chunker(plan.chunker, llm=llm, params=plan.chunker_params),
+        build_extractor(
+            plan.extractor, llm=llm, entity_types=entity_types, params=plan.extractor_params
+        ),
+        build_resolver(plan.resolver, llm=llm, embedder=embedder, params=plan.resolver_params),
+    )

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/ingestion_planner.py
@@ -135,7 +135,8 @@ def clamp_params(component: str, strategy: str, raw: dict[str, Any] | None) -> d
 
     - fixed chunker: ``chunk_overlap`` is forced below ``chunk_size``.
     - llm_verified resolver: ``hard_threshold`` must stay above
-      ``soft_threshold``; if the pair inverts, both are dropped to defaults.
+      ``soft_threshold``; if the pair inverts (a lone key is checked against
+      the other's default), both are dropped to defaults.
     """
     spec = PARAM_SPECS.get(component, {}).get(strategy, {})
     if not spec or not isinstance(raw, dict):
@@ -157,8 +158,13 @@ def clamp_params(component: str, strategy: str, raw: dict[str, Any] | None) -> d
         size = out.get("chunk_size", 1000)
         if out["chunk_overlap"] >= size:
             out["chunk_overlap"] = max(0, int(size) - 1)
-    if strategy == "llm_verified" and "hard_threshold" in out and "soft_threshold" in out:
-        if out["hard_threshold"] <= out["soft_threshold"]:
+    if strategy == "llm_verified" and ("hard_threshold" in out or "soft_threshold" in out):
+        # A lone key is compared against the other's constructor default, so a
+        # planner-picked hard_threshold=0.6 (vs default soft 0.80) can't make
+        # the constructor raise and discard the whole plan.
+        hard = out.get("hard_threshold", spec["hard_threshold"][3])
+        soft = out.get("soft_threshold", spec["soft_threshold"][3])
+        if hard <= soft:
             out.pop("hard_threshold", None)
             out.pop("soft_threshold", None)
     return out

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/pipeline.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/pipeline.py
@@ -124,18 +124,25 @@ class IngestionPipeline:
         *,
         text: str | None = None,
         document_info: DocumentInfo | None = None,
+        preloaded_document: DocumentOutput | None = None,
     ) -> IngestionResult:
         """Execute the full ingestion pipeline.
 
-        Either ``source`` or ``text`` must be provided:
-        - If ``source`` is given, the loader reads from it.
+        Either ``source``, ``text``, or ``preloaded_document`` must be provided:
+        - If ``source`` is given (and neither of the below), the loader reads from it.
         - If ``text`` is given directly, the loader step is skipped.
+        - If ``preloaded_document`` is given, it is used as-is and the loader
+          step is skipped — for a caller that already loaded ``source`` for
+          another purpose (e.g. sampling a document for the ingestion planner)
+          and wants to avoid loading it a second time.
 
         Args:
             source: Path/URL to load (passed to loader).
             ctx: Execution context (created automatically if None).
             text: Optional raw text (skips loader if provided).
             document_info: Optional pre-built document metadata.
+            preloaded_document: Optional already-loaded ``DocumentOutput``
+                (text + elements + metadata). Takes precedence over ``text``.
 
         Returns:
             IngestionResult with statistics about the pipeline run.
@@ -147,7 +154,21 @@ class IngestionPipeline:
 
         try:
             # Step 1: Load
-            if text is not None:
+            if preloaded_document is not None:
+                document = preloaded_document
+                ctx.log("Using preloaded document (loader skipped)")
+                # Same document_info merge as the loader path below, so a
+                # caller-supplied uid/path/metadata still wins.
+                if document_info is not None:
+                    document.document_info = DocumentInfo(
+                        uid=document_info.uid or document.document_info.uid,
+                        path=document_info.path or document.document_info.path,
+                        metadata={
+                            **document.document_info.metadata,
+                            **document_info.metadata,
+                        },
+                    )
+            elif text is not None:
                 document = DocumentOutput(
                     text=text,
                     document_info=document_info or DocumentInfo(path=source),

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -251,6 +251,49 @@ class TestGraphRAGIngest:
         graphrag._vector_store.backfill_entity_embeddings.assert_not_awaited()
         assert "entities_backfilled" not in result.metadata
 
+    async def test_ingest_auto_true_plans_and_loads_source_once(
+        self, mock_conn, embedder, llm, tmp_path, monkeypatch
+    ):
+        """End-to-end wiring test for ``ingest(auto=True)`` on a real file.
+
+        Closes the review gap noted on PR #275: earlier tests only drove
+        ``_plan_ingestion_strategies`` in isolation via a stub; nothing
+        exercised the real ``ingest()`` path where the planner runs after
+        loader resolution + ontology init. This also guards the double-load
+        fix: the planner's content sample must be reused by the pipeline,
+        so the loader's ``load()`` should be invoked exactly once.
+        """
+        from graphrag_sdk.ingestion.ingestion_planner import IngestionPlan
+        from graphrag_sdk.ingestion.loaders.markdown_loader import MarkdownLoader
+
+        md_file = tmp_path / "doc.md"
+        md_file.write_text("# Title\n\nSome content for the agentic ingestion test.\n")
+
+        load_calls = {"count": 0}
+        original_load = MarkdownLoader.load
+
+        async def counting_load(self_loader, source, ctx):
+            load_calls["count"] += 1
+            return await original_load(self_loader, source, ctx)
+
+        monkeypatch.setattr(MarkdownLoader, "load", counting_load)
+
+        class FixedPlanner:
+            """Stub planner asserting it saw the real loaded content, not
+            just the file path, then picks known-safe strategies."""
+
+            async def plan(self, text, *, source=None, ctx=None):
+                assert text is not None
+                assert "agentic ingestion test" in text
+                return IngestionPlan(chunker="structural", extractor="llm", resolver="exact")
+
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder, embedding_dimension=8)
+
+        result = await g.ingest(str(md_file), auto=True, planner=FixedPlanner())
+
+        assert isinstance(result, IngestionResult)
+        assert load_calls["count"] == 1
+
 
 class TestGraphRAGDeduplicateEntities:
     async def test_deduplicate_entities_merges_duplicates(self, mock_conn, embedder, llm):

--- a/graphrag_sdk/tests/test_ingestion_planner.py
+++ b/graphrag_sdk/tests/test_ingestion_planner.py
@@ -310,8 +310,51 @@ class TestPlanIngestionStrategiesMerge:
         )
         assert result == (None, None, None)
 
+    async def test_none_plan_falls_back_to_defaults(self):
+        class NonePlanner:
+            async def plan(self, *a, **k):
+                return None
 
-class TestTunableParams:
+        rag = _fake_rag(MockLLM())
+        result = await GraphRAG._plan_ingestion_strategies(
+            rag,
+            text="hello",
+            source="x.txt",
+            chunker=None,
+            extractor=None,
+            resolver=None,
+            planner=NonePlanner(),
+            ctx=None,
+        )
+        assert result == (None, None, None)
+
+    async def test_file_mode_loads_content_sample_for_planner(self):
+        seen: dict[str, str | None] = {}
+
+        class RecordingPlanner:
+            async def plan(self, text, *, source=None, ctx=None):
+                seen["text"] = text
+                return IngestionPlan(chunker="fixed", extractor="gliner", resolver="exact")
+
+        class FakeLoader:
+            async def load(self, source, ctx):
+                return SimpleNamespace(text="LOADED CONTENT SAMPLE")
+
+        rag = _fake_rag(MockLLM())
+        await GraphRAG._plan_ingestion_strategies(
+            rag,
+            text=None,
+            source="x.pdf",
+            loader=FakeLoader(),
+            chunker=None,
+            extractor=None,
+            resolver=None,
+            planner=RecordingPlanner(),
+            ctx=None,
+        )
+        # File mode: the planner sees loaded content, not just the path.
+        assert seen["text"] == "LOADED CONTENT SAMPLE"
+
     def test_clamp_within_range(self):
         out = clamp_params("chunker", "sentence", {"max_tokens": 256, "overlap_sentences": 3})
         assert out == {"max_tokens": 256, "overlap_sentences": 3}

--- a/graphrag_sdk/tests/test_ingestion_planner.py
+++ b/graphrag_sdk/tests/test_ingestion_planner.py
@@ -1,0 +1,181 @@
+"""Tests for ingestion/ingestion_planner.py and GraphRAG.ingest(auto=...)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from graphrag_sdk.api.main import GraphRAG
+from graphrag_sdk.core.exceptions import LatencyBudgetExceededError
+from graphrag_sdk.ingestion.chunking_strategies.contextual_chunking import (
+    ContextualChunking,
+)
+from graphrag_sdk.ingestion.chunking_strategies.fixed_size import FixedSizeChunking
+from graphrag_sdk.ingestion.chunking_strategies.sentence_token_cap import (
+    SentenceTokenCapChunking,
+)
+from graphrag_sdk.ingestion.chunking_strategies.structural_chunking import (
+    StructuralChunking,
+)
+from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
+    GLiNERExtractor,
+    LLMExtractor,
+)
+from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
+    GraphExtraction,
+)
+from graphrag_sdk.ingestion.ingestion_planner import (
+    CHUNKERS,
+    EXTRACTORS,
+    RESOLVERS,
+    HeuristicIngestionPlanner,
+    IngestionPlan,
+    LLMIngestionPlanner,
+    build_chunker,
+    build_extractor,
+    build_ingestion_strategies,
+    build_resolver,
+    clamp_params,
+    default_plan,
+    parse_plan,
+)
+from graphrag_sdk.ingestion.resolution_strategies.description_merge import (
+    DescriptionMergeResolution,
+)
+from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+    ExactMatchResolution,
+)
+from graphrag_sdk.ingestion.resolution_strategies.llm_verified_resolution import (
+    LLMVerifiedResolution,
+)
+from graphrag_sdk.ingestion.resolution_strategies.semantic_resolution import (
+    SemanticResolution,
+)
+
+from .conftest import MockEmbedder, MockLLM
+
+# -- IngestionPlan --
+
+
+class TestIngestionPlan:
+    def test_default_plan_uses_cheap_defaults(self):
+        plan = default_plan()
+        assert (plan.chunker, plan.extractor, plan.resolver) == (
+            "sentence",
+            "gliner",
+            "exact",
+        )
+
+    def test_rejects_unknown_option(self):
+        with pytest.raises(ValueError):
+            IngestionPlan(chunker="bogus")
+        with pytest.raises(ValueError):
+            IngestionPlan(extractor="bogus")
+        with pytest.raises(ValueError):
+            IngestionPlan(resolver="bogus")
+
+    def test_option_sets_are_expected(self):
+        assert set(CHUNKERS) == {"sentence", "fixed", "structural", "contextual"}
+        assert set(EXTRACTORS) == {"gliner", "llm"}
+        assert set(RESOLVERS) == {
+            "exact",
+            "description_merge",
+            "semantic",
+            "llm_verified",
+        }
+
+
+# -- parse_plan --
+class TestParsePlan:
+    def test_parses_json(self):
+        plan = parse_plan(
+            '{"chunker":"structural","extractor":"llm","resolver":"semantic","reason":"markdown"}'
+        )
+        assert plan == IngestionPlan("structural", "llm", "semantic", "markdown")
+
+    def test_parses_fenced_json(self):
+        plan = parse_plan('```json\n{"chunker": "fixed"}\n```')
+        assert plan is not None
+        assert plan.chunker == "fixed"
+        assert plan.extractor == "gliner"  # default-filled
+
+    def test_parses_key_value(self):
+        plan = parse_plan("chunker: contextual\nextractor = gliner\nresolver: exact")
+        assert plan == IngestionPlan("contextual", "gliner", "exact")
+
+    def test_partial_fills_defaults(self):
+        plan = parse_plan('{"resolver":"llm_verified"}')
+        assert plan == IngestionPlan("sentence", "gliner", "llm_verified")
+
+    def test_unknown_values_drop_to_default(self):
+        plan = parse_plan('{"chunker":"nope","extractor":"llm"}')
+        assert plan is not None
+        assert plan.chunker == "sentence"
+        assert plan.extractor == "llm"
+
+    def test_garbage_returns_none(self):
+        assert parse_plan("hello world") is None
+        assert parse_plan("") is None
+        assert parse_plan("   ") is None
+
+
+# -- HeuristicIngestionPlanner --
+class TestTunableParams:
+    def test_clamp_within_range(self):
+        out = clamp_params("chunker", "sentence", {"max_tokens": 256, "overlap_sentences": 3})
+        assert out == {"max_tokens": 256, "overlap_sentences": 3}
+
+    def test_clamp_out_of_range(self):
+        out = clamp_params("chunker", "sentence", {"max_tokens": 999999, "overlap_sentences": -5})
+        assert out["max_tokens"] == 2048
+        assert out["overlap_sentences"] == 0
+
+    def test_clamp_drops_unknown_and_unparseable(self):
+        out = clamp_params("extractor", "gliner", {"threshold": "high", "bogus": 1})
+        assert out == {}
+
+    def test_clamp_unknown_strategy(self):
+        assert clamp_params("chunker", "nope", {"max_tokens": 100}) == {}
+
+    def test_fixed_overlap_forced_below_size(self):
+        out = clamp_params("chunker", "fixed", {"chunk_size": 200, "chunk_overlap": 500})
+        assert out["chunk_overlap"] < out["chunk_size"]
+
+    def test_llm_verified_inverted_thresholds_dropped(self):
+        out = clamp_params(
+            "resolver", "llm_verified", {"hard_threshold": 0.6, "soft_threshold": 0.9}
+        )
+        assert "hard_threshold" not in out and "soft_threshold" not in out
+
+    def test_plan_clamps_params(self):
+        plan = IngestionPlan(chunker="sentence", chunker_params={"max_tokens": 100000})
+        assert plan.chunker_params == {"max_tokens": 2048}
+
+    def test_parse_plan_reads_params(self):
+        plan = parse_plan(
+            '{"chunker":"fixed","chunker_params":{"chunk_size":1500,"chunk_overlap":150}}'
+        )
+        assert plan is not None
+        assert plan.chunker == "fixed"
+        assert plan.chunker_params == {"chunk_size": 1500, "chunk_overlap": 150}
+
+    def test_build_chunker_applies_params(self):
+        c = build_chunker("sentence", params={"max_tokens": 256, "overlap_sentences": 1})
+        assert c.max_tokens == 256
+        assert c.overlap_sentences == 1
+
+    def test_build_extractor_applies_threshold(self):
+        ext = build_extractor("gliner", llm=MockLLM(), params={"threshold": 0.4})
+        assert ext.entity_extractor._threshold == 0.4
+
+    def test_build_resolver_applies_params(self):
+        r = build_resolver(
+            "semantic",
+            llm=MockLLM(),
+            embedder=MockEmbedder(),
+            params={"similarity_threshold": 0.88, "ann_top_k": 25},
+        )
+        assert isinstance(r, SemanticResolution)
+        assert r.similarity_threshold == 0.88
+        assert r.ann_top_k == 25

--- a/graphrag_sdk/tests/test_ingestion_planner.py
+++ b/graphrag_sdk/tests/test_ingestion_planner.py
@@ -87,6 +87,8 @@ class TestIngestionPlan:
 
 
 # -- parse_plan --
+
+
 class TestParsePlan:
     def test_parses_json(self):
         plan = parse_plan(
@@ -121,6 +123,194 @@ class TestParsePlan:
 
 
 # -- HeuristicIngestionPlanner --
+
+
+class TestHeuristicPlanner:
+    async def test_markdown_source_picks_structural(self):
+        plan = await HeuristicIngestionPlanner().plan("anything", source="notes.md")
+        assert plan.chunker == "structural"
+
+    async def test_markdown_body_picks_structural(self):
+        plan = await HeuristicIngestionPlanner().plan(
+            "# Heading\n\n- bullet one\n- bullet two", source="x.txt"
+        )
+        assert plan.chunker == "structural"
+
+    async def test_plain_prose_picks_sentence(self):
+        plan = await HeuristicIngestionPlanner().plan(
+            "Just a paragraph of ordinary prose with no structure at all.",
+            source="x.txt",
+        )
+        assert plan.chunker == "sentence"
+
+    async def test_never_upgrades_cost_options(self):
+        plan = await HeuristicIngestionPlanner().plan("# H", source="x.md")
+        assert plan.extractor == "gliner"
+        assert plan.resolver == "exact"
+
+
+# -- LLMIngestionPlanner --
+
+
+class TestLLMPlanner:
+    async def test_returns_parsed_plan(self):
+        llm = MockLLM(responses=['{"chunker":"fixed","extractor":"llm","resolver":"semantic"}'])
+        plan = await LLMIngestionPlanner(llm).plan("some text", source="x.txt")
+        assert plan == IngestionPlan("fixed", "llm", "semantic")
+
+    async def test_empty_response_falls_back_to_default(self):
+        plan = await LLMIngestionPlanner(MockLLM(responses=[""])).plan("t")
+        assert plan == default_plan()
+
+    async def test_unparseable_response_falls_back_to_default(self):
+        plan = await LLMIngestionPlanner(MockLLM(responses=["I think markdown"])).plan("t")
+        assert plan == default_plan()
+
+    async def test_llm_error_falls_back_to_default(self):
+        class BoomLLM:
+            async def ainvoke(self, *a, **k):
+                raise RuntimeError("boom")
+
+        plan = await LLMIngestionPlanner(BoomLLM()).plan("t")
+        assert plan == default_plan()
+
+    async def test_budget_error_propagates(self):
+        class BudgetLLM:
+            async def ainvoke(self, *a, **k):
+                raise LatencyBudgetExceededError("over budget")
+
+        with pytest.raises(LatencyBudgetExceededError):
+            await LLMIngestionPlanner(BudgetLLM()).plan("t")
+
+
+# -- builders --
+
+
+class TestBuilders:
+    def test_build_chunker_variants(self):
+        llm = MockLLM()
+        assert isinstance(build_chunker("sentence"), SentenceTokenCapChunking)
+        assert isinstance(build_chunker("fixed"), FixedSizeChunking)
+        assert isinstance(build_chunker("structural"), StructuralChunking)
+        assert isinstance(build_chunker("contextual", llm=llm), ContextualChunking)
+
+    def test_contextual_chunker_requires_llm(self):
+        with pytest.raises(ValueError):
+            build_chunker("contextual")
+
+    def test_build_extractor_backends(self):
+        llm = MockLLM()
+        gliner = build_extractor("gliner", llm=llm)
+        llm_ext = build_extractor("llm", llm=llm)
+        assert isinstance(gliner, GraphExtraction)
+        assert isinstance(gliner.entity_extractor, GLiNERExtractor)
+        assert isinstance(llm_ext.entity_extractor, LLMExtractor)
+
+    def test_build_resolver_variants(self):
+        llm = MockLLM()
+        emb = MockEmbedder()
+        assert isinstance(build_resolver("exact"), ExactMatchResolution)
+        assert isinstance(build_resolver("description_merge", llm=llm), DescriptionMergeResolution)
+        assert isinstance(build_resolver("semantic", llm=llm, embedder=emb), SemanticResolution)
+        assert isinstance(
+            build_resolver("llm_verified", llm=llm, embedder=emb), LLMVerifiedResolution
+        )
+
+    def test_build_ingestion_strategies_triple(self):
+        chunker, extractor, resolver = build_ingestion_strategies(
+            IngestionPlan("structural", "llm", "semantic"),
+            llm=MockLLM(),
+            embedder=MockEmbedder(),
+            entity_types=["Person"],
+        )
+        assert isinstance(chunker, StructuralChunking)
+        assert isinstance(extractor, GraphExtraction)
+        assert isinstance(resolver, SemanticResolution)
+
+
+# -- GraphRAG._plan_ingestion_strategies merge logic --
+#
+# The method only touches self.llm / self.embedder / self.ontology, so a light
+# stub stands in for a full GraphRAG instance.
+
+
+def _fake_rag(llm, *, entities=None):
+    return SimpleNamespace(
+        llm=llm,
+        embedder=MockEmbedder(),
+        ontology=SimpleNamespace(entities=entities or []),
+    )
+
+
+class TestPlanIngestionStrategiesMerge:
+    async def test_fills_all_when_none_passed(self):
+        llm = MockLLM(responses=['{"chunker":"fixed","extractor":"llm","resolver":"exact"}'])
+        rag = _fake_rag(llm)
+        chunker, extractor, resolver = await GraphRAG._plan_ingestion_strategies(
+            rag,
+            text="hello",
+            source="x.txt",
+            chunker=None,
+            extractor=None,
+            resolver=None,
+            planner=None,
+            ctx=None,
+        )
+        assert isinstance(chunker, FixedSizeChunking)
+        assert isinstance(extractor, GraphExtraction)
+        assert isinstance(resolver, ExactMatchResolution)
+
+    async def test_explicit_override_wins(self):
+        llm = MockLLM(responses=['{"chunker":"fixed","extractor":"llm","resolver":"semantic"}'])
+        rag = _fake_rag(llm)
+        explicit_chunker = SentenceTokenCapChunking()
+        chunker, extractor, resolver = await GraphRAG._plan_ingestion_strategies(
+            rag,
+            text="hello",
+            source="x.txt",
+            chunker=explicit_chunker,
+            extractor=None,
+            resolver=None,
+            planner=None,
+            ctx=None,
+        )
+        # Caller's chunker is preserved; only the unset slots come from the plan.
+        assert chunker is explicit_chunker
+        assert isinstance(resolver, SemanticResolution)
+
+    async def test_custom_heuristic_planner_used(self):
+        rag = _fake_rag(MockLLM())
+        chunker, _, _ = await GraphRAG._plan_ingestion_strategies(
+            rag,
+            text="# Title\n- a\n- b",
+            source="notes.md",
+            chunker=None,
+            extractor=None,
+            resolver=None,
+            planner=HeuristicIngestionPlanner(),
+            ctx=None,
+        )
+        assert isinstance(chunker, StructuralChunking)
+
+    async def test_planner_failure_leaves_slots_none(self):
+        class BoomPlanner:
+            async def plan(self, *a, **k):
+                raise RuntimeError("boom")
+
+        rag = _fake_rag(MockLLM())
+        result = await GraphRAG._plan_ingestion_strategies(
+            rag,
+            text="hello",
+            source="x.txt",
+            chunker=None,
+            extractor=None,
+            resolver=None,
+            planner=BoomPlanner(),
+            ctx=None,
+        )
+        assert result == (None, None, None)
+
+
 class TestTunableParams:
     def test_clamp_within_range(self):
         out = clamp_params("chunker", "sentence", {"max_tokens": 256, "overlap_sentences": 3})

--- a/graphrag_sdk/tests/test_ingestion_planner.py
+++ b/graphrag_sdk/tests/test_ingestion_planner.py
@@ -381,6 +381,20 @@ class TestPlanIngestionStrategiesMerge:
         )
         assert "hard_threshold" not in out and "soft_threshold" not in out
 
+    def test_llm_verified_lone_hard_below_default_soft_dropped(self):
+        # hard=0.6 vs constructor default soft=0.80 would make the resolver raise.
+        out = clamp_params("resolver", "llm_verified", {"hard_threshold": 0.6})
+        assert "hard_threshold" not in out
+
+    def test_llm_verified_lone_soft_above_default_hard_dropped(self):
+        # soft=0.97 vs constructor default hard=0.95 would make the resolver raise.
+        out = clamp_params("resolver", "llm_verified", {"soft_threshold": 0.97})
+        assert "soft_threshold" not in out
+
+    def test_llm_verified_lone_valid_threshold_kept(self):
+        out = clamp_params("resolver", "llm_verified", {"hard_threshold": 0.9})
+        assert out == {"hard_threshold": 0.9}
+
     def test_plan_clamps_params(self):
         plan = IngestionPlan(chunker="sentence", chunker_params={"max_tokens": 100000})
         assert plan.chunker_params == {"max_tokens": 2048}

--- a/graphrag_sdk/tests/test_ingestion_planner.py
+++ b/graphrag_sdk/tests/test_ingestion_planner.py
@@ -246,33 +246,39 @@ class TestPlanIngestionStrategiesMerge:
     async def test_fills_all_when_none_passed(self):
         llm = MockLLM(responses=['{"chunker":"fixed","extractor":"llm","resolver":"exact"}'])
         rag = _fake_rag(llm)
-        chunker, extractor, resolver = await GraphRAG._plan_ingestion_strategies(
-            rag,
-            text="hello",
-            source="x.txt",
-            chunker=None,
-            extractor=None,
-            resolver=None,
-            planner=None,
-            ctx=None,
+        chunker, extractor, resolver, preloaded_document = (
+            await GraphRAG._plan_ingestion_strategies(
+                rag,
+                text="hello",
+                source="x.txt",
+                chunker=None,
+                extractor=None,
+                resolver=None,
+                planner=None,
+                ctx=None,
+            )
         )
         assert isinstance(chunker, FixedSizeChunking)
         assert isinstance(extractor, GraphExtraction)
         assert isinstance(resolver, ExactMatchResolution)
+        # text mode: no file was loaded, so there's nothing to preload for reuse.
+        assert preloaded_document is None
 
     async def test_explicit_override_wins(self):
         llm = MockLLM(responses=['{"chunker":"fixed","extractor":"llm","resolver":"semantic"}'])
         rag = _fake_rag(llm)
         explicit_chunker = SentenceTokenCapChunking()
-        chunker, extractor, resolver = await GraphRAG._plan_ingestion_strategies(
-            rag,
-            text="hello",
-            source="x.txt",
-            chunker=explicit_chunker,
-            extractor=None,
-            resolver=None,
-            planner=None,
-            ctx=None,
+        chunker, extractor, resolver, _preloaded_document = (
+            await GraphRAG._plan_ingestion_strategies(
+                rag,
+                text="hello",
+                source="x.txt",
+                chunker=explicit_chunker,
+                extractor=None,
+                resolver=None,
+                planner=None,
+                ctx=None,
+            )
         )
         # Caller's chunker is preserved; only the unset slots come from the plan.
         assert chunker is explicit_chunker
@@ -280,7 +286,7 @@ class TestPlanIngestionStrategiesMerge:
 
     async def test_custom_heuristic_planner_used(self):
         rag = _fake_rag(MockLLM())
-        chunker, _, _ = await GraphRAG._plan_ingestion_strategies(
+        chunker, _, _, _ = await GraphRAG._plan_ingestion_strategies(
             rag,
             text="# Title\n- a\n- b",
             source="notes.md",
@@ -308,7 +314,7 @@ class TestPlanIngestionStrategiesMerge:
             planner=BoomPlanner(),
             ctx=None,
         )
-        assert result == (None, None, None)
+        assert result == (None, None, None, None)
 
     async def test_none_plan_falls_back_to_defaults(self):
         class NonePlanner:
@@ -326,7 +332,7 @@ class TestPlanIngestionStrategiesMerge:
             planner=NonePlanner(),
             ctx=None,
         )
-        assert result == (None, None, None)
+        assert result == (None, None, None, None)
 
     async def test_file_mode_loads_content_sample_for_planner(self):
         seen: dict[str, str | None] = {}
@@ -341,19 +347,25 @@ class TestPlanIngestionStrategiesMerge:
                 return SimpleNamespace(text="LOADED CONTENT SAMPLE")
 
         rag = _fake_rag(MockLLM())
-        await GraphRAG._plan_ingestion_strategies(
-            rag,
-            text=None,
-            source="x.pdf",
-            loader=FakeLoader(),
-            chunker=None,
-            extractor=None,
-            resolver=None,
-            planner=RecordingPlanner(),
-            ctx=None,
+        _chunker, _extractor, _resolver, preloaded_document = (
+            await GraphRAG._plan_ingestion_strategies(
+                rag,
+                text=None,
+                source="x.pdf",
+                loader=FakeLoader(),
+                chunker=None,
+                extractor=None,
+                resolver=None,
+                planner=RecordingPlanner(),
+                ctx=None,
+            )
         )
         # File mode: the planner sees loaded content, not just the path.
         assert seen["text"] == "LOADED CONTENT SAMPLE"
+        # The full loaded document is returned too, so the caller (ingest())
+        # can reuse it instead of loading the source a second time.
+        assert preloaded_document is not None
+        assert preloaded_document.text == "LOADED CONTENT SAMPLE"
 
     def test_clamp_within_range(self):
         out = clamp_params("chunker", "sentence", {"max_tokens": 256, "overlap_sentences": 3})


### PR DESCRIPTION
## What

Adds **agentic ingestion strategy selection** to `GraphRAG.ingest(...)`, mirroring the retrieval-side `PathRouter`. When `auto=True`, a planner inspects a sample of each document and picks the **chunker**, **entity-extraction backend**, and **resolver** per document — filling in only the strategies the caller did *not* pass explicitly.

## Design

- Explicit `chunker` / `extractor` / `resolver` always win.
- On an empty/invalid plan or any planner error, it falls back to today's defaults (`sentence` / `gliner` / `exact`), so behavior is never silently lost.
- Two planners:
  - `LLMIngestionPlanner` (default) — one small guided LLM call.
  - `HeuristicIngestionPlanner` — zero-cost, feature-based.
- The planner may also tune parameters inside each strategy; all values are coerced and clamped to safe ranges (`PARAM_SPECS`), so the model can never produce an unsafe config.

## Usage

```python
# LLM planner picks strategies per document
await rag.ingest(source="doc.md", auto=True)

# zero-cost heuristic instead
from graphrag_sdk import HeuristicIngestionPlanner
await rag.ingest(source="doc.md", auto=True, planner=HeuristicIngestionPlanner())

# explicit strategy still wins; planner fills the rest
await rag.ingest(source="doc.md", auto=True, resolver=ExactMatchResolution())
```

## Commits

1. `IngestionPlan` schema + param clamping
2. Strategy builders
3. Heuristic + LLM planners
4. Package exports
5. `auto=`/`planner=` wiring in `GraphRAG.ingest`
6. Tests: schema, parsing, tunable params
7. Tests: planners, builders, `ingest(auto=)` merge

## Tests

`38 passed` — `tests/test_ingestion_planner.py`. Ruff clean on all changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic, per-document ingestion strategy selection during ingestion.
  * Exposed new ingestion-planning options at the top-level SDK for easier access.
  * Added support for choosing chunking, extraction, and resolution strategies based on document content or planner output.

* **Bug Fixes**
  * Improved fallback behavior so ingestion continues with default strategies when planning cannot be completed.
  * Added validation and safe parameter clamping for supported ingestion strategy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->