### PR TITLE
fix: order vector node searches by distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept vector search scores consistent as higher-is-better similarities across
+  indexed and fallback relationship retrieval paths.
+
 ### Changed
 
 - Documentation migrated from MkDocs to [Mintlify](https://mintlify.com) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Kept vector search scores consistent as higher-is-better similarities across
-  indexed and fallback relationship retrieval paths.
+- Fixed vector-search ordering so chunk, entity, and relationship searches use
+  distance scores, with lower values indicating closer matches.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed vector-search ordering so chunk, entity, and relationship searches use
-  distance scores, with lower values indicating closer matches.
+  similarity scores, with higher values indicating closer matches.
 
 ### Changed
 

--- a/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
@@ -358,8 +358,8 @@ class VectorStore:
         query = (
             "CALL db.idx.vector.queryNodes('Chunk', 'embedding', $top_k, vecf32($vector)) "
             "YIELD node, score "
-            "RETURN node.id AS id, node.text AS text, score "
-            "ORDER BY score ASC"
+            "RETURN node.id AS id, node.text AS text, (1-score) AS score "
+            "ORDER BY score DESC"
         )
         try:
             result = await self._conn.query(
@@ -395,8 +395,9 @@ class VectorStore:
         query = (
             "CALL db.idx.vector.queryNodes('__Entity__', 'embedding', $top_k, vecf32($vector)) "
             "YIELD node, score "
-            "RETURN node.id AS id, node.name AS name, node.description AS description, score "
-            "ORDER BY score ASC"
+            "RETURN node.id AS id, node.name AS name, node.description AS description, "
+            "(1-score) AS score "
+            "ORDER BY score DESC"
         )
         try:
             result = await self._conn.query(
@@ -446,8 +447,8 @@ class VectorStore:
             "'RELATES', 'embedding', $top_k, vecf32($vector)) "
             "YIELD relationship AS r, score "
             "RETURN r.src_name AS src, r.rel_type AS type, "
-            "r.tgt_name AS tgt, r.fact AS fact, score "
-            "ORDER BY score ASC"
+            "r.tgt_name AS tgt, r.fact AS fact, (1-score) AS score "
+            "ORDER BY score DESC"
         )
         try:
             result = await self._conn.query(

--- a/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
@@ -346,14 +346,14 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 5,
     ) -> list[dict[str, Any]]:
-        """Vector similarity search on ``Chunk`` nodes.
+        """Vector distance search on ``Chunk`` nodes.
 
         Args:
             query_vector: The query embedding vector.
             top_k: Number of results to return.
 
         Returns:
-            List of dicts with id, text, score.
+            List of dicts with id, text, and distance score (lower is closer).
         """
         query = (
             "CALL db.idx.vector.queryNodes('Chunk', 'embedding', $top_k, vecf32($vector)) "
@@ -388,7 +388,10 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 5,
     ) -> list[dict[str, Any]]:
-        """Vector similarity search on __Entity__ nodes."""
+        """Vector distance search on ``__Entity__`` nodes.
+
+        Returned scores are distances, so lower values indicate closer matches.
+        """
         query = (
             "CALL db.idx.vector.queryNodes('__Entity__', 'embedding', $top_k, vecf32($vector)) "
             "YIELD node, score "
@@ -423,7 +426,7 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 15,
     ) -> list[dict[str, Any]]:
-        """Vector similarity search on RELATES edges.
+        """Vector distance search on RELATES edges.
 
         Uses the RELATES edge vector index for retrieval. Falls back to
         a Cypher-based cosine distance scan if edge vector queries
@@ -434,7 +437,8 @@ class VectorStore:
             top_k: Number of results to return.
 
         Returns:
-            List of dicts with src_name, type, tgt_name, fact, score.
+            List of dicts with src_name, type, tgt_name, fact, and distance
+            score (lower is closer).
         """
         # Try edge vector index query first (FalkorDB >= 4.2)
         query = (
@@ -472,7 +476,7 @@ class VectorStore:
             "WHERE r.embedding IS NOT NULL "
             "WITH a, r, b, vec.cosineDistance(r.embedding, vecf32($vector)) AS dist "
             "RETURN r.src_name AS src, r.rel_type AS type, "
-            "r.tgt_name AS tgt, r.fact AS fact, (1-dist) AS score "
+            "r.tgt_name AS tgt, r.fact AS fact, dist AS score "
             "ORDER BY dist ASC LIMIT $top_k"
         )
         try:

--- a/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
@@ -359,7 +359,7 @@ class VectorStore:
             "CALL db.idx.vector.queryNodes('Chunk', 'embedding', $top_k, vecf32($vector)) "
             "YIELD node, score "
             "RETURN node.id AS id, node.text AS text, score "
-            "ORDER BY score DESC"
+            "ORDER BY score ASC"
         )
         try:
             result = await self._conn.query(
@@ -393,7 +393,7 @@ class VectorStore:
             "CALL db.idx.vector.queryNodes('__Entity__', 'embedding', $top_k, vecf32($vector)) "
             "YIELD node, score "
             "RETURN node.id AS id, node.name AS name, node.description AS description, score "
-            "ORDER BY score DESC"
+            "ORDER BY score ASC"
         )
         try:
             result = await self._conn.query(

--- a/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
@@ -346,7 +346,7 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 5,
     ) -> list[dict[str, Any]]:
-        """Vector similarity search on ``Chunk`` nodes.
+        """Vector distance search on ``Chunk`` nodes.
 
         Args:
             query_vector: The query embedding vector.
@@ -388,7 +388,11 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 5,
     ) -> list[dict[str, Any]]:
