### PR TITLE
fix(deps): raise dependency floors to patched versions for Dependabot alerts

### DIFF
--- a/graphrag_sdk/pyproject.toml
+++ b/graphrag_sdk/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pydantic>=2.0,<3.0",
     "falkordb>=1.0,<2",
     "numpy>=1.24,<3",
-    "python-dotenv>=1.0",
+    "python-dotenv>=1.2.2",
     "tiktoken>=0.5,<1.0",
     "gliner>=0.2,<1",
     "hnswlib>=0.8",
@@ -47,12 +47,12 @@ openai = ["openai>=1.0,<3.0"]
 anthropic = ["anthropic>=0.20,<1.0"]
 cohere = ["cohere>=5.0"]
 sentence-transformers = ["sentence-transformers>=2.0"]
-pdf = ["pypdf>=6.9.2"]
+pdf = ["pypdf>=6.15.0"]
 markdown = ["markdown-it-py>=3.0.0"]
 # Optional faster/table-aware PDF backend. PyMuPDF is AGPL-3.0 — if that is
 # incompatible with your project's license, stick with the default `pdf` extra.
 pdf-fast = ["pymupdf>=1.24"]
-litellm = ["litellm>=1.83.0,<2.0"]
+litellm = ["litellm>=1.84.0,<2.0"]
 openrouter = ["openai>=1.0,<3.0"]
 fastcoref = ["fastcoref>=2.0"]
 spacy = ["spacy>=3.0"]
@@ -61,11 +61,11 @@ all = [
     "anthropic>=0.20,<1.0",
     "cohere>=5.0",
     "sentence-transformers>=2.0",
-    "pypdf>=6.9.2",
-    "litellm>=1.83.0,<2.0",
+    "pypdf>=6.15.0",
+    "litellm>=1.84.0,<2.0",
 ]
 dev = [
-    "pytest>=8.0",
+    "pytest>=9.0.3",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
     "ruff>=0.4",


### PR DESCRIPTION
## Summary

Reviewed all 127 open Dependabot alerts on the repo. **Every alert is filed against `uv.lock` at the repository root — a file that no longer exists** (it was removed in the v2.0 rewrite, which moved the project to `graphrag_sdk/pyproject.toml` with no lock file). Those alerts are stale and should auto-close on Dependabot's next scan of `main`.

The genuinely actionable issue is that `graphrag_sdk/pyproject.toml` declares dependency *floors* that are below the patched versions, so a fresh `pip install graphrag-sdk[...]` with an old resolver or a pre-existing environment can still land on a vulnerable release. This PR raises those floors.

## Changes

`graphrag_sdk/pyproject.toml`:

| Package | Before | After | Advisories addressed |
|---|---|---|---|
| `python-dotenv` (core) | `>=1.0` | `>=1.2.2` | Symlink following in `set_key` allows arbitrary file overwrite (medium) |
| `pypdf` (`pdf`, `all`) | `>=6.9.2` | `>=6.15.0` | 31 alerts — infinite loops on unterminated inline images (high ×2), memory exhaustion via XMP/form XObjects/`/ToUnicode`/CID width ranges, ignored stream-length limits |
| `litellm` (`litellm`, `all`) | `>=1.83.0` | `>=1.84.0` | Auth bypass via Host header injection (critical), MCP auth bypass via OAuth2 passthrough (high), `/user/update` self-role escalation (high), API-key route escalation (high), path traversal in Skills archive extraction, OIDC local file read |
| `pytest` (`dev`) | `>=8.0` | `>=9.0.3` | Vulnerable tmpdir handling (medium) |

Transitive-only packages with alerts (`aiohttp`, `requests`, `urllib3`, `idna`, `protobuf`, `setuptools`, `pyasn1`) were deliberately **not** pinned — over-constraining transitive deps in a library hurts downstream consumers. Verified that current resolution already picks patched versions of all of them (see Testing). The `jupyterlab` / `jupyter-server` / `notebook` / `nbconvert` / `mistune` / `bleach` / `tornado` / `soupsieve` / `Pygments` alerts came from notebook tooling in the deleted lock file and have no counterpart in the current manifest.

## Testing

- `uv pip compile --python-version 3.10 pyproject.toml --extra all --extra dev` resolves cleanly. Resulting versions include `aiohttp==3.14.3`, `urllib3==2.7.0`, `idna==3.19`, `requests==2.34.2`, `protobuf==7.36.0`, `pypdf==6.16.1`, `litellm==1.97.0`, `python-dotenv==1.2.3` — all at or above their patched versions.
- `pip install -e ".[dev]"` in a clean Python 3.12 venv, then `pytest tests/ -q`: **1096 passed, 41 skipped**. No breakage from the pytest 8 → 9 jump.
- `pytest>=9.0.3` requires Python >=3.10, which matches the project's `requires-python = ">=3.10"`, so the 3.10/3.11/3.12 CI matrix is unaffected.

## Memory / Performance Impact

N/A — dependency metadata only, no code changes.

## Related Issues

Addresses the actionable subset of https://github.com/FalkorDB/GraphRAG-SDK/security/dependabot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package requirements to newer supported versions.
  * Improved compatibility and reliability for PDF processing, language-model integrations, environment configuration, and test execution.
  * Preserved optional PDF installation choices, including the streamlined PDF setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->