### PR TITLE
ci: add explicit read-only permissions to ci.yml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, staging]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
## Summary
Fixes all open code scanning alerts for this repository under the `actions/missing-workflow-permissions` rule.

## Changes
- Added a top-level `permissions: contents: read` block to `.github/workflows/ci.yml`, matching the pattern already used in `docs.yml`. This resolves the missing default `GITHUB_TOKEN` permissions for the `lint`, `test`, and `integration` jobs.

## Testing
- Validated the workflow YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- No functional workflow behavior changes; this only scopes down default token permissions.

## Memory / Performance Impact
N/A (CI workflow configuration only).

## Related Issues
Fixes code scanning alerts #39, #43, #44 (`actions/missing-workflow-permissions`) at https://github.com/FalkorDB/GraphRAG-SDK/security/code-scanning. All other alerts in the list are already in `fixed`/`dismissed` state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build checks with explicit read-only access permissions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->