-        """Vector similarity search on __Entity__ nodes."""
+        """Vector distance search on ``__Entity__`` nodes.
+
+        Returned scores are distances, so lower values indicate closer
+        matches.
+        """
         query = (
             "CALL db.idx.vector.queryNodes('__Entity__', 'embedding', $top_k, vecf32($vector)) "
             "YIELD node, score "
@@ -423,7 +427,7 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 15,
     ) -> list[dict[str, Any]]:
-        """Vector similarity search on RELATES edges.
+        """Vector distance search on RELATES edges.
 
         Uses the RELATES edge vector index for retrieval. Falls back to
         a Cypher-based cosine distance scan if edge vector queries
@@ -434,7 +438,8 @@ class VectorStore:
             top_k: Number of results to return.
 
         Returns:
-            List of dicts with src_name, type, tgt_name, fact, score.
+            List of dicts with src_name, type, tgt_name, fact, and distance
+            in the ``score`` field. Lower distances indicate closer matches.
         """
         # Try edge vector index query first (FalkorDB >= 4.2)
         query = (
@@ -443,7 +448,7 @@ class VectorStore:
             "YIELD relationship AS r, score "
             "RETURN r.src_name AS src, r.rel_type AS type, "
             "r.tgt_name AS tgt, r.fact AS fact, score "
-            "ORDER BY score DESC"
+            "ORDER BY score ASC"
         )
         try:
             result = await self._conn.query(

--- a/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
@@ -346,7 +346,7 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 5,
     ) -> list[dict[str, Any]]:
-        """Vector distance search on ``Chunk`` nodes.
+        """Vector similarity search on ``Chunk`` nodes.
 
         Args:
             query_vector: The query embedding vector.
@@ -388,11 +388,7 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 5,
     ) -> list[dict[str, Any]]:
-        """Vector distance search on ``__Entity__`` nodes.
-
-        Returned scores are distances, so lower values indicate closer
-        matches.
-        """
+        """Vector similarity search on __Entity__ nodes."""
         query = (
             "CALL db.idx.vector.queryNodes('__Entity__', 'embedding', $top_k, vecf32($vector)) "
             "YIELD node, score "
@@ -427,7 +423,7 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 15,
     ) -> list[dict[str, Any]]:
-        """Vector distance search on RELATES edges.
+        """Vector similarity search on RELATES edges.
 
         Uses the RELATES edge vector index for retrieval. Falls back to
         a Cypher-based cosine distance scan if edge vector queries
@@ -438,8 +434,7 @@ class VectorStore:
             top_k: Number of results to return.
 
         Returns:
-            List of dicts with src_name, type, tgt_name, fact, and distance
-            in the ``score`` field. Lower distances indicate closer matches.
+            List of dicts with src_name, type, tgt_name, fact, score.
         """
         # Try edge vector index query first (FalkorDB >= 4.2)
         query = (

--- a/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/vector_store.py
@@ -346,14 +346,14 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 5,
     ) -> list[dict[str, Any]]:
