### PR TITLE
feat(resolution): IncrementalResolution — graph-aware entity linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`IncrementalResolution` — graph-aware entity resolution, now the default (#277, #278).**
+  Resolves each document's entities against the entities already in the graph, so a
+  mention can be linked onto an entity extracted from an earlier document. Fixes the
+  same-name / different-type homograph gap (e.g. "GraphRAG" extracted as both a
+  `Concept` and a `Technology`) by merging on description similarity, and links variant
+  names onto existing entities via a single LLM call per ambiguous group while keeping
+  genuine look-alikes apart. The `GraphRAG` facade uses it by default when an LLM and
+  embedder are configured; otherwise it falls back to the LLM-free
+  `ExactMatchResolution`. Note: the default now adds LLM + embedding calls during
+  ingestion — pass `resolver=ExactMatchResolution()` for LLM-free ingestion.
+
 ## [1.3.0] - 2026-06-04
 
 Ontology discovery (#271): bootstrap an ontology straight from a

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -158,7 +158,7 @@ For a detailed explanation of the extraction process, see [extraction.md](extrac
 **Default: IncrementalResolution** *(when an LLM and embedder are configured)*
 - Resolves each document's entities **against the entities already in the graph**, so a mention can be linked onto an entity extracted from an earlier document — the cross-document case batch resolvers can't see
 - Merges same-name / different-type duplicates for free by description similarity (e.g. "GraphRAG" extracted once as a `Concept` and once as a `Technology`), which closes a common homograph gap
-- Uses one LLM call per ambiguous group to link variant names onto existing entities while keeping genuine look-alikes apart (e.g. `FALKORDB_USERNAME` ≠ `FALKORDB_PASSWORD`)
+- Uses one LLM call per ambiguous group to link candidate names onto existing entities while keeping genuine look-alikes apart (e.g. `FALKORDB_USERNAME` ≠ `FALKORDB_PASSWORD`). The default candidate lookup is name-based (case/separator-folded, and catches many tokenization variants); for guaranteed variant/semantic linking use a custom `candidate_retriever` — see [strategies.md](strategies.md)
 - Facts are never invented — the LLM writes only free text (canonical name/description); provenance is unioned and immutable-property conflicts are flagged for review
 - **Adds LLM + embedding calls during ingestion.** When no LLM or embedder is available, the default automatically falls back to `ExactMatchResolution` (below), so lightweight setups keep working with no added cost
 

--- a/docs/ingestion.md
+++ b/docs/ingestion.md
@@ -155,14 +155,21 @@ For a detailed explanation of the extraction process, see [extraction.md](extrac
 
 **What it does:** Merges entities that refer to the same real-world thing. When the LLM extracts "Alice" from chunk 1 and "Alice" from chunk 5, this step recognizes they're the same entity and merges them.
 
-**Default: ExactMatchResolution**
+**Default: IncrementalResolution** *(when an LLM and embedder are configured)*
+- Resolves each document's entities **against the entities already in the graph**, so a mention can be linked onto an entity extracted from an earlier document — the cross-document case batch resolvers can't see
+- Merges same-name / different-type duplicates for free by description similarity (e.g. "GraphRAG" extracted once as a `Concept` and once as a `Technology`), which closes a common homograph gap
+- Uses one LLM call per ambiguous group to link variant names onto existing entities while keeping genuine look-alikes apart (e.g. `FALKORDB_USERNAME` ≠ `FALKORDB_PASSWORD`)
+- Facts are never invented — the LLM writes only free text (canonical name/description); provenance is unioned and immutable-property conflicts are flagged for review
+- **Adds LLM + embedding calls during ingestion.** When no LLM or embedder is available, the default automatically falls back to `ExactMatchResolution` (below), so lightweight setups keep working with no added cost
+
+**ExactMatchResolution** *(LLM-free fallback)*
 - Groups entities by ID
 - Keeps the first occurrence as the survivor
 - Merges properties from duplicates into the survivor
 - Remaps all relationship endpoints to the survivor
 - Deduplicates relationships by `(start_id, type, end_id)`
 
-**Alternative: DescriptionMergeResolution**
+**DescriptionMergeResolution**
 - Groups by `(normalized name, label)` — same name but different labels stay separate (e.g., Person "Paris" vs Location "Paris")
 - Merges descriptions (concatenation or LLM summarization)
 - Used in the benchmark-winning pipeline
@@ -266,8 +273,10 @@ stats = await rag.finalize()
 
 | Strategy | When to use |
 |----------|-------------|
-| `ExactMatchResolution` (default) | Fast, deterministic. Good when extraction is consistent |
+| `IncrementalResolution` (default, with LLM + embedder) | Graph-aware. Links entities across documents and fixes same-name/different-type duplicates. Adds LLM/embedding cost per ingest |
+| `ExactMatchResolution` (default fallback, LLM-free) | Fast, deterministic. Used automatically when no LLM/embedder is configured |
 | `DescriptionMergeResolution` | Multi-document ingestion. Used in the benchmark pipeline |
+| `SemanticResolution` / `LLMVerifiedResolution` | Embedding/LLM-verified deduplication within a batch |
 
 ---
 
@@ -290,6 +299,7 @@ stats = await rag.finalize()
 | [`loaders/pdf_loader.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/loaders/pdf_loader.py) | PdfLoader implementation |
 | [`chunking_strategies/fixed_size.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/chunking_strategies/fixed_size.py) | FixedSizeChunking implementation |
 | [`extraction_strategies/graph_extraction.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py) | 2-step extraction (NER + LLM verify/rels) |
+| [`resolution_strategies/incremental_resolution.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py) | IncrementalResolution (default, graph-aware) |
 | [`resolution_strategies/exact_match.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/exact_match.py) | ExactMatchResolution |
 | [`resolution_strategies/description_merge.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/description_merge.py) | DescriptionMergeResolution |
 | [`storage/graph_store.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py) | Batched node/relationship writes |

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -9,7 +9,7 @@ GraphRAG SDK uses the **Strategy pattern** for every algorithmic concern. Each c
 | 1 | Loading | `LoaderStrategy` | `TextLoader`, `PdfLoader`, `MarkdownLoader` |
 | 2 | Chunking | `ChunkingStrategy` | `FixedSizeChunking`, `SentenceTokenCapChunking`, `ContextualChunking`, `CallableChunking`, `StructuralChunking` |
 | 3 | Extraction | `ExtractionStrategy` | `GraphExtraction` |
-| 4 | Resolution | `ResolutionStrategy` | `ExactMatchResolution`, `DescriptionMergeResolution` |
+| 4 | Resolution | `ResolutionStrategy` | `IncrementalResolution` (default), `ExactMatchResolution`, `DescriptionMergeResolution`, `SemanticResolution`, `LLMVerifiedResolution` |
 | 5 | Retrieval | `RetrievalStrategy` | `LocalRetrieval`, `MultiPathRetrieval` |
 | 6 | Reranking | `RerankingStrategy` | `CosineReranker` |
 
@@ -398,6 +398,36 @@ class ResolutionStrategy(ABC):
 
 Returns `ResolutionResult` with deduplicated `nodes`, remapped `relationships`, and `merged_count`.
 
+### Built-in: IncrementalResolution (default)
+
+Graph-aware resolution: each document's entities are resolved **against the entities already in the graph**, so a mention can be linked onto an entity extracted from an earlier document — the cross-document case batch resolvers can't see. It is the default when the `GraphRAG` facade has both an LLM and an embedder; otherwise the facade falls back to `ExactMatchResolution`.
+
+A funnel — cheap, certain work first; the LLM only where cheap signals can't decide:
+
+1. **collapse** — merge a batch's own same-name duplicates by description similarity (no LLM). Fixes same-name / different-type duplicates like "GraphRAG" the `Concept` vs the `Technology`.
+2. **retrieve** — for each survivor, fetch look-alike existing graph entities.
+3. **pile** — group survivors that share a candidate.
+4. **link** — one LLM call per pile decides which items are the same entity and which existing node (if any) is the merge target. Genuine look-alikes stay apart (`FALKORDB_USERNAME` ≠ `FALKORDB_PASSWORD`).
+
+Facts are never invented — the LLM writes only free text (canonical name/description); provenance is unioned and immutable-property conflicts are flagged (`_needs_review`).
+
+```python
+from graphrag_sdk.ingestion.resolution_strategies.incremental_resolution import IncrementalResolution
+
+resolver = IncrementalResolution(
+    llm=llm,                       # decides links + writes merged descriptions
+    embedder=embedder,             # scores description similarity
+    candidate_retriever=retriever, # async (name, description, k) -> [GraphNode]; the
+                                   # facade wires one backed by the graph store
+    top_k=3,                       # candidates fetched per entity
+    pile_cap=12,                   # max items sent to the LLM per call
+    same_name_threshold=0.80,      # description cosine to auto-merge same-name entities
+    immutable_props=(),            # properties that flag a conflict instead of merging
+)
+```
+
+**When to use:** Default for multi-document knowledge graphs where the same entity recurs across documents. **Note:** it adds LLM + embedding calls during ingestion; for LLM-free or cost-sensitive ingestion use `ExactMatchResolution`.
+
 ### Built-in: ExactMatchResolution
 
 Deduplicates by exact property match (default: `id`). Fast, no LLM calls.
@@ -410,7 +440,7 @@ resolver = ExactMatchResolution(
 )
 ```
 
-**When to use:** Default. Fast and deterministic. Works well when extraction produces consistent entity IDs.
+**When to use:** LLM-free ingestion. Fast and deterministic; used automatically as the default fallback when no LLM/embedder is configured.
 
 ### Built-in: DescriptionMergeResolution
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -417,14 +417,15 @@ from graphrag_sdk.ingestion.resolution_strategies.incremental_resolution import 
 resolver = IncrementalResolution(
     llm=llm,                       # decides links + writes merged descriptions
     embedder=embedder,             # scores description similarity
-    candidate_retriever=retriever, # async (name, description, k) -> [GraphNode]; the
-                                   # facade wires one backed by the graph store
+    candidate_retriever=retriever, # async (name, description, k) -> [GraphNode]
     top_k=3,                       # candidates fetched per entity
     pile_cap=12,                   # max items sent to the LLM per call
     same_name_threshold=0.80,      # description cosine to auto-merge same-name entities
     immutable_props=(),            # properties that flag a conflict instead of merging
 )
 ```
+
+**Candidate retrieval.** The strategy links whatever the `candidate_retriever` surfaces. When used as the `GraphRAG` default, the facade wires a **name-based** retriever: it matches existing entities whose name is equal after folding case and separators (`GraphRAG-SDK` == `graphrag_sdk` == `GraphRAG SDK`), and also tries the separator-removed form, so it catches cross-document homographs (`GraphRAG` the Concept vs the Technology) and many tokenization variants (`llama_index` finds a stored `LlamaIndex`). It is *not* semantic — entity embeddings only exist after `finalize()`, so a vector search finds nothing mid-ingest — and because it matches an exact set of surface forms rather than fuzzily, it is best-effort (it won't catch arbitrary spellings or every direction). For guaranteed variant/semantic linking, pass a custom `candidate_retriever` (e.g. backed by your own index) or run a reconciliation pass after `finalize()` where entity embeddings are available.
 
 **When to use:** Default for multi-document knowledge graphs where the same entity recurs across documents. **Note:** it adds LLM + embedding calls during ingestion; for LLM-free or cost-sensitive ingestion use `ExactMatchResolution`.
 

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -104,6 +104,9 @@ from graphrag_sdk.ingestion.resolution_strategies.description_merge import (
 from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
     ExactMatchResolution,
 )
+from graphrag_sdk.ingestion.resolution_strategies.incremental_resolution import (
+    IncrementalResolution,
+)
 from graphrag_sdk.ingestion.resolution_strategies.llm_verified_resolution import (
     LLMVerifiedResolution,
 )
@@ -196,6 +199,7 @@ __all__ = [
     "ResolutionStrategy",
     "DescriptionMergeResolution",
     "ExactMatchResolution",
+    "IncrementalResolution",
     "LLMVerifiedResolution",
     "SemanticResolution",
     # Retrieval

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -1740,23 +1740,45 @@ class GraphRAG:
         )
 
     def _graph_candidate_retriever(self):
-        """Build a candidate retriever that finds existing graph entities which
-        share a name with an incoming entity, so cross-document duplicates
-        (e.g. the same term extracted under different types) can be linked.
+        """Build a name-based candidate retriever for ``IncrementalResolution``.
 
-        Note: this issues one name-equality lookup per resolved entity. On very
-        large graphs a range index on ``__Entity__(name)`` keeps it cheap.
+        Matches an incoming entity against existing graph entities whose name is
+        equal after folding case and separators (``-``, ``_``, spaces) — e.g.
+        ``GraphRAG-SDK`` == ``graphrag_sdk`` == ``GraphRAG SDK``. This links the
+        cross-document duplicates the strategy targets, most importantly the same
+        term extracted under different types (``GraphRAG`` the Concept vs the
+        Technology).
+
+        Matching also tries the separator-removed form, so many tokenization
+        variants are caught too (``llama_index`` finds a stored ``LlamaIndex``).
+        It is intentionally name-based, not semantic: entity embeddings are only
+        built during ``finalize()``, so a vector search would find nothing
+        mid-ingest. Because matching is by an exact set of surface forms rather
+        than fuzzy, it is best-effort — it won't catch arbitrary spellings or
+        every direction (a ``LlamaIndex`` mention won't find a stored
+        ``llama_index``). For guaranteed variant/semantic linking, supply a
+        custom ``candidate_retriever`` or run a reconciliation pass after
+        ``finalize()``. One equality lookup is issued per resolved entity; on
+        very large graphs a range index on ``__Entity__(name)`` keeps it cheap.
         """
         store = self._graph_store
 
         async def retrieve(name: str, description: str, k: int) -> list[GraphNode]:
-            lname = str(name).strip().lower()
-            if not lname:
+            base = str(name).strip().lower()
+            if not base:
                 return []
+            # Fold separators to catch surface variants without a scan: an
+            # equality IN-list over the handful of spellings this entity's name
+            # could take (hyphen/underscore/space and their removal).
+            folded = re.sub(r"[\s\-_]+", " ", base).strip()
+            variants = list({base, folded, folded.replace(" ", "")})
             result = await store.query_raw(
-                "MATCH (n:__Entity__) WHERE toLower(n.name) = $lname "
+                "MATCH (n:__Entity__) "
+                "WHERE toLower(n.name) IN $variants "
+                "OR replace(replace(replace(toLower(n.name), '-', ' '), '_', ' '), '  ', ' ') "
+                "= $folded "
                 "RETURN n.id, labels(n), n.name, n.description LIMIT $k",
-                {"lname": lname, "k": k},
+                {"variants": variants, "folded": folded, "k": k},
             )
             rows = result.result_set if result and result.result_set else []
             candidates: list[GraphNode] = []

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -40,6 +40,7 @@ from graphrag_sdk.core.models import (
     UpdateResult,
 )
 from graphrag_sdk.core.providers import Embedder, LLMInterface
+from graphrag_sdk.core.text import name_key
 from graphrag_sdk.discovery import SchemaExtensionProposal, suggest_extensions
 from graphrag_sdk.ingestion.backfill import (
     BackfillExecutor,
@@ -1732,7 +1733,13 @@ class GraphRAG:
         so lightweight setups keep working with no added cost.
         """
         if self.llm is None or self.embedder is None:
+            logger.info("Resolver: ExactMatchResolution (no LLM/embedder — LLM-free)")
             return ExactMatchResolution()
+        logger.info(
+            "Resolver: IncrementalResolution (graph-aware default; adds LLM + "
+            "embedding + graph-query cost per ingest — pass resolver="
+            "ExactMatchResolution() to opt out)"
+        )
         return IncrementalResolution(
             llm=self.llm,
             embedder=self.embedder,
@@ -1742,43 +1749,38 @@ class GraphRAG:
     def _graph_candidate_retriever(self):
         """Build a name-based candidate retriever for ``IncrementalResolution``.
 
-        Matches an incoming entity against existing graph entities whose name is
-        equal after folding case and separators (``-``, ``_``, spaces) — e.g.
-        ``GraphRAG-SDK`` == ``graphrag_sdk`` == ``GraphRAG SDK``. This links the
-        cross-document duplicates the strategy targets, most importantly the same
-        term extracted under different types (``GraphRAG`` the Concept vs the
-        Technology).
+        Matches an incoming entity against existing graph entities that share a
+        ``name_key`` — the name folded to lowercase with all separators removed
+        (see :func:`graphrag_sdk.core.text.name_key`). This links the
+        cross-document duplicates the strategy targets: the same term extracted
+        under different types (``GraphRAG`` the Concept vs the Technology), and
+        surface/tokenization variants (``GraphRAG-SDK`` / ``graphrag_sdk`` /
+        ``GraphRAG SDK``, and ``llama_index`` ↔ ``LlamaIndex``) — symmetrically,
+        since both sides reduce to the same key.
 
-        Matching also tries the separator-removed form, so many tokenization
-        variants are caught too (``llama_index`` finds a stored ``LlamaIndex``).
-        It is intentionally name-based, not semantic: entity embeddings are only
-        built during ``finalize()``, so a vector search would find nothing
-        mid-ingest. Because matching is by an exact set of surface forms rather
-        than fuzzy, it is best-effort — it won't catch arbitrary spellings or
-        every direction (a ``LlamaIndex`` mention won't find a stored
-        ``llama_index``). For guaranteed variant/semantic linking, supply a
-        custom ``candidate_retriever`` or run a reconciliation pass after
-        ``finalize()``. One equality lookup is issued per resolved entity; on
-        very large graphs a range index on ``__Entity__(name)`` keeps it cheap.
+        The lookup is an **indexed equality** on ``name_key`` (a range index the
+        store ensures exists), so it does not scan every entity — unlike a
+        ``toLower(name)`` predicate, where the function on the property defeats
+        any index. It is intentionally name-based, not semantic: entity
+        embeddings are only built during ``finalize()``, so a vector search
+        would find nothing mid-ingest. For fuzzy/semantic linking beyond shared
+        keys, supply a custom ``candidate_retriever`` or run a reconciliation
+        pass after ``finalize()``.
         """
         store = self._graph_store
+        index_ready = {"done": False}
 
         async def retrieve(name: str, description: str, k: int) -> list[GraphNode]:
-            base = str(name).strip().lower()
-            if not base:
+            key = name_key(name)
+            if not key:
                 return []
-            # Fold separators to catch surface variants without a scan: an
-            # equality IN-list over the handful of spellings this entity's name
-            # could take (hyphen/underscore/space and their removal).
-            folded = re.sub(r"[\s\-_]+", " ", base).strip()
-            variants = list({base, folded, folded.replace(" ", "")})
+            if not index_ready["done"]:
+                await store.ensure_name_key_index()
+                index_ready["done"] = True
             result = await store.query_raw(
-                "MATCH (n:__Entity__) "
-                "WHERE toLower(n.name) IN $variants "
-                "OR replace(replace(replace(toLower(n.name), '-', ' '), '_', ' '), '  ', ' ') "
-                "= $folded "
+                "MATCH (n:__Entity__) WHERE n.name_key = $key "
                 "RETURN n.id, labels(n), n.name, n.description LIMIT $k",
-                {"variants": variants, "folded": folded, "k": k},
+                {"key": key, "k": k},
             )
             rows = result.result_set if result and result.result_set else []
             candidates: list[GraphNode] = []

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -72,6 +72,9 @@ from graphrag_sdk.ingestion.loaders.text_loader import TextLoader
 from graphrag_sdk.ingestion.pipeline import IngestionPipeline
 from graphrag_sdk.ingestion.resolution_strategies.base import ResolutionStrategy
 from graphrag_sdk.ingestion.resolution_strategies.exact_match import ExactMatchResolution
+from graphrag_sdk.ingestion.resolution_strategies.incremental_resolution import (
+    IncrementalResolution,
+)
 from graphrag_sdk.retrieval.reranking_strategies.base import RerankingStrategy
 from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
 from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval
@@ -1545,7 +1548,7 @@ class GraphRAG:
             loader=loader or TextLoader(),
             chunker=chunker or SentenceTokenCapChunking(),
             extractor=extractor or self._default_extractor(),
-            resolver=resolver or ExactMatchResolution(),
+            resolver=resolver or self._default_resolver(),
             graph_store=self._graph_store,
             vector_store=self._vector_store,
             ontology=self._global_ontology,
@@ -1717,6 +1720,58 @@ class GraphRAG:
             llm=self.llm,
             entity_types=entity_types,
         )
+
+    def _default_resolver(self) -> ResolutionStrategy:
+        """The default entity-resolution strategy.
+
+        When both an LLM and an embedder are configured, use graph-aware
+        :class:`IncrementalResolution`: it resolves each document's entities
+        against the entities already in the graph, so a mention can be linked
+        onto an entity extracted from an earlier document. Without an LLM or
+        embedder it falls back to the LLM-free :class:`ExactMatchResolution`,
+        so lightweight setups keep working with no added cost.
+        """
+        if self.llm is None or self.embedder is None:
+            return ExactMatchResolution()
+        return IncrementalResolution(
+            llm=self.llm,
+            embedder=self.embedder,
+            candidate_retriever=self._graph_candidate_retriever(),
+        )
+
+    def _graph_candidate_retriever(self):
+        """Build a candidate retriever that finds existing graph entities which
+        share a name with an incoming entity, so cross-document duplicates
+        (e.g. the same term extracted under different types) can be linked.
+
+        Note: this issues one name-equality lookup per resolved entity. On very
+        large graphs a range index on ``__Entity__(name)`` keeps it cheap.
+        """
+        store = self._graph_store
+
+        async def retrieve(name: str, description: str, k: int) -> list[GraphNode]:
+            lname = str(name).strip().lower()
+            if not lname:
+                return []
+            result = await store.query_raw(
+                "MATCH (n:__Entity__) WHERE toLower(n.name) = $lname "
+                "RETURN n.id, labels(n), n.name, n.description LIMIT $k",
+                {"lname": lname, "k": k},
+            )
+            rows = result.result_set if result and result.result_set else []
+            candidates: list[GraphNode] = []
+            for node_id, labels, node_name, node_desc in rows:
+                label = next((lbl for lbl in (labels or []) if lbl != "__Entity__"), "Unknown")
+                candidates.append(
+                    GraphNode(
+                        id=node_id,
+                        label=label,
+                        properties={"name": node_name or node_id, "description": node_desc or ""},
+                    )
+                )
+            return candidates
+
+        return retrieve
 
     @staticmethod
     def _default_loader_for(source: str) -> LoaderStrategy:
@@ -2113,7 +2168,7 @@ class GraphRAG:
             loader=loader or TextLoader(),  # unused (text is provided below)
             chunker=chunker or SentenceTokenCapChunking(),
             extractor=extractor or self._default_extractor(),
-            resolver=resolver or ExactMatchResolution(),
+            resolver=resolver or self._default_resolver(),
             graph_store=self._graph_store,
             vector_store=self._vector_store,
             ontology=self._global_ontology,

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -1775,8 +1775,11 @@ class GraphRAG:
             if not key:
                 return []
             if not index_ready["done"]:
-                await store.ensure_name_key_index()
-                index_ready["done"] = True
+                # Backfill legacy entities (ingested before name_key existed) so
+                # they remain matchable, then only treat the index as ready if it
+                # actually created — otherwise retry the setup on the next call.
+                await store.backfill_name_keys()
+                index_ready["done"] = await store.ensure_name_key_index()
             result = await store.query_raw(
                 "MATCH (n:__Entity__) WHERE n.name_key = $key "
                 "RETURN n.id, labels(n), n.name, n.description LIMIT $k",

--- a/graphrag_sdk/src/graphrag_sdk/core/prompts.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/prompts.py
@@ -1,0 +1,18 @@
+"""Shared prompt fragments.
+
+Keeping cross-cutting instructions in one place so the steps that must agree —
+notably how an entity *description* is written — cannot drift apart.
+"""
+
+# The single rule for how an entity description is produced. Used verbatim by
+# entity extraction (writing each entity's description) and by resolution
+# (writing the merged description when entities are unified), so both steps
+# emit descriptions of the same shape and length. Because the rule bounds the
+# text, callers can feed descriptions to the LLM in full — no ad-hoc truncation,
+# which is what caused rich descriptions to erode across repeated merges.
+ENTITY_DESCRIPTION_RULE = (
+    "Describe the entity in a self-contained way — what it is and its key "
+    "facts and roles — understandable without the source text (it is embedded "
+    "for semantic search). Be concise and factual: at most 2-3 sentences, no "
+    "filler, no restating the name."
+)

--- a/graphrag_sdk/src/graphrag_sdk/core/prompts.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/prompts.py
@@ -10,9 +10,11 @@ notably how an entity *description* is written — cannot drift apart.
 # emit descriptions of the same shape and length. Because the rule bounds the
 # text, callers can feed descriptions to the LLM in full — no ad-hoc truncation,
 # which is what caused rich descriptions to erode across repeated merges.
+# Wording kept close to the long-standing extraction instruction so that making
+# it a shared constant does not change extraction behaviour (a reworded version
+# shifted real-LLM output and destabilised integration tests).
 ENTITY_DESCRIPTION_RULE = (
-    "Describe the entity in a self-contained way — what it is and its key "
-    "facts and roles — understandable without the source text (it is embedded "
-    "for semantic search). Be concise and factual: at most 2-3 sentences, no "
-    "filler, no restating the name."
+    "A concise 1-2 sentence description capturing the entity's key attributes "
+    "and roles. It is embedded for semantic search, so it must be self-contained "
+    "and understandable without the original text."
 )

--- a/graphrag_sdk/src/graphrag_sdk/core/text.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/text.py
@@ -1,0 +1,31 @@
+"""Name-normalization helpers shared by storage and resolution.
+
+Kept in ``core`` so both the graph store (which writes ``name_key`` at ingest)
+and the resolution strategies (which look entities up by it) can agree on one
+definition without cross-layer imports.
+"""
+
+import re
+
+_SEPARATORS = re.compile(r"[\s\-_]+")
+
+
+def normalize_name(name: str) -> str:
+    """Fold case and separator runs so surface variants share one form.
+
+    ``"GraphRAG-SDK"``, ``"graphrag_sdk"`` and ``"GraphRAG SDK"`` all normalize
+    to ``"graphrag sdk"``.
+    """
+    return _SEPARATORS.sub(" ", str(name).strip().lower()).strip()
+
+
+def name_key(name: str) -> str:
+    """A separator-free key for indexed entity lookup.
+
+    Drops the spaces from :func:`normalize_name`, so it is symmetric across
+    tokenization variants — ``"llama_index"`` and ``"LlamaIndex"`` both key to
+    ``"llamaindex"``. Stored on every entity as ``name_key`` and matched by
+    indexed equality, which avoids the per-entity scan a ``toLower(name)``
+    predicate forces.
+    """
+    return normalize_name(name).replace(" ", "")

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -24,6 +24,7 @@ from graphrag_sdk.core.models import (
     Relation,
     TextChunks,
 )
+from graphrag_sdk.core.prompts import ENTITY_DESCRIPTION_RULE
 from graphrag_sdk.core.providers import LLMInterface
 from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
 from graphrag_sdk.ingestion.extraction_strategies.coref_resolvers import CorefResolver
@@ -64,9 +65,7 @@ VERIFY_EXTRACT_RELS_PROMPT = (
     "(e.g. sh, cd, dt, ls, rm, cp, mv)\n"
     "  - A generic short token (1-2 characters) that is not a widely-recognised "
     "named entity or acronym (AI, US, UK, Go are fine; dt, bg, fn are not)\n"
-    "- For each verified entity provide a concise 1-2 sentence description "
-    "capturing key attributes and roles from the text. This description is "
-    "embedded for semantic search.\n\n"
+    "- For each verified entity provide a description. " + ENTITY_DESCRIPTION_RULE + "\n\n"
     "### Relationships\n"
     "- Extract ALL factual connections stated or implied in the text.\n"
     "- source and target must be entity names from the verified entity list.\n"

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/__init__.py
@@ -5,6 +5,9 @@ from graphrag_sdk.ingestion.resolution_strategies.description_merge import (
     DescriptionMergeResolution,
 )
 from graphrag_sdk.ingestion.resolution_strategies.exact_match import ExactMatchResolution
+from graphrag_sdk.ingestion.resolution_strategies.incremental_resolution import (
+    IncrementalResolution,
+)
 from graphrag_sdk.ingestion.resolution_strategies.llm_verified_resolution import (
     LLMVerifiedResolution,
 )
@@ -16,4 +19,5 @@ __all__ = [
     "DescriptionMergeResolution",
     "SemanticResolution",
     "LLMVerifiedResolution",
+    "IncrementalResolution",
 ]

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
@@ -187,7 +187,13 @@ class IncrementalResolution(ResolutionStrategy):
         survivors, remap, merged = await self._collapse_within_batch(nodes)
 
         # 2. Fetch look-alike existing entities for each survivor (free).
-        candidates = await self._fetch_candidates(survivors)
+        # Without an LLM stage 4 never runs, so candidate retrieval would be
+        # pure overhead (and could surface graph-store latency/failures);
+        # resolution then reduces to the within-batch collapse from step 1.
+        if self.llm is None:
+            candidates = [[] for _ in survivors]
+        else:
+            candidates = await self._fetch_candidates(survivors)
 
         # 3. Group survivors that share a candidate into piles (free).
         # 4. Ask the LLM to link each pile against the graph (LLM).
@@ -354,7 +360,9 @@ class IncrementalResolution(ResolutionStrategy):
         merged = 0
         consumed: set[int] = set()  # refs already placed by an earlier group
         for group in decisions:
-            member_refs = [r for r in group.members if r in by_ref]
+            # Dedupe refs within the group first: a repeated ref would place the
+            # same survivor twice and make the code absorb a node into itself.
+            member_refs = [r for r in dict.fromkeys(group.members) if r in by_ref]
             # Enforce a disjoint partition: a sloppy-but-parseable LLM response
             # can reuse a ref across groups, which would double-absorb a node and
             # let the last-wins remap merge unrelated entities. Drop any group
@@ -480,7 +488,7 @@ class IncrementalResolution(ResolutionStrategy):
             # np.array is inside the guard: a ragged/malformed embedder result
             # would otherwise raise here and crash the whole document.
             matrix = np.array([v or [0.0] for v in raw], dtype=np.float32)
-        except Exception as exc:  # pragma: no cover - defensive
+        except Exception as exc:
             logger.warning("IncrementalResolution: embedding failed: %s", exc)
             return None
         if matrix.ndim != 2 or matrix.shape[1] <= 1:
@@ -590,9 +598,9 @@ def _parse_decisions(content: str) -> list[_LinkDecision] | None:
                 _LinkDecision(
                     members=members,
                     target=target if target is not None else "new",
-                    canonical=group.get("canonical"),
-                    type=group.get("type"),
-                    description=group.get("description"),
+                    canonical=_as_text(group.get("canonical")),
+                    type=_as_text(group.get("type")),
+                    description=_as_text(group.get("description")),
                 )
             )
     return decisions or None
@@ -613,6 +621,24 @@ def _as_ref(value: object) -> int | None:
         return int(value) if value.is_integer() else None
     if isinstance(value, str) and value.strip().lstrip("-").isdigit():
         return int(value)
+    return None
+
+
+def _as_text(value: object) -> str | None:
+    """Coerce an LLM-supplied name/type/description to a clean string.
+
+    The model can emit ``null``, numbers or nested objects for these fields;
+    letting those through would set ``name``/``description`` to non-string types
+    that then propagate into storage and later resolution. Scalars (str, int,
+    float, bool) are stringified; anything structural (dict, list, ``None``)
+    is dropped so the carrier keeps its own value.
+    """
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return str(value)
     return None
 
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
@@ -202,7 +202,22 @@ class IncrementalResolution(ResolutionStrategy):
 
         _flatten(remap)
         absorbed = set(remap)
-        surviving_nodes = [n for n in survivors if n.id not in absorbed]
+        # Collapse carriers that were independently linked onto the same graph
+        # node — across pile chunks or across two LLM groups sharing a target —
+        # so the output never contains two nodes with one id (which would make
+        # the store MERGE the same (label, id) twice and clobber the earlier
+        # node's provenance/conflicts). The first keeper wins; the rest fold in.
+        keeper_by_id: dict[str, GraphNode] = {}
+        surviving_nodes: list[GraphNode] = []
+        for node in survivors:
+            if node.id in absorbed:
+                continue
+            keeper = keeper_by_id.get(node.id)
+            if keeper is None:
+                keeper_by_id[node.id] = node
+                surviving_nodes.append(node)
+            else:
+                self._absorb(keeper, node)
         relationships = remap_relationships(graph_data.relationships, remap)
         ctx.log(
             f"IncrementalResolution: {len(surviving_nodes)} entities ({merged} merged or linked)"

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
@@ -189,10 +189,16 @@ class IncrementalResolution(ResolutionStrategy):
 
         # 3. Group survivors that share a candidate into piles (free).
         # 4. Ask the LLM to link each pile against the graph (LLM).
+        # A pile with more survivors than the prompt budget is split into
+        # chunks — otherwise the survivors alone would breach ``pile_cap`` and
+        # evict every candidate, so the LLM could never link. Reserve room for
+        # each chunk's candidates.
+        survivor_budget = max(1, self.pile_cap - self.top_k)
         for pile in self._partition_into_piles(candidates):
             if self.llm is None or not any(candidates[i] for i in pile):
                 continue  # nothing to link → these survivors are new; keep as-is
-            merged += await self._link_pile(pile, survivors, candidates, remap)
+            for chunk in _chunked(pile, survivor_budget):
+                merged += await self._link_pile(chunk, survivors, candidates, remap)
 
         _flatten(remap)
         absorbed = set(remap)
@@ -240,11 +246,19 @@ class IncrementalResolution(ResolutionStrategy):
     async def _same_name_merges(
         self, group: list[GraphNode]
     ) -> list[tuple[GraphNode, list[GraphNode]]]:
-        """Yield ``(survivor, losers)`` pairs for one same-name group."""
-        units = await self._embed(_descriptions(group))
+        """Yield ``(survivor, losers)`` pairs for one same-name group.
+
+        A cross-type merge requires *real* descriptions on every member: without
+        them description similarity degrades to name-vs-name (always cosine 1.0),
+        which would merge genuine homographs (Paris the city vs the person) on
+        name identity alone — against the fail-toward-splitting stance. When any
+        description is missing, only exact same-type duplicates are folded.
+        """
+        descriptions = [str(n.properties.get("description") or "") for n in group]
+        units = await self._embed(descriptions) if all(descriptions) else None
         if units is not None and _min_pairwise_cosine(units) >= self.same_name_threshold:
             return [(group[0], group[1:])]  # coherent → one entity (type wobble)
-        # Incoherent (or no embedder): only fold exact same-type duplicates.
+        # No evidence to cross types: only fold exact same-type duplicates.
         return [
             (same_type[0], same_type[1:])
             for same_type in _group_by(group, key=lambda n: n.label)
@@ -381,7 +395,15 @@ class IncrementalResolution(ResolutionStrategy):
 
     def _absorb(self, survivor: GraphNode, loser: GraphNode) -> None:
         """Fold ``loser`` into ``survivor``: union provenance, keep the
-        survivor's values, and flag any immutable-property disagreement."""
+        survivor's values, and flag any immutable-property disagreement.
+
+        Conflicts are recorded as ``"<field>: <a> vs <b>"`` strings, not dicts:
+        the graph store persists lists of primitives but silently drops lists of
+        dicts, so a structured record would never reach the graph. Both the
+        loser's prior conflicts and its ``_needs_review`` flag are carried over,
+        so a node flagged in an earlier stage keeps that flag when it is later
+        absorbed.
+        """
         sources = _unique(
             survivor.properties.get(_SOURCE_IDS) or [],
             loser.properties.get(_SOURCE_IDS) or [],
@@ -389,15 +411,17 @@ class IncrementalResolution(ResolutionStrategy):
         if sources:
             survivor.properties[_SOURCE_IDS] = sources
 
-        conflicts = list(survivor.properties.get(_CONFLICTS, []))
+        conflicts = list(survivor.properties.get(_CONFLICTS, [])) + list(
+            loser.properties.get(_CONFLICTS, [])
+        )
         for key, value in loser.properties.items():
             if key in (_SOURCE_IDS, _CONFLICTS, _NEEDS_REVIEW):
                 continue
             if key not in survivor.properties:
                 survivor.properties[key] = value
             elif key in self.immutable_props and survivor.properties[key] != value:
-                conflicts.append({"field": key, "values": [survivor.properties[key], value]})
-        if conflicts:
+                conflicts.append(f"{key}: {survivor.properties[key]} vs {value}")
+        if conflicts or loser.properties.get(_NEEDS_REVIEW):
             survivor.properties[_CONFLICTS] = conflicts
             survivor.properties[_NEEDS_REVIEW] = True
 
@@ -408,11 +432,13 @@ class IncrementalResolution(ResolutionStrategy):
             return None
         try:
             raw = await self.embedder.aembed_documents(texts)
+            # np.array is inside the guard: a ragged/malformed embedder result
+            # would otherwise raise here and crash the whole document.
+            matrix = np.array([v or [0.0] for v in raw], dtype=np.float32)
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("IncrementalResolution: embedding failed: %s", exc)
             return None
-        matrix = np.array([v or [0.0] for v in raw], dtype=np.float32)
-        if matrix.shape[1] <= 1:
+        if matrix.ndim != 2 or matrix.shape[1] <= 1:
             return None
         norms = np.linalg.norm(matrix, axis=1, keepdims=True)
         norms[norms == 0] = 1.0
@@ -487,8 +513,10 @@ def _description_of(node: GraphNode) -> str:
     return str(node.properties.get("description") or node.properties.get("name") or "")
 
 
-def _descriptions(nodes: Iterable[GraphNode]) -> list[str]:
-    return [_description_of(n) for n in nodes]
+def _chunked(items: list[int], size: int) -> Iterable[list[int]]:
+    """Split ``items`` into consecutive chunks of at most ``size``."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
 
 
 def _parse_decisions(content: str) -> list[_LinkDecision] | None:

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
@@ -44,9 +44,9 @@ store's name/vector search.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
-import re
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass
@@ -57,6 +57,7 @@ from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import GraphData, GraphNode, ResolutionResult
 from graphrag_sdk.core.prompts import ENTITY_DESCRIPTION_RULE
 from graphrag_sdk.core.providers import Embedder, LLMInterface
+from graphrag_sdk.core.text import normalize_name
 from graphrag_sdk.ingestion.resolution_strategies.base import (
     ResolutionStrategy,
     remap_relationships,
@@ -64,21 +65,12 @@ from graphrag_sdk.ingestion.resolution_strategies.base import (
 
 logger = logging.getLogger(__name__)
 
-_SEPARATORS = re.compile(r"[\s\-_]+")
-
 # Internal property keys the resolver writes; never treated as extracted facts.
 _SOURCE_IDS = "source_chunk_ids"
 _CONFLICTS = "_merge_conflicts"
 _NEEDS_REVIEW = "_needs_review"
 
-
-def normalize_name(name: str) -> str:
-    """Fold case and separators so surface variants share one key.
-
-    ``"GraphRAG-SDK"``, ``"graphrag_sdk"`` and ``"GraphRAG SDK"`` all normalize
-    to ``"graphrag sdk"``.
-    """
-    return _SEPARATORS.sub(" ", str(name).strip().lower()).strip()
+__all__ = ["IncrementalResolution", "normalize_name"]
 
 
 # Returns the existing graph entities that look like ``(name, description)``.
@@ -149,9 +141,13 @@ class IncrementalResolution(ResolutionStrategy):
         pile_cap: Upper bound on items (survivors + candidates) sent to the LLM
             in a single call, so a crowded name cannot blow up a prompt.
         same_name_threshold: Minimum pairwise description cosine at which
-            same-name entities auto-merge for free. Same name is already strong
-            evidence, so this bar is deliberately low; genuine homographs
-            (Paris the city vs the person) fall below it and stay separate.
+            same-name, same-type entities auto-merge for free. Same name is
+            already strong evidence, so this bar is deliberately low.
+        cross_type_threshold: The (higher) bar a same-name group spanning
+            different types must clear to free-merge. Crossing types is the only
+            unrecoverable free path, so it demands stronger evidence; genuine
+            homographs (Paris the city vs the person) fall below it and stay
+            separate for the LLM to judge.
         max_summary_tokens: Budget hint for LLM-written merged descriptions.
         immutable_props: Properties that must not change on merge. A conflict
             flags the survivor for review instead of silently picking a value —
@@ -167,6 +163,7 @@ class IncrementalResolution(ResolutionStrategy):
         top_k: int = 3,
         pile_cap: int = 12,
         same_name_threshold: float = 0.80,
+        cross_type_threshold: float = 0.90,
         max_summary_tokens: int = 300,
         immutable_props: Sequence[str] = (),
     ) -> None:
@@ -176,6 +173,7 @@ class IncrementalResolution(ResolutionStrategy):
         self.top_k = top_k
         self.pile_cap = pile_cap
         self.same_name_threshold = same_name_threshold
+        self.cross_type_threshold = cross_type_threshold
         self.max_summary_tokens = max_summary_tokens
         self.immutable_props = frozenset(immutable_props)
 
@@ -272,12 +270,19 @@ class IncrementalResolution(ResolutionStrategy):
         which would merge genuine homographs (Paris the city vs the person) on
         name identity alone — against the fail-toward-splitting stance. When any
         description is missing, only exact same-type duplicates are folded.
+
+        Merging *across types* is the only unrecoverable free path, so it needs
+        stronger evidence: a single-type group merges at ``same_name_threshold``,
+        but a group spanning types must clear the higher ``cross_type_threshold``.
         """
         descriptions = [str(n.properties.get("description") or "") for n in group]
         units = await self._embed(descriptions) if all(descriptions) else None
-        if units is not None and _min_pairwise_cosine(units) >= self.same_name_threshold:
-            return [(group[0], group[1:])]  # coherent → one entity (type wobble)
-        # No evidence to cross types: only fold exact same-type duplicates.
+        if units is not None:
+            single_type = len({n.label for n in group}) == 1
+            bar = self.same_name_threshold if single_type else self.cross_type_threshold
+            if _min_pairwise_cosine(units) >= bar:
+                return [(group[0], group[1:])]  # coherent → one entity (type wobble)
+        # Not enough evidence to cross types: only fold exact same-type duplicates.
         return [
             (same_type[0], same_type[1:])
             for same_type in _group_by(group, key=lambda n: n.label)
@@ -289,26 +294,31 @@ class IncrementalResolution(ResolutionStrategy):
     async def _fetch_candidates(self, survivors: list[GraphNode]) -> list[list[GraphNode]]:
         """For each survivor, the existing graph entities that look like it.
 
-        A retriever failure for one survivor degrades to "no candidates" (that
-        entity is treated as new) rather than aborting the whole document —
-        keeping with the strategy's fail-toward-splitting stance.
+        Lookups run concurrently (``gather`` preserves order, which the piling
+        step relies on). A retriever failure for one survivor degrades to "no
+        candidates" — that entity is treated as new rather than aborting the
+        whole document, keeping the fail-toward-splitting stance.
         """
         if self.candidate_retriever is None:
             return [[] for _ in survivors]
+        results = await asyncio.gather(
+            *(
+                self.candidate_retriever(_name_of(s), _description_of(s), self.top_k)
+                for s in survivors
+            ),
+            return_exceptions=True,
+        )
         found: list[list[GraphNode]] = []
-        for survivor in survivors:
-            try:
-                candidates = await self.candidate_retriever(
-                    _name_of(survivor), _description_of(survivor), self.top_k
-                )
-                found.append(list(candidates))
-            except Exception as exc:  # pragma: no cover - defensive
+        for survivor, result in zip(survivors, results, strict=True):
+            if isinstance(result, Exception):
                 logger.warning(
                     "IncrementalResolution: candidate retrieval failed for %r: %s",
                     _name_of(survivor),
-                    exc,
+                    result,
                 )
                 found.append([])
+            else:
+                found.append(list(result))
         return found
 
     @staticmethod
@@ -342,8 +352,17 @@ class IncrementalResolution(ResolutionStrategy):
 
         by_ref = {item.ref: item for item in items}
         merged = 0
+        consumed: set[int] = set()  # refs already placed by an earlier group
         for group in decisions:
-            members = [by_ref[r] for r in group.members if r in by_ref]
+            member_refs = [r for r in group.members if r in by_ref]
+            # Enforce a disjoint partition: a sloppy-but-parseable LLM response
+            # can reuse a ref across groups, which would double-absorb a node and
+            # let the last-wins remap merge unrelated entities. Drop any group
+            # that reuses a ref — fail toward splitting.
+            if any(r in consumed for r in member_refs):
+                continue
+            consumed.update(member_refs)
+            members = [by_ref[r] for r in member_refs]
             survivor_members = [m.survivor_idx for m in members if m.survivor_idx is not None]
             if not survivor_members:
                 continue  # a group of only existing nodes — nothing new to place

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
@@ -1,0 +1,509 @@
+"""Incremental, graph-aware entity resolution.
+
+Most resolvers deduplicate a document's entities *among themselves*. This one
+resolves them **against the knowledge graph built so far**, so a mention in
+today's document can be linked to an entity extracted from a document ingested
+last week — the case ordinary batch resolution structurally cannot see.
+
+The algorithm is a funnel: cheap, certain work first; the language model only
+where cheap signals genuinely cannot decide.
+
+    ┌ 1. collapse ─ merge a batch's own same-name duplicates            (free)
+    │ 2. retrieve ─ for each survivor, fetch look-alike graph entities  (free)
+    │ 3. pile     ─ group survivors that share a candidate              (free)
+    └ 4. link     ─ ask the LLM, per pile: which are the same entity,
+                    and which existing node (if any) is the target      (LLM)
+
+Two duplication axes, each handled where it is cheapest and most reliable:
+
+* **same name, different type** (``GraphRAG`` the *Concept* vs the *Technology*)
+  is resolved in step 1 by description similarity — no model call. An LLM asked
+  to be careful tends to *over-split* these; the embedding is both cheaper and
+  more accurate.
+* **different name, same entity** (``llama_index`` ≈ ``LlamaIndex``, or a new
+  mention of an existing ``Gal Sh``) is resolved in step 4, where the model is
+  asked to *partition* a small pile — the framing that keeps genuine
+  look-alikes apart (``FALKORDB_USERNAME`` ≠ ``FALKORDB_PASSWORD``).
+
+Design choices worth knowing:
+
+* **Fail toward splitting.** When evidence is thin or a call errors, entities
+  stay separate. A stray duplicate is recoverable later; a wrong merge is data
+  loss.
+* **Existing nodes win.** When a batch entity links to a graph node, the graph
+  node's id survives, so the store's ``MERGE (n {id})`` write attaches the new
+  mention with no special-casing and existing edges are untouched.
+* **Facts are never invented.** The LLM owns free text (canonical name, type,
+  merged description); provenance is unioned and immutable-property conflicts
+  are *flagged*, never guessed.
+
+The graph lookup is injected as ``candidate_retriever``, so the strategy is
+fully testable without a live database; in production it wraps the graph
+store's name/vector search.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections import defaultdict
+from collections.abc import Awaitable, Callable, Iterable, Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import GraphData, GraphNode, ResolutionResult
+from graphrag_sdk.core.providers import Embedder, LLMInterface
+from graphrag_sdk.ingestion.resolution_strategies.base import (
+    ResolutionStrategy,
+    remap_relationships,
+)
+
+logger = logging.getLogger(__name__)
+
+_SEPARATORS = re.compile(r"[\s\-_]+")
+
+# Internal property keys the resolver writes; never treated as extracted facts.
+_SOURCE_IDS = "source_chunk_ids"
+_CONFLICTS = "_merge_conflicts"
+_NEEDS_REVIEW = "_needs_review"
+
+
+def normalize_name(name: str) -> str:
+    """Fold case and separators so surface variants share one key.
+
+    ``"GraphRAG-SDK"``, ``"graphrag_sdk"`` and ``"GraphRAG SDK"`` all normalize
+    to ``"graphrag sdk"``.
+    """
+    return _SEPARATORS.sub(" ", str(name).strip().lower()).strip()
+
+
+# Returns the existing graph entities that look like ``(name, description)``.
+# ``GraphNode.id`` is the live graph id, used as the merge target.
+CandidateRetriever = Callable[[str, str, int], Awaitable[Sequence[GraphNode]]]
+
+
+_LINK_PROMPT = (
+    "You are linking newly extracted entities to an existing knowledge graph.\n"
+    "Each item has: ref, origin ('new' = just extracted, 'graph' = already in "
+    "the graph), name, type, description.\n\n"
+    "Items:\n{items}\n\n"
+    "Group items that are the SAME real-world entity. Rules:\n"
+    "- Group two items only if they truly denote the same entity (spelling "
+    "variants, abbreviations). Similar names for different things (e.g. two "
+    "people who share a first name) must stay in separate groups.\n"
+    "- If a group contains a 'graph' item, the new items merge INTO it: set "
+    "target to that item's ref.\n"
+    "- If a group has only 'new' items, it is a new entity: target = \"new\".\n"
+    "- A 'graph' item that matches nothing is left out of every group.\n\n"
+    "Respond with JSON only:\n"
+    '{{"groups": [{{"members": [refs...], "target": <ref or "new">, '
+    '"canonical": "<name>", "type": "<type>", '
+    '"description": "<merged description, max {max_tokens} tokens>"}}]}}'
+)
+
+
+@dataclass(frozen=True)
+class _PileItem:
+    """One entry the LLM sees, tagged so its verdict can be mapped back."""
+
+    ref: int                    # 1-based label used in the prompt
+    node: GraphNode
+    survivor_idx: int | None    # index into ``survivors`` when freshly extracted
+    graph_id: str | None        # live graph id when already in the graph
+
+    @property
+    def origin(self) -> str:
+        return "new" if self.survivor_idx is not None else "graph"
+
+
+@dataclass(frozen=True)
+class _LinkDecision:
+    """One parsed group from the LLM's partition of a pile."""
+
+    members: list[int]          # refs the model judged to be the same entity
+    target: int | str           # a graph item's ref, or "new"
+    canonical: str | None
+    type: str | None
+    description: str | None
+
+
+class IncrementalResolution(ResolutionStrategy):
+    """Resolve a document's entities against the existing graph (see module doc).
+
+    Args:
+        llm: Partitions ambiguous piles and writes merged descriptions — one
+            call per pile. Without it, resolution reduces to the free
+            within-batch collapse (step 1 only).
+        embedder: Scores description similarity for the within-batch collapse.
+        candidate_retriever: ``async (name, description, k) -> [GraphNode]``
+            returning look-alike existing graph nodes. Without it, this behaves
+            as a within-batch resolver.
+        top_k: Candidates fetched per survivor.
+        pile_cap: Upper bound on items (survivors + candidates) sent to the LLM
+            in a single call, so a crowded name cannot blow up a prompt.
+        same_name_threshold: Minimum pairwise description cosine at which
+            same-name entities auto-merge for free. Same name is already strong
+            evidence, so this bar is deliberately low; genuine homographs
+            (Paris the city vs the person) fall below it and stay separate.
+        max_summary_tokens: Budget hint for LLM-written merged descriptions.
+        immutable_props: Properties that must not change on merge. A conflict
+            flags the survivor for review instead of silently picking a value —
+            often the sign of a wrong merge.
+    """
+
+    def __init__(
+        self,
+        llm: LLMInterface | None = None,
+        embedder: Embedder | None = None,
+        candidate_retriever: CandidateRetriever | None = None,
+        *,
+        top_k: int = 3,
+        pile_cap: int = 12,
+        same_name_threshold: float = 0.80,
+        max_summary_tokens: int = 300,
+        immutable_props: Sequence[str] = (),
+    ) -> None:
+        self.llm = llm
+        self.embedder = embedder
+        self.candidate_retriever = candidate_retriever
+        self.top_k = top_k
+        self.pile_cap = pile_cap
+        self.same_name_threshold = same_name_threshold
+        self.max_summary_tokens = max_summary_tokens
+        self.immutable_props = frozenset(immutable_props)
+
+    async def resolve(self, graph_data: GraphData, ctx: Context) -> ResolutionResult:
+        nodes = list(graph_data.nodes)
+        if not nodes:
+            return ResolutionResult(nodes=[], relationships=[], merged_count=0, remap={})
+        ctx.log(f"IncrementalResolution: resolving {len(nodes)} extracted entities")
+
+        # 1. Collapse the batch's own same-name duplicates (free).
+        survivors, remap, merged = await self._collapse_within_batch(nodes)
+
+        # 2. Fetch look-alike existing entities for each survivor (free).
+        candidates = await self._fetch_candidates(survivors)
+
+        # 3. Group survivors that share a candidate into piles (free).
+        # 4. Ask the LLM to link each pile against the graph (LLM).
+        for pile in self._partition_into_piles(candidates):
+            if self.llm is None or not any(candidates[i] for i in pile):
+                continue  # nothing to link → these survivors are new; keep as-is
+            merged += await self._link_pile(pile, survivors, candidates, remap)
+
+        _flatten(remap)
+        absorbed = set(remap)
+        surviving_nodes = [n for n in survivors if n.id not in absorbed]
+        relationships = remap_relationships(graph_data.relationships, remap)
+        ctx.log(
+            f"IncrementalResolution: {len(surviving_nodes)} entities "
+            f"({merged} merged or linked)"
+        )
+        return ResolutionResult(
+            nodes=surviving_nodes,
+            relationships=relationships,
+            merged_count=merged,
+            remap=remap,
+        )
+
+    # ── step 1: within-batch collapse ──────────────────────────────────────
+
+    async def _collapse_within_batch(
+        self, nodes: list[GraphNode]
+    ) -> tuple[list[GraphNode], dict[str, str], int]:
+        """Merge same-name duplicates the extractor produced in this document.
+
+        Within one name group: if the descriptions are coherent the whole group
+        is one entity (type wobble); otherwise only exact same-type duplicates
+        merge and any genuine homograph is preserved for the LLM to judge later.
+        """
+        remap: dict[str, str] = {}
+        merged = 0
+        absorbed: set[int] = set()  # tracked by object identity — ids may collide
+
+        for group in _group_by(nodes, key=lambda n: normalize_name(_name_of(n))):
+            if len(group) < 2:
+                continue
+            for survivor, losers in await self._same_name_merges(group):
+                for loser in losers:
+                    self._absorb(survivor, loser)
+                    if loser.id != survivor.id:
+                        remap[loser.id] = survivor.id
+                    absorbed.add(id(loser))
+                    merged += 1
+
+        survivors = [n for n in nodes if id(n) not in absorbed]
+        return survivors, remap, merged
+
+    async def _same_name_merges(
+        self, group: list[GraphNode]
+    ) -> list[tuple[GraphNode, list[GraphNode]]]:
+        """Yield ``(survivor, losers)`` pairs for one same-name group."""
+        units = await self._embed(_descriptions(group))
+        if units is not None and _min_pairwise_cosine(units) >= self.same_name_threshold:
+            return [(group[0], group[1:])]  # coherent → one entity (type wobble)
+        # Incoherent (or no embedder): only fold exact same-type duplicates.
+        return [
+            (same_type[0], same_type[1:])
+            for same_type in _group_by(group, key=lambda n: n.label)
+            if len(same_type) >= 2
+        ]
+
+    # ── step 2 & 3: candidate retrieval and piling ─────────────────────────
+
+    async def _fetch_candidates(
+        self, survivors: list[GraphNode]
+    ) -> list[list[GraphNode]]:
+        """For each survivor, the existing graph entities that look like it."""
+        if self.candidate_retriever is None:
+            return [[] for _ in survivors]
+        return [
+            list(await self.candidate_retriever(_name_of(s), _description_of(s), self.top_k))
+            for s in survivors
+        ]
+
+    @staticmethod
+    def _partition_into_piles(candidates: list[list[GraphNode]]) -> list[list[int]]:
+        """Group survivor indices that share at least one candidate.
+
+        Survivors linked through a common graph node must be judged together, so
+        the LLM can, say, route three spellings of one name onto the same
+        existing entity in a single call.
+        """
+        shared: dict[str, list[int]] = defaultdict(list)
+        for i, cands in enumerate(candidates):
+            for c in cands:
+                shared[c.id].append(i)
+        return _connected_components(len(candidates), shared.values())
+
+    # ── step 4: link a pile against the graph via the LLM ──────────────────
+
+    async def _link_pile(
+        self,
+        pile: list[int],
+        survivors: list[GraphNode],
+        candidates: list[list[GraphNode]],
+        remap: dict[str, str],
+    ) -> int:
+        """Partition one pile with the LLM and apply the resulting merges."""
+        items = self._build_pile(pile, survivors, candidates)
+        decisions = await self._ask(items)
+        if decisions is None:
+            return 0  # fail-safe: unparseable verdict → leave the pile untouched
+
+        by_ref = {item.ref: item for item in items}
+        graph_id_by_ref = {item.ref: item.graph_id for item in items if item.graph_id}
+        merged = 0
+        for group in decisions:
+            members = [by_ref[r] for r in group.members if r in by_ref]
+            survivor_members = [m.survivor_idx for m in members if m.survivor_idx is not None]
+            if not survivor_members:
+                continue  # a group of only existing nodes — nothing new to place
+
+            carrier = survivors[survivor_members[0]]
+            target_id = graph_id_by_ref.get(group.target) if isinstance(group.target, int) else None
+            final_id = target_id or carrier.id
+
+            for idx in survivor_members[1:]:
+                self._absorb(carrier, survivors[idx])
+                remap[survivors[idx].id] = final_id
+                merged += 1
+            if final_id != carrier.id:
+                remap[carrier.id] = final_id  # link this batch entity onto a graph node
+                merged += 1
+
+            _apply_canonical(carrier, final_id, group)
+        return merged
+
+    def _build_pile(
+        self,
+        pile: list[int],
+        survivors: list[GraphNode],
+        candidates: list[list[GraphNode]],
+    ) -> list[_PileItem]:
+        """Assemble the labelled items for one LLM call: survivors then their
+        deduplicated candidates, capped at ``pile_cap``."""
+        items = [
+            _PileItem(ref=n + 1, node=survivors[i], survivor_idx=i, graph_id=None)
+            for n, i in enumerate(pile)
+        ]
+        seen: set[str] = set()
+        for i in pile:
+            if len(items) >= self.pile_cap:
+                break
+            for cand in candidates[i]:
+                if cand.id in seen:
+                    continue
+                seen.add(cand.id)
+                items.append(_PileItem(ref=len(items) + 1, node=cand,
+                                       survivor_idx=None, graph_id=cand.id))
+                if len(items) >= self.pile_cap:
+                    break
+        return items
+
+    async def _ask(self, items: list[_PileItem]) -> list[_LinkDecision] | None:
+        """Send one partition request and parse it; ``None`` on any failure."""
+        lines = "\n".join(
+            f"[{it.ref}] origin={it.origin} name={_name_of(it.node)!r} "
+            f"type={it.node.label} desc={_description_of(it.node)[:180]!r}"
+            for it in items
+        )
+        prompt = _LINK_PROMPT.format(items=lines, max_tokens=self.max_summary_tokens)
+        results = await self.llm.abatch_invoke([prompt])
+        if results and results[0].ok:
+            return _parse_decisions(results[0].response.content)
+        return None
+
+    # ── shared helpers ─────────────────────────────────────────────────────
+
+    def _absorb(self, survivor: GraphNode, loser: GraphNode) -> None:
+        """Fold ``loser`` into ``survivor``: union provenance, keep the
+        survivor's values, and flag any immutable-property disagreement."""
+        sources = _unique(
+            survivor.properties.get(_SOURCE_IDS) or [],
+            loser.properties.get(_SOURCE_IDS) or [],
+        )
+        if sources:
+            survivor.properties[_SOURCE_IDS] = sources
+
+        conflicts = list(survivor.properties.get(_CONFLICTS, []))
+        for key, value in loser.properties.items():
+            if key in (_SOURCE_IDS, _CONFLICTS, _NEEDS_REVIEW):
+                continue
+            if key not in survivor.properties:
+                survivor.properties[key] = value
+            elif key in self.immutable_props and survivor.properties[key] != value:
+                conflicts.append({"field": key, "values": [survivor.properties[key], value]})
+        if conflicts:
+            survivor.properties[_CONFLICTS] = conflicts
+            survivor.properties[_NEEDS_REVIEW] = True
+
+    async def _embed(self, texts: list[str]) -> np.ndarray | None:
+        """Return unit-normalized row vectors for ``texts``, or ``None`` if no
+        embedder is configured or embedding fails."""
+        if self.embedder is None or not texts:
+            return None
+        try:
+            raw = await self.embedder.aembed_documents(texts)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("IncrementalResolution: embedding failed: %s", exc)
+            return None
+        matrix = np.array([v or [0.0] for v in raw], dtype=np.float32)
+        if matrix.shape[1] <= 1:
+            return None
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        return matrix / norms
+
+
+# ── module-level helpers ───────────────────────────────────────────────────
+
+
+def _apply_canonical(node: GraphNode, final_id: str, decision: _LinkDecision) -> None:
+    """Retarget ``node`` to ``final_id`` and apply the LLM's canonical fields."""
+    node.id = final_id
+    if decision.canonical:
+        node.properties["name"] = decision.canonical
+    if decision.type:
+        node.label = decision.type
+    if decision.description:
+        node.properties["description"] = decision.description
+
+
+def _connected_components(size: int, edges: Iterable[list[int]]) -> list[list[int]]:
+    """Union-find components over ``size`` items linked by each group in ``edges``."""
+    parent = list(range(size))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for members in edges:
+        for other in members[1:]:
+            parent[find(other)] = find(members[0])
+
+    components: dict[int, list[int]] = defaultdict(list)
+    for i in range(size):
+        components[find(i)].append(i)
+    return list(components.values())
+
+
+def _group_by(items: Iterable, key: Callable) -> list[list]:
+    """Stable group-by that preserves first-seen order of keys and members."""
+    groups: dict = defaultdict(list)
+    for item in items:
+        groups[key(item)].append(item)
+    return list(groups.values())
+
+
+def _min_pairwise_cosine(units: np.ndarray) -> float:
+    """Smallest cosine similarity among unit-normalized row vectors."""
+    similarities = units @ units.T
+    return float(similarities[np.triu_indices(len(units), k=1)].min())
+
+
+def _unique(*sequences: Sequence[str]) -> list[str]:
+    """Order-preserving union of string sequences."""
+    seen: dict[str, None] = {}
+    for seq in sequences:
+        for value in seq:
+            seen.setdefault(value, None)
+    return list(seen)
+
+
+def _name_of(node: GraphNode) -> str:
+    return str(node.properties.get("name", node.id))
+
+
+def _description_of(node: GraphNode) -> str:
+    return str(node.properties.get("description") or node.properties.get("name") or "")
+
+
+def _descriptions(nodes: Iterable[GraphNode]) -> list[str]:
+    return [_description_of(n) for n in nodes]
+
+
+def _parse_decisions(content: str) -> list[_LinkDecision] | None:
+    """Parse the LLM's JSON partition; ``None`` on anything malformed."""
+    if not content:
+        return None
+    start, end = content.find("{"), content.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        payload = json.loads(content[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    groups = payload.get("groups")
+    if not isinstance(groups, list):
+        return None
+
+    decisions = []
+    for group in groups:
+        if not isinstance(group, dict) or not isinstance(group.get("members"), list):
+            continue
+        members = [int(r) for r in group["members"] if isinstance(r, (int, float))]
+        if members:
+            decisions.append(_LinkDecision(
+                members=members,
+                target=group.get("target", "new"),
+                canonical=group.get("canonical"),
+                type=group.get("type"),
+                description=group.get("description"),
+            ))
+    return decisions or None
+
+
+def _flatten(remap: dict[str, str]) -> None:
+    """Collapse transitive chains in place so every key maps to its final id."""
+    for key in list(remap):
+        target, seen = remap[key], {key}
+        while target in remap and target not in seen:
+            seen.add(target)
+            target = remap[target]
+        remap[key] = target

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
@@ -55,6 +55,7 @@ import numpy as np
 
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import GraphData, GraphNode, ResolutionResult
+from graphrag_sdk.core.prompts import ENTITY_DESCRIPTION_RULE
 from graphrag_sdk.core.providers import Embedder, LLMInterface
 from graphrag_sdk.ingestion.resolution_strategies.base import (
     ResolutionStrategy,
@@ -98,10 +99,13 @@ _LINK_PROMPT = (
     "target to that item's ref.\n"
     "- If a group has only 'new' items, it is a new entity: target = \"new\".\n"
     "- A 'graph' item that matches nothing is left out of every group.\n\n"
+    "Each group is ONE entity and gets its OWN 'description' (never shared "
+    "across groups). Write that entity's description by merging the descriptions "
+    "of the items IN THAT GROUP, following this rule: " + ENTITY_DESCRIPTION_RULE + "\n\n"
     "Respond with JSON only:\n"
     '{{"groups": [{{"members": [refs...], "target": <ref or "new">, '
     '"canonical": "<name>", "type": "<type>", '
-    '"description": "<merged description, max {max_tokens} tokens>"}}]}}'
+    '"description": "<merged description per the rule above, at most {max_tokens} tokens>"}}]}}'
 )
 
 
@@ -394,10 +398,17 @@ class IncrementalResolution(ResolutionStrategy):
         return items
 
     async def _ask(self, items: list[_PileItem]) -> list[_LinkDecision] | None:
-        """Send one partition request and parse it; ``None`` on any failure."""
+        """Send one partition request and parse it; ``None`` on any failure.
+
+        Descriptions are sent in FULL, not truncated: extraction and this step
+        both write them under ``ENTITY_DESCRIPTION_RULE``, so they are already
+        bounded. Truncating the input here is what eroded rich descriptions
+        across repeated merges — the model would rewrite from a snippet and the
+        result would overwrite the stored full text.
+        """
         lines = "\n".join(
             f"[{it.ref}] origin={it.origin} name={_name_of(it.node)!r} "
-            f"type={it.node.label} desc={_description_of(it.node)[:180]!r}"
+            f"type={it.node.label} desc={_description_of(it.node)!r}"
             for it in items
         )
         prompt = _LINK_PROMPT.format(items=lines, max_tokens=self.max_summary_tokens)

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
@@ -254,13 +254,29 @@ class IncrementalResolution(ResolutionStrategy):
     # ── step 2 & 3: candidate retrieval and piling ─────────────────────────
 
     async def _fetch_candidates(self, survivors: list[GraphNode]) -> list[list[GraphNode]]:
-        """For each survivor, the existing graph entities that look like it."""
+        """For each survivor, the existing graph entities that look like it.
+
+        A retriever failure for one survivor degrades to "no candidates" (that
+        entity is treated as new) rather than aborting the whole document —
+        keeping with the strategy's fail-toward-splitting stance.
+        """
         if self.candidate_retriever is None:
             return [[] for _ in survivors]
-        return [
-            list(await self.candidate_retriever(_name_of(s), _description_of(s), self.top_k))
-            for s in survivors
-        ]
+        found: list[list[GraphNode]] = []
+        for survivor in survivors:
+            try:
+                candidates = await self.candidate_retriever(
+                    _name_of(survivor), _description_of(survivor), self.top_k
+                )
+                found.append(list(candidates))
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "IncrementalResolution: candidate retrieval failed for %r: %s",
+                    _name_of(survivor),
+                    exc,
+                )
+                found.append([])
+        return found
 
     @staticmethod
     def _partition_into_piles(candidates: list[list[GraphNode]]) -> list[list[int]]:
@@ -292,7 +308,6 @@ class IncrementalResolution(ResolutionStrategy):
             return 0  # fail-safe: unparseable verdict → leave the pile untouched
 
         by_ref = {item.ref: item for item in items}
-        graph_id_by_ref = {item.ref: item.graph_id for item in items if item.graph_id}
         merged = 0
         for group in decisions:
             members = [by_ref[r] for r in group.members if r in by_ref]
@@ -301,8 +316,15 @@ class IncrementalResolution(ResolutionStrategy):
                 continue  # a group of only existing nodes — nothing new to place
 
             carrier = survivors[survivor_members[0]]
-            target_id = graph_id_by_ref.get(group.target) if isinstance(group.target, int) else None
-            final_id = target_id or carrier.id
+            target = by_ref.get(group.target) if isinstance(group.target, int) else None
+            if target is not None and target.graph_id is not None:
+                # Link into an existing node: keep its id AND its label. Graph
+                # writes are label-scoped (``MERGE (n:<label> {id})``), so a
+                # different label would create a second same-id node instead of
+                # updating the existing one.
+                final_id, final_label = target.graph_id, target.node.label
+            else:
+                final_id, final_label = carrier.id, group.type or carrier.label
 
             for idx in survivor_members[1:]:
                 self._absorb(carrier, survivors[idx])
@@ -312,7 +334,7 @@ class IncrementalResolution(ResolutionStrategy):
                 remap[carrier.id] = final_id  # link this batch entity onto a graph node
                 merged += 1
 
-            _apply_canonical(carrier, final_id, group)
+            _apply_canonical(carrier, final_id, final_label, group)
         return merged
 
     def _build_pile(
@@ -400,13 +422,16 @@ class IncrementalResolution(ResolutionStrategy):
 # ── module-level helpers ───────────────────────────────────────────────────
 
 
-def _apply_canonical(node: GraphNode, final_id: str, decision: _LinkDecision) -> None:
-    """Retarget ``node`` to ``final_id`` and apply the LLM's canonical fields."""
+def _apply_canonical(
+    node: GraphNode, final_id: str, final_label: str, decision: _LinkDecision
+) -> None:
+    """Retarget ``node`` to ``(final_id, final_label)`` and apply the LLM's
+    canonical name and description. The label is resolved by the caller so that
+    linking into an existing graph node preserves that node's label."""
     node.id = final_id
+    node.label = final_label
     if decision.canonical:
         node.properties["name"] = decision.canonical
-    if decision.type:
-        node.label = decision.type
     if decision.description:
         node.properties["description"] = decision.description
 
@@ -485,18 +510,37 @@ def _parse_decisions(content: str) -> list[_LinkDecision] | None:
     for group in groups:
         if not isinstance(group, dict) or not isinstance(group.get("members"), list):
             continue
-        members = [int(r) for r in group["members"] if isinstance(r, (int, float))]
+        members = [r for r in map(_as_ref, group["members"]) if r is not None]
         if members:
+            target = _as_ref(group.get("target"))
             decisions.append(
                 _LinkDecision(
                     members=members,
-                    target=group.get("target", "new"),
+                    target=target if target is not None else "new",
                     canonical=group.get("canonical"),
                     type=group.get("type"),
                     description=group.get("description"),
                 )
             )
     return decisions or None
+
+
+def _as_ref(value: object) -> int | None:
+    """Coerce an int-like value (``5``, ``5.0``, ``"5"``) to an int ref.
+
+    LLMs are inconsistent about number formatting, so a group's members and its
+    ``target`` may arrive as strings or floats. Anything not cleanly integer —
+    including ``"new"``, booleans and fractional floats — returns ``None``.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else None
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value)
+    return None
 
 
 def _flatten(remap: dict[str, str]) -> None:

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/resolution_strategies/incremental_resolution.py
@@ -109,10 +109,10 @@ _LINK_PROMPT = (
 class _PileItem:
     """One entry the LLM sees, tagged so its verdict can be mapped back."""
 
-    ref: int                    # 1-based label used in the prompt
+    ref: int  # 1-based label used in the prompt
     node: GraphNode
-    survivor_idx: int | None    # index into ``survivors`` when freshly extracted
-    graph_id: str | None        # live graph id when already in the graph
+    survivor_idx: int | None  # index into ``survivors`` when freshly extracted
+    graph_id: str | None  # live graph id when already in the graph
 
     @property
     def origin(self) -> str:
@@ -123,8 +123,8 @@ class _PileItem:
 class _LinkDecision:
     """One parsed group from the LLM's partition of a pile."""
 
-    members: list[int]          # refs the model judged to be the same entity
-    target: int | str           # a graph item's ref, or "new"
+    members: list[int]  # refs the model judged to be the same entity
+    target: int | str  # a graph item's ref, or "new"
     canonical: str | None
     type: str | None
     description: str | None
@@ -199,8 +199,7 @@ class IncrementalResolution(ResolutionStrategy):
         surviving_nodes = [n for n in survivors if n.id not in absorbed]
         relationships = remap_relationships(graph_data.relationships, remap)
         ctx.log(
-            f"IncrementalResolution: {len(surviving_nodes)} entities "
-            f"({merged} merged or linked)"
+            f"IncrementalResolution: {len(surviving_nodes)} entities ({merged} merged or linked)"
         )
         return ResolutionResult(
             nodes=surviving_nodes,
@@ -254,9 +253,7 @@ class IncrementalResolution(ResolutionStrategy):
 
     # ── step 2 & 3: candidate retrieval and piling ─────────────────────────
 
-    async def _fetch_candidates(
-        self, survivors: list[GraphNode]
-    ) -> list[list[GraphNode]]:
+    async def _fetch_candidates(self, survivors: list[GraphNode]) -> list[list[GraphNode]]:
         """For each survivor, the existing graph entities that look like it."""
         if self.candidate_retriever is None:
             return [[] for _ in survivors]
@@ -338,8 +335,9 @@ class IncrementalResolution(ResolutionStrategy):
                 if cand.id in seen:
                     continue
                 seen.add(cand.id)
-                items.append(_PileItem(ref=len(items) + 1, node=cand,
-                                       survivor_idx=None, graph_id=cand.id))
+                items.append(
+                    _PileItem(ref=len(items) + 1, node=cand, survivor_idx=None, graph_id=cand.id)
+                )
                 if len(items) >= self.pile_cap:
                     break
         return items
@@ -489,13 +487,15 @@ def _parse_decisions(content: str) -> list[_LinkDecision] | None:
             continue
         members = [int(r) for r in group["members"] if isinstance(r, (int, float))]
         if members:
-            decisions.append(_LinkDecision(
-                members=members,
-                target=group.get("target", "new"),
-                canonical=group.get("canonical"),
-                type=group.get("type"),
-                description=group.get("description"),
-            ))
+            decisions.append(
+                _LinkDecision(
+                    members=members,
+                    target=group.get("target", "new"),
+                    canonical=group.get("canonical"),
+                    type=group.get("type"),
+                    description=group.get("description"),
+                )
+            )
     return decisions or None
 
 

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -14,6 +14,7 @@ from typing import Any
 from graphrag_sdk.core.connection import FalkorDBConnection
 from graphrag_sdk.core.exceptions import DatabaseError
 from graphrag_sdk.core.models import DocumentRecord, GraphNode, GraphRelationship
+from graphrag_sdk.core.text import name_key
 from graphrag_sdk.utils.cypher import sanitize_cypher_label
 
 logger = logging.getLogger(__name__)
@@ -96,13 +97,13 @@ class GraphStore:
             # Process in batches
             for start in range(0, len(cleaned_group), self._BATCH_SIZE):
                 batch = cleaned_group[start : start + self._BATCH_SIZE]
-                batch_data = [
-                    {
-                        "id": cid,
-                        "properties": self._clean_properties(n.properties),
-                    }
-                    for n, cid in batch
-                ]
+                batch_data = []
+                for n, cid in batch:
+                    props = self._clean_properties(n.properties)
+                    if is_entity:
+                        # Indexed lookup key for name-based candidate retrieval.
+                        props["name_key"] = name_key(str(n.properties.get("name", cid)))
+                    batch_data.append({"id": cid, "properties": props})
                 query = (
                     f"UNWIND $batch AS item "
                     f"MERGE (n:`{safe_label}` {{id: item.id}}) "
@@ -122,12 +123,11 @@ class GraphStore:
                     for node, cid in batch:
                         safe_node_label = sanitize_cypher_label(node.label)
                         q = f"MERGE (n:`{safe_node_label}` {{id: $id}}) SET n += $properties"
+                        props = self._clean_properties(node.properties)
                         if is_entity:
                             q += " SET n:__Entity__"
-                        params = {
-                            "id": cid,
-                            "properties": self._clean_properties(node.properties),
-                        }
+                            props["name_key"] = name_key(str(node.properties.get("name", cid)))
+                        params = {"id": cid, "properties": props}
                         try:
                             await self._conn.query(q, params)
                             count += 1
@@ -330,6 +330,18 @@ class GraphStore:
         for standard operations.
         """
         return await self._conn.query(cypher, params)
+
+    async def ensure_name_key_index(self) -> None:
+        """Create the range index on ``__Entity__(name_key)`` if absent.
+
+        Idempotent — a re-create raises and is swallowed. This is what lets
+        name-based candidate retrieval use an indexed equality lookup instead
+        of scanning every entity per query.
+        """
+        try:
+            await self._conn.query("CREATE INDEX FOR (n:__Entity__) ON (n.name_key)")
+        except Exception:
+            pass  # already exists
 
     # ── Statistics ────────────────────────────────────────────────
 

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -331,17 +331,65 @@ class GraphStore:
         """
         return await self._conn.query(cypher, params)
 
-    async def ensure_name_key_index(self) -> None:
+    async def ensure_name_key_index(self) -> bool:
         """Create the range index on ``__Entity__(name_key)`` if absent.
 
-        Idempotent — a re-create raises and is swallowed. This is what lets
-        name-based candidate retrieval use an indexed equality lookup instead
-        of scanning every entity per query.
+        Idempotent: an "already indexed" error means the index is in place and
+        is treated as success. Any *other* failure (permissions, syntax, a
+        transient connection drop) is logged and reported as ``False`` so the
+        caller can tell the index is not actually ready rather than assuming it
+        is. This is what lets name-based candidate retrieval use an indexed
+        equality lookup instead of scanning every entity per query.
+
+        Returns:
+            ``True`` if the index exists (created now or already present),
+            ``False`` if creation failed for an unexpected reason.
         """
         try:
             await self._conn.query("CREATE INDEX FOR (n:__Entity__) ON (n.name_key)")
-        except Exception:
-            pass  # already exists
+            return True
+        except Exception as exc:
+            if "already" in str(exc).lower():
+                return True  # already indexed — the desired end state
+            logger.warning("Could not create name_key index: %s", exc)
+            return False
+
+    async def backfill_name_keys(self, batch_size: int = 1000) -> int:
+        """Populate ``name_key`` on entities that predate the property.
+
+        Entities ingested before ``name_key`` existed have no such property, so
+        the indexed ``WHERE n.name_key = $key`` lookup can never match them —
+        exactly the cross-document links :class:`IncrementalResolution` needs on
+        an upgraded graph. This one-time pass reads those nodes and computes the
+        key in Python (the fold is a regex the store already owns and Cypher
+        cannot express cleanly), so legacy entities become matchable.
+
+        Returns:
+            The number of entities updated.
+        """
+        updated = 0
+        while True:
+            result = await self._conn.query(
+                "MATCH (n:__Entity__) WHERE n.name_key IS NULL AND n.name IS NOT NULL "
+                "RETURN n.id, n.name LIMIT $limit",
+                {"limit": batch_size},
+            )
+            rows = result.result_set if result and result.result_set else []
+            if not rows:
+                break
+            pairs = [
+                {"id": node_id, "key": name_key(str(node_name))} for node_id, node_name in rows
+            ]
+            await self._conn.query(
+                "UNWIND $pairs AS p MATCH (n:__Entity__ {id: p.id}) SET n.name_key = p.key",
+                {"pairs": pairs},
+            )
+            updated += len(pairs)
+            if len(rows) < batch_size:
+                break
+        if updated:
+            logger.info("Backfilled name_key on %d legacy entities", updated)
+        return updated
 
     # ── Statistics ────────────────────────────────────────────────
 

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -115,6 +115,31 @@ class TestGraphRAGInit:
         g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder, retrieval_strategy=strategy, embedding_dimension=8)
         assert g._retrieval_strategy is strategy
 
+    def test_default_resolver_is_incremental_with_llm_and_embedder(
+        self, mock_conn, embedder, llm
+    ):
+        """Lock in the default-resolver selection so a regression can't
+        silently change ingestion cost/behavior (Copilot re-review)."""
+        from graphrag_sdk.ingestion.resolution_strategies.incremental_resolution import (
+            IncrementalResolution,
+        )
+
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder, embedding_dimension=8)
+        assert isinstance(g._default_resolver(), IncrementalResolution)
+
+    def test_default_resolver_falls_back_to_exact_match_without_embedder(
+        self, mock_conn, embedder, llm
+    ):
+        """No embedder → the LLM-free ExactMatchResolution, so lightweight
+        setups keep working with no added embedding cost."""
+        from graphrag_sdk.ingestion.resolution_strategies.exact_match import (
+            ExactMatchResolution,
+        )
+
+        g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder, embedding_dimension=8)
+        g.embedder = None  # simulate an embedder-free setup for the selection check
+        assert isinstance(g._default_resolver(), ExactMatchResolution)
+
     async def test_async_context_manager_returns_self_and_closes(self, mock_conn, embedder, llm):
         g = GraphRAG(connection=mock_conn, llm=llm, embedder=embedder, embedding_dimension=8)
 

--- a/graphrag_sdk/tests/test_graph_store.py
+++ b/graphrag_sdk/tests/test_graph_store.py
@@ -586,3 +586,37 @@ class TestGraphStoreDocumentLifecycle:
         n = await graph_store.delete_orphan_entities(ids)
         assert n == 6
         assert mock_connection.query.await_count == 3
+
+
+class TestNameKeyIndex:
+    async def test_ensure_returns_true_on_create(self, graph_store, mock_connection):
+        assert await graph_store.ensure_name_key_index() is True
+
+    async def test_ensure_returns_true_when_already_indexed(self, graph_store, mock_connection):
+        mock_connection.query = AsyncMock(side_effect=Exception("Index already indexed"))
+        assert await graph_store.ensure_name_key_index() is True
+
+    async def test_ensure_returns_false_on_unexpected_error(self, graph_store, mock_connection):
+        """A real failure (not 'already exists') must be reported so the caller
+        knows the index is not in place, instead of a silent success."""
+        mock_connection.query = AsyncMock(side_effect=Exception("permission denied"))
+        assert await graph_store.ensure_name_key_index() is False
+
+    async def test_backfill_name_keys_computes_and_sets_legacy_keys(
+        self, graph_store, mock_connection
+    ):
+        """Legacy entities with no name_key get one, computed in Python from
+        their name, so an upgraded graph stays matchable."""
+        first = MagicMock(result_set=[["llama__x", "LlamaIndex"], ["gr__y", "GraphRAG-SDK"]])
+        empty = MagicMock(result_set=[])
+        # match(null) → rows, UNWIND SET, match(null) → empty → stop.
+        mock_connection.query = AsyncMock(side_effect=[first, MagicMock(result_set=[]), empty])
+
+        updated = await graph_store.backfill_name_keys()
+        assert updated == 2
+        set_params = mock_connection.query.await_args_list[1][0][1]
+        keys = {p["id"]: p["key"] for p in set_params["pairs"]}
+        assert keys == {"llama__x": "llamaindex", "gr__y": "graphragsdk"}
+
+    async def test_backfill_no_legacy_nodes_is_noop(self, graph_store, mock_connection):
+        assert await graph_store.backfill_name_keys() == 0

--- a/graphrag_sdk/tests/test_incremental_resolution.py
+++ b/graphrag_sdk/tests/test_incremental_resolution.py
@@ -233,6 +233,89 @@ class TestIncrementalResolution:
         assert len(res.nodes) == 1
         assert res.nodes[0].id == "xylo__t"
 
+    async def test_linking_into_existing_node_preserves_its_label(self):
+        """Graph writes are label-scoped, so linking into an existing node must
+        keep that node's label even when the LLM returns a conflicting type —
+        otherwise the store would create a second same-id node."""
+        batch = [
+            GraphNode(
+                id="gal_var__person",
+                label="Person",
+                properties={"name": "gal.sh", "description": "FalkorDB engineer"},
+            ),
+        ]
+        # ref 1 = new (gal.sh), ref 2 = graph (Gal Sh / Person); LLM says "Robot".
+        decision = json.dumps(
+            {
+                "groups": [
+                    {
+                        "members": [1, 2],
+                        "target": 2,
+                        "canonical": "Gal Shubeli",
+                        "type": "Robot",
+                        "description": "Engineer.",
+                    },
+                ]
+            }
+        )
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[decision]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([GAL_SH]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        merged = next(n for n in res.nodes if n.id == "gal_sh__person")
+        assert merged.label == "Person", "existing node's label must be preserved on link"
+
+    async def test_string_or_float_target_still_links(self):
+        """LLM refs emitted as strings/floats still resolve and link correctly."""
+        batch = [
+            GraphNode(
+                id="gal_var__person",
+                label="Person",
+                properties={"name": "gal", "description": "engineer"},
+            ),
+        ]
+        decision = json.dumps(
+            {
+                "groups": [
+                    {
+                        "members": ["1", 2.0],
+                        "target": "2",  # str + float, as some LLMs emit
+                        "canonical": "Gal Sh",
+                        "type": "Person",
+                        "description": "d",
+                    },
+                ]
+            }
+        )
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[decision]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([GAL_SH]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert res.remap.get("gal_var__person") == "gal_sh__person"
+
+    async def test_retriever_failure_degrades_to_new_entity(self):
+        """A retriever that raises must not abort resolution — the entity is
+        simply treated as new (fail toward splitting)."""
+
+        async def boom(name, description, k):
+            raise RuntimeError("graph store unavailable")
+
+        batch = [
+            GraphNode(id="solo__t", label="T", properties={"name": "Solo", "description": "d"}),
+        ]
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[""]),
+            embedder=WordEmbedder(),
+            candidate_retriever=boom,
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert len(res.nodes) == 1
+        assert res.nodes[0].id == "solo__t"
+
     def test_normalize_name_folds_case_and_separators(self):
         assert normalize_name("GraphRAG-SDK") == "graphrag sdk"
         assert normalize_name("graphrag_sdk") == "graphrag sdk"

--- a/graphrag_sdk/tests/test_incremental_resolution.py
+++ b/graphrag_sdk/tests/test_incremental_resolution.py
@@ -1,0 +1,182 @@
+"""Tests for IncrementalResolution — resolve a batch against the existing graph."""
+from __future__ import annotations
+
+import json
+
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import GraphData, GraphNode
+from graphrag_sdk.core.providers import Embedder
+from graphrag_sdk.ingestion.resolution_strategies.incremental_resolution import (
+    IncrementalResolution,
+    normalize_name,
+)
+
+from .conftest import MockLLM
+
+
+class WordEmbedder(Embedder):
+    """Deterministic bag-of-words embedder — shared words → high cosine."""
+
+    def __init__(self) -> None:
+        self._vocab: dict[str, int] = {}
+
+    @property
+    def model_name(self) -> str:
+        return "word-embedder"
+
+    def embed_query(self, text: str, **kw):
+        toks = str(text).lower().split()
+        vec = [0.0] * 64
+        for t in toks:
+            self._vocab.setdefault(t, len(self._vocab) % 64)
+            vec[self._vocab[t] % 64] += 1.0
+        return vec or [0.0] * 64
+
+
+def _ctx():
+    return Context(tenant_id="t", latency_budget_ms=5000.0)
+
+
+# Existing graph nodes (candidates the retriever can return).
+GAL_SH = GraphNode(id="gal_sh__person", label="Person",
+                   properties={"name": "Gal Sh", "description": "Engineer at FalkorDB."})
+GAL_BR = GraphNode(id="gal_br__person", label="Person",
+                   properties={"name": "Gal Br", "description": "Designer at another firm."})
+
+
+def make_retriever(returns):
+    async def retriever(name, description, k):
+        return returns
+    return retriever
+
+
+class TestIncrementalResolution:
+    async def test_links_new_entities_into_existing_node_and_rejects_lookalike(self):
+        """gal / gal.sh / Gal Shubeli → merge INTO existing Gal Sh;
+        Gal Kurland → new; Gal Br (candidate) → rejected."""
+        batch = [
+            GraphNode(id="gal__person", label="Person",
+                      properties={"name": "gal", "description": "works at FalkorDB"}),
+            GraphNode(id="gal.sh__person", label="Person",
+                      properties={"name": "gal.sh", "description": "FalkorDB engineer"}),
+            GraphNode(id="gal_shubeli__person", label="Person",
+                      properties={"name": "Gal Shubeli", "description": "engineer at FalkorDB"}),
+            GraphNode(id="gal_kurland__person", label="Person",
+                      properties={"name": "Gal Kurland", "description": "researcher elsewhere"}),
+        ]
+        # LLM sees refs 1..4 = new (gal, gal.sh, Gal Shubeli, Gal Kurland),
+        # refs 5,6 = graph (Gal Sh, Gal Br).
+        decision = json.dumps({"groups": [
+            {"members": [1, 2, 3, 5], "target": 5,
+             "canonical": "Gal Shubeli", "type": "Person", "description": "Engineer at FalkorDB."},
+            {"members": [4], "target": "new",
+             "canonical": "Gal Kurland", "type": "Person", "description": "A researcher."},
+        ]})
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[decision]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([GAL_SH, GAL_BR]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+
+        ids = {n.id for n in res.nodes}
+        # Merged entity carries the EXISTING graph id, and Gal Kurland is new.
+        assert "gal_sh__person" in ids, "new mentions should link into existing Gal Sh"
+        assert "gal_kurland__person" in ids, "Gal Kurland stays a new entity"
+        assert len(res.nodes) == 2
+        # Gal Br was a candidate only — never written as a batch node.
+        assert "gal_br__person" not in ids
+        # All three gal-variants remap onto the existing node.
+        for old in ("gal__person", "gal.sh__person", "gal_shubeli__person"):
+            assert res.remap.get(old) == "gal_sh__person"
+        merged = next(n for n in res.nodes if n.id == "gal_sh__person")
+        assert merged.properties["name"] == "Gal Shubeli"
+
+    async def test_no_candidates_means_new_entity_no_llm(self):
+        """A survivor with no graph candidates is created as new — LLM untouched."""
+        batch = [GraphNode(id="novel__person", label="Person",
+                           properties={"name": "Nadia Q", "description": "brand new person"})]
+
+        class BoomLLM(MockLLM):
+            def invoke(self, *a, **k):
+                raise AssertionError("LLM must not be called when there are no candidates")
+
+        resolver = IncrementalResolution(
+            llm=BoomLLM(responses=[""]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([]),  # nothing similar in graph
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert len(res.nodes) == 1
+        assert res.nodes[0].id == "novel__person"
+
+    async def test_free_merge_collapses_same_name_before_llm(self):
+        """Same-name/different-type homograph merges for free in stage 1."""
+        batch = [
+            GraphNode(id="graphrag__concept", label="Concept",
+                      properties={"name": "GraphRAG", "description": "graph based RAG technique"}),
+            GraphNode(id="graphrag__technology", label="Technology",
+                      properties={"name": "GraphRAG", "description": "graph based RAG technique"}),
+        ]
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[""]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([]),  # no graph yet
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert len(res.nodes) == 1, "GraphRAG Concept+Technology should free-merge"
+        assert res.remap.get("graphrag__technology") == "graphrag__concept"
+
+    async def test_immutable_conflict_flags_review(self):
+        """Merging nodes that disagree on an immutable prop flags _needs_review."""
+        batch = [
+            GraphNode(id="acme_a__org", label="Org",
+                      properties={"name": "Acme", "description": "a company", "founded": "2001"}),
+            GraphNode(id="acme_b__org", label="Org",
+                      properties={"name": "Acme", "description": "a company", "founded": "1998"}),
+        ]
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[""]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([]),
+            immutable_props=("founded",),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert len(res.nodes) == 1
+        assert res.nodes[0].properties.get("_needs_review") is True
+        assert res.nodes[0].properties.get("_merge_conflicts")
+
+    async def test_genuine_homograph_stays_separate(self):
+        """Same name, different type, divergent descriptions → NOT free-merged."""
+        batch = [
+            GraphNode(id="paris__location", label="Location",
+                      properties={"name": "Paris", "description": "capital city france europe"}),
+            GraphNode(id="paris__person", label="Person",
+                      properties={"name": "Paris",
+                                  "description": "american media personality celebrity"}),
+        ]
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[""]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert len(res.nodes) == 2, "distinct homographs must stay separate"
+
+    async def test_malformed_llm_response_leaves_pile_untouched(self):
+        """An unparseable partition → fail-safe: no merges applied."""
+        batch = [GraphNode(id="xylo__t", label="T",
+                           properties={"name": "Xylo", "description": "d"})]
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=["not valid json"]),  # consulted (has a candidate)
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([GAL_SH]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert len(res.nodes) == 1
+        assert res.nodes[0].id == "xylo__t"
+
+    def test_normalize_name_folds_case_and_separators(self):
+        assert normalize_name("GraphRAG-SDK") == "graphrag sdk"
+        assert normalize_name("graphrag_sdk") == "graphrag sdk"
+        assert normalize_name("  GraphRAG   SDK ") == "graphrag sdk"

--- a/graphrag_sdk/tests/test_incremental_resolution.py
+++ b/graphrag_sdk/tests/test_incremental_resolution.py
@@ -5,14 +5,30 @@ from __future__ import annotations
 import json
 
 from graphrag_sdk.core.context import Context
-from graphrag_sdk.core.models import GraphData, GraphNode
+from graphrag_sdk.core.models import GraphData, GraphNode, LLMResponse
 from graphrag_sdk.core.providers import Embedder
+from graphrag_sdk.core.providers.base import LLMBatchItem
 from graphrag_sdk.ingestion.resolution_strategies.incremental_resolution import (
     IncrementalResolution,
     normalize_name,
 )
 
 from .conftest import MockLLM
+
+
+class CapturingLLM(MockLLM):
+    """Records the prompts sent to ``abatch_invoke`` for assertions."""
+
+    def __init__(self, response: str) -> None:
+        super().__init__(responses=[response])
+        self.prompts: list[str] = []
+
+    async def abatch_invoke(self, prompts, **kw):
+        self.prompts.extend(prompts)
+        return [
+            LLMBatchItem(index=i, response=LLMResponse(content=self._responses[0]))
+            for i in range(len(prompts))
+        ]
 
 
 class WordEmbedder(Embedder):
@@ -468,6 +484,44 @@ class TestIncrementalResolution:
         )
         res = await resolver.resolve(GraphData(nodes=batch), _ctx())  # must not raise
         assert len(res.nodes) == 2
+
+    async def test_full_description_sent_to_llm_not_truncated(self):
+        """The merge prompt must send the FULL description, not a 180-char snippet
+        (Naseem #3) — else repeated merges erode rich descriptions."""
+        long_desc = "FalkorDB is a graph database. " + "detail " * 60  # > 180 chars
+        batch = [
+            GraphNode(
+                id="acme__t", label="T", properties={"name": "Acme", "description": long_desc}
+            ),
+        ]
+        candidate = GraphNode(
+            id="acme_hub__t",
+            label="T",
+            properties={"name": "Acme", "description": "short existing"},
+        )
+        decision = json.dumps(
+            {
+                "groups": [
+                    {
+                        "members": [1, 2],
+                        "target": 2,
+                        "canonical": "Acme",
+                        "type": "T",
+                        "description": "merged",
+                    },
+                ]
+            }
+        )
+        llm = CapturingLLM(decision)
+        resolver = IncrementalResolution(
+            llm=llm,
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([candidate]),
+        )
+        await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert llm.prompts, "the LLM should have been asked to link the pile"
+        assert len(long_desc) > 180
+        assert long_desc in llm.prompts[0], "full description must be sent, not truncated"
 
     def test_normalize_name_folds_case_and_separators(self):
         assert normalize_name("GraphRAG-SDK") == "graphrag sdk"

--- a/graphrag_sdk/tests/test_incremental_resolution.py
+++ b/graphrag_sdk/tests/test_incremental_resolution.py
@@ -50,6 +50,20 @@ class WordEmbedder(Embedder):
         return vec or [0.0] * 64
 
 
+class ScriptedEmbedder(Embedder):
+    """Returns a fixed vector per exact text, for precise cosine control."""
+
+    def __init__(self, table: dict[str, list[float]]) -> None:
+        self._table = table
+
+    @property
+    def model_name(self) -> str:
+        return "scripted"
+
+    def embed_query(self, text: str, **kw):
+        return self._table.get(str(text), [1.0, 0.0])
+
+
 def _ctx():
     return Context(tenant_id="t", latency_budget_ms=5000.0)
 
@@ -522,6 +536,77 @@ class TestIncrementalResolution:
         assert llm.prompts, "the LLM should have been asked to link the pile"
         assert len(long_desc) > 180
         assert long_desc in llm.prompts[0], "full description must be sent, not truncated"
+
+    async def test_overlapping_llm_groups_are_dropped(self):
+        """A ref reused across LLM groups must not double-merge unrelated entities
+        (Naseem #2) — the second, overlapping group is dropped."""
+        batch = [
+            GraphNode(id="a__t", label="T", properties={"name": "Aye", "description": "d1"}),
+            GraphNode(id="b__t", label="T", properties={"name": "Bee", "description": "d2"}),
+        ]
+        # refs 1=Aye, 2=Bee (new), 3=Gal Sh (graph candidate). Group 2 reuses ref 1.
+        decision = json.dumps(
+            {
+                "groups": [
+                    {
+                        "members": [1, 2],
+                        "target": "new",
+                        "canonical": "AyeBee",
+                        "type": "T",
+                        "description": "d",
+                    },
+                    {
+                        "members": [1, 3],
+                        "target": 3,
+                        "canonical": "X",
+                        "type": "T",
+                        "description": "d",
+                    },
+                ]
+            }
+        )
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[decision]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([GAL_SH]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        # Group 1 applied (Bee → Aye); overlapping group 2 dropped, so nothing
+        # links onto the graph candidate.
+        assert res.remap.get("b__t") == "a__t"
+        assert "gal_sh__person" not in res.remap.values()
+        assert "gal_sh__person" not in {n.id for n in res.nodes}
+
+    async def test_cross_type_merge_needs_higher_bar(self):
+        """Same-name cross-type auto-merge requires cross_type_threshold, while
+        same-type merges at the lower same_name_threshold (Naseem #5)."""
+        # Two descriptions at cosine 0.85 — above same_name (0.80), below cross (0.90).
+        table = {"desc-A": [1.0, 0.0], "desc-B": [0.85, 0.5268]}
+
+        async def resolve_pair(label_b):
+            batch = [
+                GraphNode(
+                    id="paris__location",
+                    label="Location",
+                    properties={"name": "Paris", "description": "desc-A"},
+                ),
+                GraphNode(
+                    id="paris__other",
+                    label=label_b,
+                    properties={"name": "Paris", "description": "desc-B"},
+                ),
+            ]
+            resolver = IncrementalResolution(
+                llm=MockLLM(responses=[""]),
+                embedder=ScriptedEmbedder(table),
+                candidate_retriever=make_retriever([]),
+            )
+            return await resolver.resolve(GraphData(nodes=batch), _ctx())
+
+        same_type = await resolve_pair("Location")  # 0.85 ≥ 0.80 → merge
+        cross_type = await resolve_pair("Person")  # 0.85 < 0.90 → stay separate
+        assert len(same_type.nodes) == 1, "same-type should merge at 0.85"
+        assert len(cross_type.nodes) == 2, "cross-type needs 0.90, so 0.85 stays split"
 
     def test_normalize_name_folds_case_and_separators(self):
         assert normalize_name("GraphRAG-SDK") == "graphrag sdk"

--- a/graphrag_sdk/tests/test_incremental_resolution.py
+++ b/graphrag_sdk/tests/test_incremental_resolution.py
@@ -608,6 +608,62 @@ class TestIncrementalResolution:
         assert len(same_type.nodes) == 1, "same-type should merge at 0.85"
         assert len(cross_type.nodes) == 2, "cross-type needs 0.90, so 0.85 stays split"
 
+    async def test_repeated_ref_within_group_does_not_drop_entity(self):
+        """A ref repeated inside one LLM group must not self-absorb the node
+        (Copilot re-review). Without de-duping members, the survivor remaps onto
+        itself and is then dropped as 'absorbed' — the entity vanishes."""
+        batch = [
+            GraphNode(id="acme__org", label="Org", properties={"name": "Acme", "description": "d"}),
+        ]
+        # ref 1 = Acme (new), ref 2 = Gal Sh (graph candidate, gives it a pile).
+        # The group lists ref 1 twice and keeps it new (target new).
+        decision = json.dumps(
+            {"groups": [{"members": [1, 1], "target": "new", "canonical": "Acme", "type": "Org"}]}
+        )
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[decision]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([GAL_SH]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert {n.id for n in res.nodes} == {"acme__org"}, "the entity must survive"
+        assert res.remap.get("acme__org") is None, "no self-referential remap"
+
+    async def test_non_string_llm_fields_are_coerced_or_dropped(self):
+        """Non-string canonical/type/description from the LLM must not land in
+        node properties as dicts/None (Copilot re-review)."""
+        batch = [
+            GraphNode(
+                id="gal__person",
+                label="Person",
+                properties={"name": "gal", "description": "FalkorDB engineer"},
+            ),
+        ]
+        # ref 1 = gal (new), ref 2 = Gal Sh (graph candidate). Link into ref 2 but
+        # the LLM emits a dict canonical, null description and a list type.
+        decision = json.dumps(
+            {
+                "groups": [
+                    {
+                        "members": [1, 2],
+                        "target": 2,
+                        "canonical": {"unexpected": "object"},
+                        "type": ["Person"],
+                        "description": None,
+                    }
+                ]
+            }
+        )
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[decision]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([GAL_SH]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        node = next(n for n in res.nodes if n.id == "gal_sh__person")
+        assert isinstance(node.properties["name"], str)
+        assert isinstance(node.properties.get("description", ""), str)
+
     def test_normalize_name_folds_case_and_separators(self):
         assert normalize_name("GraphRAG-SDK") == "graphrag sdk"
         assert normalize_name("graphrag_sdk") == "graphrag sdk"

--- a/graphrag_sdk/tests/test_incremental_resolution.py
+++ b/graphrag_sdk/tests/test_incremental_resolution.py
@@ -1,4 +1,5 @@
 """Tests for IncrementalResolution — resolve a batch against the existing graph."""
+
 from __future__ import annotations
 
 import json
@@ -38,15 +39,22 @@ def _ctx():
 
 
 # Existing graph nodes (candidates the retriever can return).
-GAL_SH = GraphNode(id="gal_sh__person", label="Person",
-                   properties={"name": "Gal Sh", "description": "Engineer at FalkorDB."})
-GAL_BR = GraphNode(id="gal_br__person", label="Person",
-                   properties={"name": "Gal Br", "description": "Designer at another firm."})
+GAL_SH = GraphNode(
+    id="gal_sh__person",
+    label="Person",
+    properties={"name": "Gal Sh", "description": "Engineer at FalkorDB."},
+)
+GAL_BR = GraphNode(
+    id="gal_br__person",
+    label="Person",
+    properties={"name": "Gal Br", "description": "Designer at another firm."},
+)
 
 
 def make_retriever(returns):
     async def retriever(name, description, k):
         return returns
+
     return retriever
 
 
@@ -55,23 +63,49 @@ class TestIncrementalResolution:
         """gal / gal.sh / Gal Shubeli → merge INTO existing Gal Sh;
         Gal Kurland → new; Gal Br (candidate) → rejected."""
         batch = [
-            GraphNode(id="gal__person", label="Person",
-                      properties={"name": "gal", "description": "works at FalkorDB"}),
-            GraphNode(id="gal.sh__person", label="Person",
-                      properties={"name": "gal.sh", "description": "FalkorDB engineer"}),
-            GraphNode(id="gal_shubeli__person", label="Person",
-                      properties={"name": "Gal Shubeli", "description": "engineer at FalkorDB"}),
-            GraphNode(id="gal_kurland__person", label="Person",
-                      properties={"name": "Gal Kurland", "description": "researcher elsewhere"}),
+            GraphNode(
+                id="gal__person",
+                label="Person",
+                properties={"name": "gal", "description": "works at FalkorDB"},
+            ),
+            GraphNode(
+                id="gal.sh__person",
+                label="Person",
+                properties={"name": "gal.sh", "description": "FalkorDB engineer"},
+            ),
+            GraphNode(
+                id="gal_shubeli__person",
+                label="Person",
+                properties={"name": "Gal Shubeli", "description": "engineer at FalkorDB"},
+            ),
+            GraphNode(
+                id="gal_kurland__person",
+                label="Person",
+                properties={"name": "Gal Kurland", "description": "researcher elsewhere"},
+            ),
         ]
         # LLM sees refs 1..4 = new (gal, gal.sh, Gal Shubeli, Gal Kurland),
         # refs 5,6 = graph (Gal Sh, Gal Br).
-        decision = json.dumps({"groups": [
-            {"members": [1, 2, 3, 5], "target": 5,
-             "canonical": "Gal Shubeli", "type": "Person", "description": "Engineer at FalkorDB."},
-            {"members": [4], "target": "new",
-             "canonical": "Gal Kurland", "type": "Person", "description": "A researcher."},
-        ]})
+        decision = json.dumps(
+            {
+                "groups": [
+                    {
+                        "members": [1, 2, 3, 5],
+                        "target": 5,
+                        "canonical": "Gal Shubeli",
+                        "type": "Person",
+                        "description": "Engineer at FalkorDB.",
+                    },
+                    {
+                        "members": [4],
+                        "target": "new",
+                        "canonical": "Gal Kurland",
+                        "type": "Person",
+                        "description": "A researcher.",
+                    },
+                ]
+            }
+        )
         resolver = IncrementalResolution(
             llm=MockLLM(responses=[decision]),
             embedder=WordEmbedder(),
@@ -94,8 +128,13 @@ class TestIncrementalResolution:
 
     async def test_no_candidates_means_new_entity_no_llm(self):
         """A survivor with no graph candidates is created as new — LLM untouched."""
-        batch = [GraphNode(id="novel__person", label="Person",
-                           properties={"name": "Nadia Q", "description": "brand new person"})]
+        batch = [
+            GraphNode(
+                id="novel__person",
+                label="Person",
+                properties={"name": "Nadia Q", "description": "brand new person"},
+            )
+        ]
 
         class BoomLLM(MockLLM):
             def invoke(self, *a, **k):
@@ -113,10 +152,16 @@ class TestIncrementalResolution:
     async def test_free_merge_collapses_same_name_before_llm(self):
         """Same-name/different-type homograph merges for free in stage 1."""
         batch = [
-            GraphNode(id="graphrag__concept", label="Concept",
-                      properties={"name": "GraphRAG", "description": "graph based RAG technique"}),
-            GraphNode(id="graphrag__technology", label="Technology",
-                      properties={"name": "GraphRAG", "description": "graph based RAG technique"}),
+            GraphNode(
+                id="graphrag__concept",
+                label="Concept",
+                properties={"name": "GraphRAG", "description": "graph based RAG technique"},
+            ),
+            GraphNode(
+                id="graphrag__technology",
+                label="Technology",
+                properties={"name": "GraphRAG", "description": "graph based RAG technique"},
+            ),
         ]
         resolver = IncrementalResolution(
             llm=MockLLM(responses=[""]),
@@ -130,10 +175,16 @@ class TestIncrementalResolution:
     async def test_immutable_conflict_flags_review(self):
         """Merging nodes that disagree on an immutable prop flags _needs_review."""
         batch = [
-            GraphNode(id="acme_a__org", label="Org",
-                      properties={"name": "Acme", "description": "a company", "founded": "2001"}),
-            GraphNode(id="acme_b__org", label="Org",
-                      properties={"name": "Acme", "description": "a company", "founded": "1998"}),
+            GraphNode(
+                id="acme_a__org",
+                label="Org",
+                properties={"name": "Acme", "description": "a company", "founded": "2001"},
+            ),
+            GraphNode(
+                id="acme_b__org",
+                label="Org",
+                properties={"name": "Acme", "description": "a company", "founded": "1998"},
+            ),
         ]
         resolver = IncrementalResolution(
             llm=MockLLM(responses=[""]),
@@ -149,11 +200,16 @@ class TestIncrementalResolution:
     async def test_genuine_homograph_stays_separate(self):
         """Same name, different type, divergent descriptions → NOT free-merged."""
         batch = [
-            GraphNode(id="paris__location", label="Location",
-                      properties={"name": "Paris", "description": "capital city france europe"}),
-            GraphNode(id="paris__person", label="Person",
-                      properties={"name": "Paris",
-                                  "description": "american media personality celebrity"}),
+            GraphNode(
+                id="paris__location",
+                label="Location",
+                properties={"name": "Paris", "description": "capital city france europe"},
+            ),
+            GraphNode(
+                id="paris__person",
+                label="Person",
+                properties={"name": "Paris", "description": "american media personality celebrity"},
+            ),
         ]
         resolver = IncrementalResolution(
             llm=MockLLM(responses=[""]),
@@ -165,8 +221,9 @@ class TestIncrementalResolution:
 
     async def test_malformed_llm_response_leaves_pile_untouched(self):
         """An unparseable partition → fail-safe: no merges applied."""
-        batch = [GraphNode(id="xylo__t", label="T",
-                           properties={"name": "Xylo", "description": "d"})]
+        batch = [
+            GraphNode(id="xylo__t", label="T", properties={"name": "Xylo", "description": "d"})
+        ]
         resolver = IncrementalResolution(
             llm=MockLLM(responses=["not valid json"]),  # consulted (has a candidate)
             embedder=WordEmbedder(),

--- a/graphrag_sdk/tests/test_incremental_resolution.py
+++ b/graphrag_sdk/tests/test_incremental_resolution.py
@@ -434,6 +434,10 @@ class TestIncrementalResolution:
         # NOT all evicted by the survivor count.
         assert res.remap.get("e0__person") == "hub__person"
         assert res.remap.get("e3__person") == "hub__person"
+        # Two chunks both retargeted a carrier to hub — the output must not contain
+        # the same id twice (else the store would MERGE it twice and clobber data).
+        ids = [n.id for n in res.nodes]
+        assert len(ids) == len(set(ids)), "resolved nodes must have unique ids"
 
     async def test_ragged_embedder_does_not_crash(self):
         """A malformed embedder returning ragged vectors degrades to no-merge

--- a/graphrag_sdk/tests/test_incremental_resolution.py
+++ b/graphrag_sdk/tests/test_incremental_resolution.py
@@ -195,7 +195,10 @@ class TestIncrementalResolution:
         res = await resolver.resolve(GraphData(nodes=batch), _ctx())
         assert len(res.nodes) == 1
         assert res.nodes[0].properties.get("_needs_review") is True
-        assert res.nodes[0].properties.get("_merge_conflicts")
+        conflicts = res.nodes[0].properties.get("_merge_conflicts")
+        # Recorded as strings so the graph store (which drops lists of dicts) persists them.
+        assert conflicts and all(isinstance(c, str) for c in conflicts)
+        assert any("founded" in c for c in conflicts)
 
     async def test_genuine_homograph_stays_separate(self):
         """Same name, different type, divergent descriptions → NOT free-merged."""
@@ -315,6 +318,152 @@ class TestIncrementalResolution:
         res = await resolver.resolve(GraphData(nodes=batch), _ctx())
         assert len(res.nodes) == 1
         assert res.nodes[0].id == "solo__t"
+
+    async def test_conflict_flag_survives_later_absorption(self):
+        """A node flagged in stage 1 keeps its review flag if it is absorbed as a
+        loser during stage-4 linking (Naseem #10 / CodeRabbit #7)."""
+        batch = [
+            GraphNode(
+                id="bee__t", label="T", properties={"name": "Bee", "description": "unrelated"}
+            ),
+            GraphNode(
+                id="node_a__t",
+                label="T",
+                properties={"name": "Node", "description": "d", "founded": "2001"},
+            ),
+            GraphNode(
+                id="node_b__t",
+                label="T",
+                properties={"name": "Node", "description": "d", "founded": "1998"},
+            ),
+        ]
+        # Stage 1 merges the two "Node" rows (flagging the founded conflict); stage 4
+        # groups the survivor "Node" with "Bee" (Bee first → carrier), absorbing the
+        # flagged node. The flag must propagate to Bee.
+        decision = json.dumps(
+            {
+                "groups": [
+                    {
+                        "members": [1, 2],
+                        "target": "new",
+                        "canonical": "Merged",
+                        "type": "T",
+                        "description": "d",
+                    },
+                ]
+            }
+        )
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[decision]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([GAL_SH]),  # both share a candidate → one pile
+            immutable_props=("founded",),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        carrier = next(n for n in res.nodes if n.id == "bee__t")
+        assert carrier.properties.get("_needs_review") is True
+        assert any("founded" in c for c in carrier.properties.get("_merge_conflicts", []))
+
+    async def test_no_description_homograph_not_merged(self):
+        """Same name, different type, NO descriptions → not auto-merged (Naseem #12).
+        Description would fall back to the name (cosine 1.0); that isn't evidence."""
+        batch = [
+            GraphNode(id="paris__location", label="Location", properties={"name": "Paris"}),
+            GraphNode(id="paris__person", label="Person", properties={"name": "Paris"}),
+        ]
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[""]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        assert len(res.nodes) == 2, "no-evidence homographs must stay separate"
+
+    async def test_large_pile_still_links_candidates(self):
+        """A survivor pile larger than pile_cap is chunked, so candidates still
+        reach the LLM and linking works (Naseem #9 / CodeRabbit #6)."""
+        hub = GraphNode(
+            id="hub__person", label="Person", properties={"name": "Hub", "description": "shared"}
+        )
+        batch = [
+            GraphNode(
+                id=f"e{i}__person",
+                label="Person",
+                properties={"name": f"Name{i}", "description": f"desc {i}"},
+            )
+            for i in range(5)
+        ]
+        # pile_cap=4, top_k=1 → survivor budget 3 → chunks [0,1,2] and [3,4].
+        # chunk 1: refs 1-3 survivors, ref 4 = Hub → link ref1 into ref4.
+        # chunk 2: refs 1-2 survivors, ref 3 = Hub → link ref1 into ref3.
+        r1 = json.dumps(
+            {
+                "groups": [
+                    {
+                        "members": [1, 4],
+                        "target": 4,
+                        "canonical": "Hub",
+                        "type": "Person",
+                        "description": "d",
+                    }
+                ]
+            }
+        )
+        r2 = json.dumps(
+            {
+                "groups": [
+                    {
+                        "members": [1, 3],
+                        "target": 3,
+                        "canonical": "Hub",
+                        "type": "Person",
+                        "description": "d",
+                    }
+                ]
+            }
+        )
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[r1, r2]),
+            embedder=WordEmbedder(),
+            candidate_retriever=make_retriever([hub]),
+            top_k=1,
+            pile_cap=4,
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())
+        # A survivor from each chunk linked into the existing hub — candidates were
+        # NOT all evicted by the survivor count.
+        assert res.remap.get("e0__person") == "hub__person"
+        assert res.remap.get("e3__person") == "hub__person"
+
+    async def test_ragged_embedder_does_not_crash(self):
+        """A malformed embedder returning ragged vectors degrades to no-merge
+        rather than crashing the document (CodeRabbit #8)."""
+
+        class RaggedEmbedder(Embedder):
+            @property
+            def model_name(self):
+                return "ragged"
+
+            def embed_query(self, text, **kw):
+                return [1.0] * (len(str(text)) % 3 + 1)  # inconsistent lengths
+
+        batch = [
+            GraphNode(
+                id="p__location",
+                label="Location",
+                properties={"name": "Paris", "description": "abc"},
+            ),
+            GraphNode(
+                id="p__person", label="Person", properties={"name": "Paris", "description": "abcd"}
+            ),
+        ]
+        resolver = IncrementalResolution(
+            llm=MockLLM(responses=[""]),
+            embedder=RaggedEmbedder(),
+            candidate_retriever=make_retriever([]),
+        )
+        res = await resolver.resolve(GraphData(nodes=batch), _ctx())  # must not raise
+        assert len(res.nodes) == 2
 
     def test_normalize_name_folds_case_and_separators(self):
         assert normalize_name("GraphRAG-SDK") == "graphrag sdk"


### PR DESCRIPTION
New `IncrementalResolution` strategy + exports, and it is wired as the **default resolver** in the `GraphRAG` facade.

**Behavior change:** when an LLM and embedder are configured, ingestion now defaults to `IncrementalResolution` (was `ExactMatchResolution`), which adds LLM + embedding calls per ingest. It falls back to `ExactMatchResolution` automatically when no LLM/embedder is present, so LLM-free setups are unchanged; opt out explicitly with `resolver=ExactMatchResolution()`. Documented in `docs/ingestion.md`, `docs/strategies.md`, and CHANGELOG.

Closes #277

---

Closes #277

## What

Adds `IncrementalResolution`, a resolution strategy that resolves a document's
entities **against the knowledge graph built so far** — so a mention in today's
document can be linked to an entity extracted from a document ingested earlier.
Ordinary batch resolvers only deduplicate a document's entities among
themselves and structurally cannot see cross-document duplicates.

## Algorithm

A funnel — cheap, certain work first; the LLM only where cheap signals can't decide:

1. **collapse** — merge a batch's own same-name duplicates (description-gated, no LLM)
2. **retrieve** — for each survivor, fetch look-alike existing graph entities
3. **pile** — group survivors that share a candidate (union-find)
4. **link** — one LLM call per pile: which items are the same entity, and which
   existing node (if any) is the merge target

Two duplication axes, each handled where it's cheapest and most reliable:
- **same name, different type** (`GraphRAG` Concept vs Technology) → resolved for
  free by description similarity. An LLM told to be careful tends to *over-split*
  these; the embedding is cheaper and more accurate.
- **different name, same entity** (`llama_index` ≈ `LlamaIndex`, or a new mention
  of an existing node) → the LLM partitions a small pile, the framing that keeps
  genuine look-alikes apart (`FALKORDB_USERNAME` ≠ `FALKORDB_PASSWORD`).

## Design choices

- **Fail toward splitting** — thin evidence or a failed call leaves entities separate.
- **Existing nodes win the id** — the store's `MERGE (n {id})` attaches the new
  mention with no special-casing; existing edges untouched.
- **Facts are never invented** — the LLM owns free text (canonical name, type,
  merged description); provenance is unioned and immutable-property conflicts are
  flagged (`_needs_review`), never guessed.
- **Testable without a database** — the graph lookup is an injected
  `candidate_retriever`; in production it wraps the graph store's name/vector search.

## Scope

Adds the new strategy and makes it the default resolver (see the Behavior change note at the top). Closes the same-name/different-type homograph gap in #277.

## Tests

`tests/test_incremental_resolution.py` — 7 tests: cross-document linking into an
existing node while rejecting a look-alike, new-entity when no candidates (no LLM
call), free same-name collapse, genuine-homograph preservation, immutable-conflict
flagging, malformed-LLM fail-safe, and name normalization. Ruff clean; existing
resolution suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an incremental, graph-aware entity resolution strategy that links new mentions to existing knowledge-graph entities and merges duplicates when appropriate.
  * Updated default ingestion/update duplicate resolution to use this strategy when LLM + embeddings are configured; otherwise it falls back to deterministic exact-match.
  * Exposed `IncrementalResolution` for direct importing.
* **Bug Fixes**
  * Fail-safe behavior: malformed or failed LLM partitioning won’t apply merges.
* **Documentation**
  * Updated ingestion/strategy docs and changelog to reflect the new defaults.
* **Tests**
  * Added comprehensive async and unit tests covering linking, homographs, conflicts, and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


