### PR TITLE
docs: add missing examples 06, 08-10 to README examples table

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,11 @@ guards the default.
 | 3 | [Custom Strategies](graphrag_sdk/examples/03_custom_strategies.py) | Composing ingestion strategies explicitly |
 | 4 | [Custom Provider](graphrag_sdk/examples/04_custom_provider.py) | Plug in any LLM or embedder behind a clean interface |
 | 5 | [Notebook Demo](graphrag_sdk/examples/05_notebook_demo.ipynb) | An interactive walkthrough that shows the provenance trail |
+| 6 | [Markdown, Document-Aware](graphrag_sdk/examples/06_markdown_document_aware.py) | Structure-preserving Markdown ingestion with queryable heading breadcrumbs |
 | 7 | [Incremental Updates](graphrag_sdk/examples/07_incremental_updates.py) | `update`, `delete_document`, and `apply_changes` for CI-driven graph syncs |
+| 8 | [Ontology Lifecycle](graphrag_sdk/examples/08_ontology_lifecycle.py) | Declare an ontology, ingest with it, and round-trip it as JSON config |
+| 9 | [Ontology Evolution](graphrag_sdk/examples/09_ontology_evolution.py) | Mutating schema evolution — rename types and atomically add attributes with LLM backfill |
+| 10 | [Ontology Discovery](graphrag_sdk/examples/10_ontology_discovery.py) | Discover an ontology from raw sources and propose extensions as new docs arrive |
 
 ---
 


### PR DESCRIPTION
## What

The examples table in the README lists examples 1–5 and 7, but four working examples under `graphrag_sdk/examples/` are missing:

- `06_markdown_document_aware.py` — structure-preserving Markdown ingestion (`StructuralChunking` + `MarkdownLoader`)
- `08_ontology_lifecycle.py` — declare an `Ontology`, ingest with it, read it back, round-trip as JSON
- `09_ontology_evolution.py` — mutating evolution (`add_attribute` with atomic LLM backfill, renames, drops)
- `10_ontology_discovery.py` — `Ontology.from_sources(...)` and `suggest_schema_extensions(...)`

This adds one table row per example, with a short description of what each builds.

## Why

The table currently jumps from 5 to 7, and the three ontology examples are not discoverable from the README at all, even though they demonstrate the v1.2 ontology API. The new rows use the `ontology` vocabulary to stay consistent with the migration in #279.

## How I verified

- Confirmed all four files exist in `graphrag_sdk/examples/` and read each script to match the description to its actual behavior.
- Checked that every relative link in the updated table resolves to an existing file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted and expanded the README.
  * Added benchmark results and methodology.
  * Updated Quick Start guidance.
  * Documented incremental updates and ingestion/retrieval pipelines.
  * Added examples covering Markdown ingestion, ontology lifecycle, evolution, and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->