-        """Vector distance search on ``Chunk`` nodes.
+        """Vector similarity search on ``Chunk`` nodes.
 
         Args:
             query_vector: The query embedding vector.
             top_k: Number of results to return.
 
         Returns:
-            List of dicts with id, text, and distance score (lower is closer).
+            List of dicts with id, text, and similarity score (higher is closer).
         """
         query = (
             "CALL db.idx.vector.queryNodes('Chunk', 'embedding', $top_k, vecf32($vector)) "
@@ -388,9 +388,9 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 5,
     ) -> list[dict[str, Any]]:
-        """Vector distance search on ``__Entity__`` nodes.
+        """Vector similarity search on ``__Entity__`` nodes.
 
-        Returned scores are distances, so lower values indicate closer matches.
+        Returned scores are similarities, so higher values indicate closer matches.
         """
         query = (
             "CALL db.idx.vector.queryNodes('__Entity__', 'embedding', $top_k, vecf32($vector)) "
@@ -427,7 +427,7 @@ class VectorStore:
         query_vector: list[float],
         top_k: int = 15,
     ) -> list[dict[str, Any]]:
-        """Vector distance search on RELATES edges.
+        """Vector similarity search on RELATES edges.
 
         Uses the RELATES edge vector index for retrieval. Falls back to
         a Cypher-based cosine distance scan if edge vector queries
@@ -438,8 +438,8 @@ class VectorStore:
             top_k: Number of results to return.
 
         Returns:
