### PR TITLE
chore(release): prepare v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-08-10
+
+Chunk-level extraction cache for `update()` (#288): re-ingesting a
+document whose text is mostly unchanged now rebuilds the untouched
+chunks from the live graph instead of re-extracting them, so editing one
+paragraph of a 50-chunk document costs roughly one LLM extraction rather
+than fifty. Opt-in via `cache_unchanged_chunks=True` — the default is
+`False` and existing ingest paths are unaffected.
+
+The database layer gained a matching error contract: driver-level
+failures now surface as `DatabaseError`, with a new
+`DatabaseUnavailableError` separating "the server never answered" from
+"the server answered and rejected the query". That split is what lets
+the cache decide when falling open is safe. See **Changed** for the
+migration note if you were catching `redis.exceptions.*` directly.
+
 ### Added
 
 #### Chunk-level extraction cache for `update()` (`cache_unchanged_chunks`)
@@ -61,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already exists") is unaffected. Catch `DatabaseError` instead of
   `redis.exceptions.ConnectionError` if you were relying on the
   driver's own types.
+
 - **`FalkorDBConnection.ping()` returns `False` when the server is
   unreachable** instead of raising. Reporting "not alive" is the point
   of the call. A missing `falkordb` package still raises `ImportError`
@@ -75,6 +92,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recognizes syntax errors, invalid input, unknown functions, type
   mismatches, and missing procedures, so a rejected query fails fast
   instead of burning the full retry budget first.
+
+### Fixed
+
+- **`graphrag_sdk.__version__` reported `1.2.0` on the 1.3.0 release** —
+  the constant was not bumped alongside `pyproject.toml`, so the value
+  returned by `__version__` and by the API's `/version` endpoint was one
+  minor version stale. Both now report `1.4.0`.
 
 ## [1.3.0] - 2026-06-04
 

--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphrag-sdk"
-version = "1.3.0"
+version = "1.4.0"
 description = "The most accurate Graph RAG framework. Build knowledge graphs and query them with natural language. Built on FalkorDB."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/graphrag_sdk/src/graphrag_sdk/__init__.py
+++ b/graphrag_sdk/src/graphrag_sdk/__init__.py
@@ -11,7 +11,7 @@
 #   Adaptability — Optimization-ready core, strategies are swappable.
 #   Velocity — Production-grade throughput.
 
-__version__ = "1.2.0"
+__version__ = "1.4.0"
 
 # ── API Surface (Facade) ────────────────────────────────────────
 from graphrag_sdk.api.main import GraphRAG


### PR DESCRIPTION
Cuts the `[Unreleased]` section into `[1.4.0]` and bumps the version. No functional changes — everything released here is already merged on `main`.

## What's in 1.4.0

**Chunk-level extraction cache for `update()` (#288)** — `update(..., cache_unchanged_chunks=True)` rebuilds untouched chunks from the live graph instead of re-extracting them, so editing one paragraph of a 50-chunk document costs roughly one LLM extraction rather than fifty. Opt-in; the default stays `False`.

**`DatabaseError` / `DatabaseUnavailableError` contract** — driver-level failures now surface as `DatabaseError`, with `DatabaseUnavailableError` separating "the server never answered" from "the server answered and rejected the query". That split is what lets the cache decide when falling open is safe.

Minor bump: purely additive, no breaking changes to existing ingest paths. Callers catching `redis.exceptions.*` directly should catch `DatabaseError` instead — see the **Changed** section of the changelog.

## Changes

| File | Change |
| --- | --- |
| `CHANGELOG.md` | `[Unreleased]` → `[1.4.0] - 2026-08-10` + summary paragraph |
| `graphrag_sdk/pyproject.toml` | `1.3.0` → `1.4.0` |
| `graphrag_sdk/src/graphrag_sdk/__init__.py` | `__version__` `1.2.0` → `1.4.0` |

## Note on `__version__`

`__version__` was left at `1.2.0` when 1.3.0 was cut, so the 1.3.0 release reported a stale version through `__version__` and the API's `/version` endpoint. Fixed here and logged under **Fixed**. The existing `test_version` only regex-checks for a `1.x` shape, which is why it never caught the drift — worth pinning it to `pyproject.toml` in a follow-up.

## Not included

- **#278 (`IncrementalResolution`)** — conflicting with `main` and has requested changes outstanding; it lands in a later release.
- **#291** — docs-only benchmark refresh, no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chunk-level extraction caching to speed up updates and avoid redundant processing.
* **Bug Fixes**
  * Improved database error handling and clearer distinction between unavailable servers and other failures.
  * Expanded detection of permanent database errors.
* **Documentation**
  * Added release documentation for the new caching and database behavior.
* **Chores**
  * Updated the package version to 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->