### PR TITLE
chore(ci): pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       run:
         working-directory: graphrag_sdk
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -33,8 +33,8 @@ jobs:
       run:
         working-directory: graphrag_sdk
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
@@ -65,8 +65,8 @@ jobs:
       FALKOR_HOST: localhost
       FALKOR_PORT: "6379"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - run: pip install -e ".[dev]"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24.19.0"
 

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -16,9 +16,9 @@ jobs:
       run:
         working-directory: graphrag_sdk
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -37,11 +37,11 @@ jobs:
       - run: python -m build
       - run: twine check dist/*
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: python-package-distributions
           path: graphrag_sdk/dist/
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: graphrag_sdk/dist/


### PR DESCRIPTION
## Summary
Pins every GitHub Actions `uses:` reference in this repository's workflows to a full 40-character commit SHA instead of a mutable tag or branch.

Mutable refs (`@v4`, `@main`, `@stable`, …) are re-pointable by the action owner or an attacker who compromises the action repo. Because these workflows run with repository secrets and write permissions, a moved tag is a direct supply-chain code-execution path. GitHub's own hardening guide and OpenSSF Scorecard both require full-SHA pinning.

## Changes
- Pinned **12** action reference(s) across **3** workflow file(s).
- Each SHA is the commit the original tag/branch resolved to at the time of this PR, so **behaviour is unchanged**.
- The original version is preserved as a trailing comment for readability and for Dependabot, e.g.
  ```yaml
  uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
  ```

Workflow files touched:
- `ci.yml`
- `docs.yml`
- `pypi-publish.yaml`

Resulting pinned references:
- `actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6`
- `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4`
- `actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6`
- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7`
- `pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1`

## Testing
- All modified workflow files were validated as parseable YAML.
- The diff is strictly 1-line-in / 1-line-out on `uses:` lines only — no jobs, steps, triggers, inputs, permissions or action *versions* were changed (verified via `git diff --shortstat`).
- Every SHA was resolved through the GitHub API (`GET /repos/{owner}/{repo}/commits/{ref}`) from the exact ref previously in use; no ref failed to resolve.
- Final verification is the CI run on this PR.

## Memory / Performance Impact
N/A — CI configuration only.

## Related Issues
N/A — part of an org-wide GitHub Actions supply-chain hardening pass across the FalkorDB organisation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability and security by pinning automation actions to immutable versions.
  * Applied consistent action versioning across CI, documentation, and package publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->