-            List of dicts with src_name, type, tgt_name, fact, and distance
-            score (lower is closer).
+            List of dicts with src_name, type, tgt_name, fact, and similarity
+            score (higher is closer).
         """
         # Try edge vector index query first (FalkorDB >= 4.2)
         query = (
@@ -477,7 +477,7 @@ class VectorStore:
             "WHERE r.embedding IS NOT NULL "
             "WITH a, r, b, vec.cosineDistance(r.embedding, vecf32($vector)) AS dist "
             "RETURN r.src_name AS src, r.rel_type AS type, "
-            "r.tgt_name AS tgt, r.fact AS fact, dist AS score "
+            "r.tgt_name AS tgt, r.fact AS fact, (1-dist) AS score "
             "ORDER BY dist ASC LIMIT $top_k"
         )
         try:

--- a/graphrag_sdk/tests/test_vector_store.py
+++ b/graphrag_sdk/tests/test_vector_store.py
@@ -214,18 +214,18 @@ class TestVectorStoreSearch:
         assert "1-score" in cypher
         assert "ORDER BY score DESC" in cypher
 
-    async def test_search_relationships_fallback_returns_distance(
+    async def test_search_relationships_fallback_returns_similarity(
         self, vector_store, mock_connection
     ):
         fallback_result = MagicMock()
-        fallback_result.result_set = [["Alice", "WORKS_AT", "Acme", "self-match", 0.0]]
+        fallback_result.result_set = [["Alice", "WORKS_AT", "Acme", "self-match", 1.0]]
         mock_connection.query = AsyncMock(side_effect=[Exception("unsupported"), fallback_result])
 
         results = await vector_store.search_relationships(query_vector=[0.1] * 8, top_k=5)
 
-        assert results[0]["score"] == 0.0
+        assert results[0]["score"] == 1.0
         fallback_cypher = mock_connection.query.call_args_list[1][0][0]
-        assert "dist AS score" in fallback_cypher
+        assert "(1-dist) AS score" in fallback_cypher
 
     async def test_search_chunks_empty(self, vector_store, mock_connection):
         result_mock = MagicMock()

--- a/graphrag_sdk/tests/test_vector_store.py
+++ b/graphrag_sdk/tests/test_vector_store.py
@@ -164,52 +164,68 @@ class TestVectorStoreSearch:
     async def test_search_chunks(self, vector_store, mock_connection):
         result_mock = MagicMock()
         result_mock.result_set = [
-            ["chunk-self", "Hello world", 0.0],
-            ["chunk-2", "Goodbye world", 0.80],
+            ["chunk-self", "Hello world", 1.0],
+            ["chunk-2", "Goodbye world", 0.20],
         ]
         mock_connection.query = AsyncMock(return_value=result_mock)
         results = await vector_store.search_chunks(query_vector=[0.1] * 8, top_k=5)
         assert len(results) == 2
         assert results[0]["id"] == "chunk-self"
-        assert results[0]["score"] == 0.0
-        assert results[1]["score"] == 0.80
+        assert results[0]["score"] == 1.0
+        assert results[1]["score"] == 0.20
         cypher = mock_connection.query.call_args[0][0]
         assert "'Chunk'" in cypher
-        assert "ORDER BY score ASC" in cypher
+        assert "1-score" in cypher
+        assert "ORDER BY score DESC" in cypher
 
     async def test_search_entities_orders_by_distance(self, vector_store, mock_connection):
         result_mock = MagicMock()
         result_mock.result_set = [
-            ["entity-self", "Alice", "Engineer", 0.0],
-            ["entity-2", "Bob", "Researcher", 0.80],
+            ["entity-self", "Alice", "Engineer", 1.0],
+            ["entity-2", "Bob", "Researcher", 0.20],
         ]
         mock_connection.query = AsyncMock(return_value=result_mock)
 
         results = await vector_store.search_entities(query_vector=[0.1] * 8, top_k=5)
 
         assert results[0]["id"] == "entity-self"
-        assert results[0]["score"] == 0.0
-        assert results[1]["score"] == 0.80
+        assert results[0]["score"] == 1.0
+        assert results[1]["score"] == 0.20
         cypher = mock_connection.query.call_args[0][0]
         assert "'__Entity__'" in cypher
-        assert "ORDER BY score ASC" in cypher
+        assert "1-score" in cypher
+        assert "ORDER BY score DESC" in cypher
 
     async def test_search_relationships_orders_by_distance(self, vector_store, mock_connection):
         result_mock = MagicMock()
         result_mock.result_set = [
-            ["Alice", "WORKS_AT", "Acme", "self-match", 0.0],
-            ["Bob", "KNOWS", "Carol", "other-match", 0.80],
+            ["Alice", "WORKS_AT", "Acme", "self-match", 1.0],
+            ["Bob", "KNOWS", "Carol", "other-match", 0.20],
         ]
         mock_connection.query = AsyncMock(return_value=result_mock)
 
         results = await vector_store.search_relationships(query_vector=[0.1] * 8, top_k=5)
 
         assert results[0]["fact"] == "self-match"
-        assert results[0]["score"] == 0.0
-        assert results[1]["score"] == 0.80
+        assert results[0]["score"] == 1.0
+        assert results[1]["score"] == 0.20
         cypher = mock_connection.query.call_args[0][0]
         assert "queryRelationships" in cypher
-        assert "ORDER BY score ASC" in cypher
+        assert "1-score" in cypher
+        assert "ORDER BY score DESC" in cypher
+
+    async def test_search_relationships_fallback_returns_similarity(
+        self, vector_store, mock_connection
+    ):
+        fallback_result = MagicMock()
+        fallback_result.result_set = [["Alice", "WORKS_AT", "Acme", "self-match", 1.0]]
+        mock_connection.query = AsyncMock(side_effect=[Exception("unsupported"), fallback_result])
+
+        results = await vector_store.search_relationships(query_vector=[0.1] * 8, top_k=5)
+
+        assert results[0]["score"] == 1.0
+        fallback_cypher = mock_connection.query.call_args_list[1][0][0]
+        assert "(1-dist) AS score" in fallback_cypher
 
     async def test_search_chunks_empty(self, vector_store, mock_connection):
         result_mock = MagicMock()

--- a/graphrag_sdk/tests/test_vector_store.py
+++ b/graphrag_sdk/tests/test_vector_store.py
@@ -164,29 +164,51 @@ class TestVectorStoreSearch:
     async def test_search_chunks(self, vector_store, mock_connection):
         result_mock = MagicMock()
         result_mock.result_set = [
-            ["chunk-1", "Hello world", 0.95],
+            ["chunk-self", "Hello world", 0.0],
             ["chunk-2", "Goodbye world", 0.80],
         ]
         mock_connection.query = AsyncMock(return_value=result_mock)
         results = await vector_store.search_chunks(query_vector=[0.1] * 8, top_k=5)
         assert len(results) == 2
-        assert results[0]["id"] == "chunk-1"
-        assert results[0]["score"] == 0.95
+        assert results[0]["id"] == "chunk-self"
+        assert results[0]["score"] == 0.0
+        assert results[1]["score"] == 0.80
         cypher = mock_connection.query.call_args[0][0]
         assert "'Chunk'" in cypher
         assert "ORDER BY score ASC" in cypher
 
     async def test_search_entities_orders_by_distance(self, vector_store, mock_connection):
         result_mock = MagicMock()
-        result_mock.result_set = [["entity-1", "Alice", "Engineer", 0.95]]
+        result_mock.result_set = [
+            ["entity-self", "Alice", "Engineer", 0.0],
+            ["entity-2", "Bob", "Researcher", 0.80],
+        ]
         mock_connection.query = AsyncMock(return_value=result_mock)
 
         results = await vector_store.search_entities(query_vector=[0.1] * 8, top_k=5)
 
-        assert results[0]["id"] == "entity-1"
-        assert results[0]["score"] == 0.95
+        assert results[0]["id"] == "entity-self"
+        assert results[0]["score"] == 0.0
+        assert results[1]["score"] == 0.80
         cypher = mock_connection.query.call_args[0][0]
         assert "'__Entity__'" in cypher
+        assert "ORDER BY score ASC" in cypher
+
+    async def test_search_relationships_orders_by_distance(self, vector_store, mock_connection):
+        result_mock = MagicMock()
+        result_mock.result_set = [
+            ["Alice", "WORKS_AT", "Acme", "self-match", 0.0],
+            ["Bob", "KNOWS", "Carol", "other-match", 0.80],
+        ]
+        mock_connection.query = AsyncMock(return_value=result_mock)
+
+        results = await vector_store.search_relationships(query_vector=[0.1] * 8, top_k=5)
+
+        assert results[0]["fact"] == "self-match"
+        assert results[0]["score"] == 0.0
+        assert results[1]["score"] == 0.80
+        cypher = mock_connection.query.call_args[0][0]
+        assert "queryRelationships" in cypher
         assert "ORDER BY score ASC" in cypher
 
     async def test_search_chunks_empty(self, vector_store, mock_connection):

--- a/graphrag_sdk/tests/test_vector_store.py
+++ b/graphrag_sdk/tests/test_vector_store.py
@@ -214,18 +214,18 @@ class TestVectorStoreSearch:
         assert "1-score" in cypher
         assert "ORDER BY score DESC" in cypher
 
-    async def test_search_relationships_fallback_returns_similarity(
+    async def test_search_relationships_fallback_returns_distance(
         self, vector_store, mock_connection
     ):
         fallback_result = MagicMock()
-        fallback_result.result_set = [["Alice", "WORKS_AT", "Acme", "self-match", 1.0]]
+        fallback_result.result_set = [["Alice", "WORKS_AT", "Acme", "self-match", 0.0]]
         mock_connection.query = AsyncMock(side_effect=[Exception("unsupported"), fallback_result])
 
         results = await vector_store.search_relationships(query_vector=[0.1] * 8, top_k=5)
 
-        assert results[0]["score"] == 1.0
+        assert results[0]["score"] == 0.0
         fallback_cypher = mock_connection.query.call_args_list[1][0][0]
-        assert "(1-dist) AS score" in fallback_cypher
+        assert "dist AS score" in fallback_cypher
 
     async def test_search_chunks_empty(self, vector_store, mock_connection):
         result_mock = MagicMock()

--- a/graphrag_sdk/tests/test_vector_store.py
+++ b/graphrag_sdk/tests/test_vector_store.py
@@ -174,6 +174,20 @@ class TestVectorStoreSearch:
         assert results[0]["score"] == 0.95
         cypher = mock_connection.query.call_args[0][0]
         assert "'Chunk'" in cypher
+        assert "ORDER BY score ASC" in cypher
+
+    async def test_search_entities_orders_by_distance(self, vector_store, mock_connection):
+        result_mock = MagicMock()
+        result_mock.result_set = [["entity-1", "Alice", "Engineer", 0.95]]
+        mock_connection.query = AsyncMock(return_value=result_mock)
+
+        results = await vector_store.search_entities(query_vector=[0.1] * 8, top_k=5)
+
+        assert results[0]["id"] == "entity-1"
+        assert results[0]["score"] == 0.95
+        cypher = mock_connection.query.call_args[0][0]
+        assert "'__Entity__'" in cypher
+        assert "ORDER BY score ASC" in cypher
 
     async def test_search_chunks_empty(self, vector_store, mock_connection):
         result_mock = MagicMock()


### PR DESCRIPTION
## Issue

Closes #294.

## Background

FalkorDB vector-index scores are distances, where lower values are closer matches. The node and relationship vector search paths previously exposed some results in descending order, returning less similar results first to direct callers.

## Changes

- Order chunk, entity, and relationship vector-index searches by ascending distance.
- Keep the relationship fallback ordered by ascending cosine distance.
- Add multi-row regression coverage with an exact `0.0` self-match for all three search methods.
- Document that returned `score` values represent distances.

## Compatibility

This changes only the ordering of direct vector search results so the closest matches are returned first. Public method signatures and result shapes are unchanged.

## Test Plan

- `python -m pytest graphrag_sdk/tests/test_vector_store.py -q` — 32 passed.
- `git diff --check` — passed.
- `python -m ruff check graphrag_sdk/src/graphrag_sdk/storage/vector_store.py graphrag_sdk/tests/test_vector_store.py` — existing unrelated lint errors remain in `test_vector_store.py` (unused import, unused local, import ordering).
- Full suite was attempted with `python -m pytest graphrag_sdk/tests/ -q`; the environment hit an existing Windows temp-directory permission error, and a rerun with `--basetemp=.pytest-tmp` encountered unrelated failures and a long-running test, so no full-suite pass is claimed.
- The benchmark was not run because the repository does not provide a self-contained benchmark command/data set in the checkout and its documented evaluation requires the separate 100-question corpus and model setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vector search results for chunks, entities, and relationships now use consistent cosine-distance scores.
  * Results are ordered from the lowest distance score to the highest, with lower scores representing closer matches.
  * Relationship fallback searches now report distance scores consistently.

* **Tests**
  * Expanded coverage for result ordering, self-matches, entity and relationship searches, result parsing, and generated queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->