### PR TITLE
docs: consolidate hallucination-reduction and grounding docs (supersedes #311, #312, #314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accuracy to the SDK APIs that implement them.
 - New example `graphrag_sdk/examples/grounded_answers_with_abstention.py`
   showing a retrieval gate that returns an explicit evidence-insufficient
-  response — with zero LLM calls — before generation, plus the citations
+  response — before the generation call — plus the citations
   behind a grounded answer. Covered by
   `graphrag_sdk/tests/test_grounded_abstention.py`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New documentation page **Reducing LLM Hallucinations**
+  (`docs/reducing-llm-hallucinations.mdx`) — the guide to grounded retrieval,
+  `MENTIONED_IN` source provenance, inspecting the evidence trail with
+  `return_context=True`, and defining an explicit abstention path.
+  Cross-linked from the index, architecture, retrieval and benchmark pages.
+- New documentation page **Reliability and Grounding**
+  (`docs/reliability-and-grounding.mdx`), the API-level reference behind that
+  guide: it maps grounded retrieval, source provenance, evidence trails,
+  relationship-aware retrieval, metadata filtering, confidence thresholds,
+  abstention behavior, unsupported claims, retrieval validation and factual
+  accuracy to the SDK APIs that implement them.
+- New example `graphrag_sdk/examples/grounded_answers_with_abstention.py`
+  showing a retrieval gate that returns an explicit evidence-insufficient
+  response — with zero LLM calls — before generation, plus the citations
+  behind a grounded answer. Covered by
+  `graphrag_sdk/tests/test_grounded_abstention.py`.
+
 ### Fixed
 
 - Fixed vector-search ordering so chunk, entity, and relationship searches use

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">GraphRAG-SDK</h1>
 <h2 align="center">The simplest, most accurate GraphRAG framework built on FalkorDB</h2>
 
-<p align="center"><b>Benchmark-leading accuracy</b> · <b>FalkorDB-fast</b> · <b>Multi-tenant</b> · <b>Graph traversal</b> · <b><a href="#quick-start">5-minute setup</a></b></p>
+<p align="center"><b>Benchmark-leading accuracy</b> · <b><a href="https://docs.falkordb.com/graphrag/reducing-llm-hallucinations">Reduce LLM hallucinations</a></b> · <b>FalkorDB-fast</b> · <b>Multi-tenant</b> · <b>Graph traversal</b> · <b><a href="#quick-start">5-minute setup</a></b></p>
 
 <p align="center">
   <a href="https://pypi.org/project/graphrag-sdk/"><img src="https://img.shields.io/pypi/v/graphrag-sdk.svg?label=pypi" alt="PyPI version"></a>
@@ -17,6 +17,22 @@
 
 
 Most GraphRAG systems work in demos and break under production constraints. GraphRAG SDK was built from real deployments around a simple idea: the retrieval harness matters more than the model. The result is a modular, benchmark-leading framework with predictable cost and sensible defaults that gets you from raw documents to cited answers in under 5 minutes.
+
+It is designed to **reduce LLM hallucinations**: every answer is grounded in context retrieved from the knowledge graph and stays traceable to its source chunks through `MENTIONED_IN` provenance edges, so any claim can be checked against the document it came from. When the graph holds no supporting evidence, your application can abstain and say so instead of letting the model guess — see the [Reducing LLM Hallucinations guide](https://docs.falkordb.com/graphrag/reducing-llm-hallucinations) and the [grounded answers with abstention example](graphrag_sdk/examples/grounded_answers_with_abstention.py).
+
+---
+
+## Why GraphRAG for factual reliability?
+
+Hallucinations in RAG are usually a retrieval failure, not a model failure: the model is asked to answer from context that never contained the answer. A knowledge graph attacks that at the retrieval layer, and keeps the evidence attached to the answer.
+
+- **Relationship traversal retrieves the connected evidence vector similarity misses** — multi-hop facts rarely live in one chunk that happens to be similar to the question.
+- **Every answer is traceable to its source chunks** via `MENTIONED_IN` edges; pass `return_context=True` to `completion()` to get the retrieval trail back with the answer.
+- **The ontology constrains what can be extracted**, so the graph stores typed, checkable facts instead of free-form model output.
+- **The system can abstain when evidence is insufficient** — gate generation on retrieval and return an explicit "evidence-insufficient" response ([example](graphrag_sdk/examples/grounded_answers_with_abstention.py)).
+- **Benchmark accuracy is the measurable outcome** of all of the above — see the table below.
+
+→ Full guide: [Reducing LLM hallucinations](https://docs.falkordb.com/graphrag/reducing-llm-hallucinations) · API reference: [Reliability and Grounding](https://docs.falkordb.com/graphrag/reliability-and-grounding)
 
 ---
 
@@ -208,7 +224,7 @@ guards the default.
 | Retrieval | Relationship expansion | DB |
 | Retrieval | Cosine reranking | Local |
 
-> 💡 Every answer is traceable to its source chunks via `MENTIONS` edges. Pass `return_context=True` to `completion()` to get the retrieval trail alongside the answer.
+> 💡 Every answer is traceable to its source chunks via `MENTIONED_IN` edges. Pass `return_context=True` to `completion()` to get the retrieval trail alongside the answer.
 
 ---
 
@@ -228,6 +244,7 @@ guards the default.
 | 8 | [Ontology Lifecycle](graphrag_sdk/examples/08_ontology_lifecycle.py) | Declare an ontology, ingest with it, and round-trip it as JSON config |
 | 9 | [Ontology Evolution](graphrag_sdk/examples/09_ontology_evolution.py) | Mutating schema evolution — rename types and atomically add attributes with LLM backfill |
 | 10 | [Ontology Discovery](graphrag_sdk/examples/10_ontology_discovery.py) | Discover an ontology from raw sources and propose extensions as new docs arrive |
+| ★ | [Grounded Answers with Abstention](graphrag_sdk/examples/grounded_answers_with_abstention.py) | Cite the retrieved context behind an answer, and abstain when the graph has no supporting evidence |
 
 ---
 
@@ -239,9 +256,11 @@ Full documentation: **<https://docs.falkordb.com/graphrag>**
 |-------|-------------|
 | [Getting Started](https://docs.falkordb.com/graphrag/getting-started) | Step-by-step tutorial from install to first query |
 | [Architecture](https://docs.falkordb.com/graphrag/architecture) | Pipeline design, graph schema, retrieval strategy |
+| [Reducing LLM Hallucinations](https://docs.falkordb.com/graphrag/reducing-llm-hallucinations) | Grounded retrieval, source provenance, and abstention |
 | [Configuration](https://docs.falkordb.com/graphrag/configuration) | Connection, providers, and tuning reference |
 | [Strategies](https://docs.falkordb.com/graphrag/strategies) | All ABCs and built-in implementations |
 | [Providers](https://docs.falkordb.com/graphrag/providers) | LLM and embedder configuration guide |
+| [Reliability and Grounding](https://docs.falkordb.com/graphrag/reliability-and-grounding) | Grounding, provenance and abstention mapped to the APIs that implement them |
 | [Benchmark](https://docs.falkordb.com/graphrag/benchmark) | Methodology, results, and reproduction instructions |
 | [Accuracy Benchmark: FalkorDB vs Vector RAG](https://docs.falkordb.com/graphrag/graphrag-accuracy-benchmark) | 71.48 vs 55.39 comparison, evaluation definition, limitations, how to cite |
 | [API Reference](https://docs.falkordb.com/graphrag/api-reference) | Full API documentation |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Most GraphRAG systems work in demos and break under production constraints. GraphRAG SDK was built from real deployments around a simple idea: the retrieval harness matters more than the model. The result is a modular, benchmark-leading framework with predictable cost and sensible defaults that gets you from raw documents to cited answers in under 5 minutes.
 
-It is designed to **reduce LLM hallucinations**: every answer is grounded in context retrieved from the knowledge graph and stays traceable to its source chunks through `MENTIONED_IN` provenance edges, so any claim can be checked against the document it came from. When the graph holds no supporting evidence, your application can abstain and say so instead of letting the model guess — see the [Reducing LLM Hallucinations guide](https://docs.falkordb.com/graphrag/reducing-llm-hallucinations) and the [grounded answers with abstention example](graphrag_sdk/examples/grounded_answers_with_abstention.py).
+It is designed to **reduce LLM hallucinations**: answers can be grounded in context retrieved from the knowledge graph, while applications inspect that context, validate generated claims, and gate generation when evidence is insufficient. `MENTIONED_IN` provenance edges trace entity mentions to their source chunks — see the [Reducing LLM Hallucinations guide](https://docs.falkordb.com/graphrag/reducing-llm-hallucinations) and the [grounded answers with abstention example](graphrag_sdk/examples/grounded_answers_with_abstention.py).
 
 ---
 
@@ -27,9 +27,9 @@ It is designed to **reduce LLM hallucinations**: every answer is grounded in con
 Hallucinations in RAG are usually a retrieval failure, not a model failure: the model is asked to answer from context that never contained the answer. A knowledge graph attacks that at the retrieval layer, and keeps the evidence attached to the answer.
 
 - **Relationship traversal retrieves the connected evidence vector similarity misses** — multi-hop facts rarely live in one chunk that happens to be similar to the question.
-- **Every answer is traceable to its source chunks** via `MENTIONED_IN` edges; pass `return_context=True` to `completion()` to get the retrieval trail back with the answer.
+- **Retrieved context is traceable to source chunks**; `MENTIONED_IN` edges trace entity mentions, and `return_context=True` returns the retrieval trail for application-level validation.
 - **The ontology constrains what can be extracted**, so the graph stores typed, checkable facts instead of free-form model output.
-- **The system can abstain when evidence is insufficient** — gate generation on retrieval and return an explicit "evidence-insufficient" response ([example](graphrag_sdk/examples/grounded_answers_with_abstention.py)).
+- **Your application can abstain when evidence is insufficient** — gate generation on retrieval and return an explicit "evidence-insufficient" response ([example](graphrag_sdk/examples/grounded_answers_with_abstention.py)).
 - **Benchmark accuracy is the measurable outcome** of all of the above — see the table below.
 
 → Full guide: [Reducing LLM hallucinations](https://docs.falkordb.com/graphrag/reducing-llm-hallucinations) · API reference: [Reliability and Grounding](https://docs.falkordb.com/graphrag/reliability-and-grounding)
@@ -224,7 +224,7 @@ guards the default.
 | Retrieval | Relationship expansion | DB |
 | Retrieval | Cosine reranking | Local |
 
-> 💡 Every answer is traceable to its source chunks via `MENTIONED_IN` edges. Pass `return_context=True` to `completion()` to get the retrieval trail alongside the answer.
+> 💡 Retrieved context can be traced to source chunks; `MENTIONED_IN` edges connect entity mentions to chunks. Pass `return_context=True` to `completion()` so your application can inspect the retrieval trail and validate generated claims.
 
 ---
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -73,6 +73,8 @@ The knowledge graph contains these node types and edge types:
 
 All LLM-extracted relationships use the single `RELATES` edge type. The original relationship type (e.g. `WORKS_AT`, `LOCATED_IN`) is preserved as the `rel_type` property on the edge. A `fact` property stores a human-readable fact string for embedding.
 
+`MENTIONED_IN` edges are what let retrieval trace an entity mentioned in an answer back to its source chunk — see [Reducing LLM Hallucinations](/reducing-llm-hallucinations) for how to surface that provenance trail and define an abstention path when it's missing.
+
 ### Post-ingestion: Entity Deduplication
 
 Entity deduplication is handled post-ingestion via `deduplicate_entities()` rather than during the pipeline. This allows ingesting multiple documents independently, then deduplicating globally. The method groups entities by `(normalized name, label)` to prevent cross-type merging (e.g. Person "Paris" and Location "Paris" remain separate).
@@ -180,3 +182,4 @@ Each subsystem has a dedicated document with step-by-step explanations:
 - [Graph Schema](/graph-schema) — how the knowledge graph is structured in FalkorDB
 - [Storage](/storage) — GraphStore, VectorStore, and EntityDeduplicator internals
 - [Retrieval](/retrieval) — the multi-path retrieval system that answers questions
+- [Reducing LLM Hallucinations](/reducing-llm-hallucinations) — grounding answers in retrieved evidence and defining an abstention path

--- a/docs/benchmark.mdx
+++ b/docs/benchmark.mdx
@@ -21,6 +21,11 @@ dependencies — is available on request; open an
 [Discord](https://discord.gg/6M4QwDXn2w). The ontologies themselves are
 published below, along with the full configuration.
 
+This score is a ceiling on task performance against a fixed dataset, not a
+guarantee about your data. Grounded retrieval and an explicit abstention path
+are what set the floor for production reliability — see
+[Reducing LLM Hallucinations](/reducing-llm-hallucinations).
+
 ## Results
 
 Scores are ACC unless noted. **Average is the unweighted mean of the four ACC
@@ -164,6 +169,15 @@ reported to the benchmark authors.
 over 2053 of 2062 Medical and 1995 of 2009 Novel predictions. Every prediction
 itself succeeded; there were no generation failures or empty answers in either
 subset.
+
+<Note>
+A benchmark score measures task performance on a fixed, offline dataset. It
+does not measure hallucination rate on your own data — that also depends on
+your source-data quality, how narrowly retrieval is scoped, prompting, and
+the abstention logic your application defines. See
+[Reducing LLM Hallucinations](/reducing-llm-hallucinations) for how to ground
+and verify answers in your own deployment.
+</Note>
 
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,6 +52,7 @@
                   "index",
                   "getting-started",
                   "architecture",
+                  "reducing-llm-hallucinations",
                   "configuration"
                 ]
               },
@@ -79,6 +80,7 @@
                   "strategies",
                   "providers",
                   "api-reference",
+                  "reliability-and-grounding",
                   "graphrag-accuracy-benchmark",
                   "benchmark"
                 ]

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,6 +7,10 @@ description: "The most accurate Graph RAG framework. Build knowledge graphs from
 
 GraphRAG SDK builds knowledge graphs from documents and answers questions over them using graph-based retrieval-augmented generation. Every pipeline step is a swappable strategy behind an abstract interface.
 
+<Card title="Reducing LLM Hallucinations" icon="shield-check" href="/reducing-llm-hallucinations">
+  How grounded retrieval, source provenance, and an explicit abstention path make answers verifiable instead of guessed.
+</Card>
+
 ## Key Highlights
 
 - **#1 on GraphRAG-Bench** — 66.09 ACC on Novel and 76.87 on Medical ([benchmark](/benchmark))
@@ -45,6 +49,7 @@ asyncio.run(main())
 
 - [Getting Started](/getting-started) -- Full tutorial from install to first query
 - [Architecture](/architecture) -- How the 9-step pipeline works
+- [Reducing LLM Hallucinations](/reducing-llm-hallucinations) -- Grounded retrieval, provenance, and abstention
 - [Strategies](/strategies) -- All swappable strategy ABCs and built-in options
 - [Ontology Discovery](/ontology-discovery) -- Auto-draft a schema from a corpus (`method="llm"` or `method="grounded"` with DBpediaCatalog)
 - [Ontology Evolution](/ontology-evolution) -- Safely change schema on a populated graph

--- a/docs/reducing-llm-hallucinations.mdx
+++ b/docs/reducing-llm-hallucinations.mdx
@@ -60,12 +60,20 @@ named in the opening paragraph map onto it like this:
 Embedding similarity search runs in two places: over `Chunk` text (finds
 passages with similar meaning, even without shared keywords) and over
 `RELATES` edges (finds structured facts — `Entity —[REL]→ Entity` — by
-meaning). Both are implemented with FalkorDB's `db.idx.vector.queryNodes` and
-scored, so low-relevance results can be filtered before they reach the LLM
+meaning). They use different FalkorDB procedures: chunk and entity search call
+`db.idx.vector.queryNodes`, while edge search calls
+`db.idx.vector.queryRelationships` (FalkorDB ≥ 4.2), falling back to a
+`vec.cosineDistance` Cypher scan on older servers
 (`search_relates_edges()` in
 [`entity_discovery.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py),
 `retrieve_chunks()` in
 [`chunk_retrieval.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/chunk_retrieval.py)).
+
+Both paths return a similarity score, but note where that score is and isn't
+used as a filter: facts are thresholded by `filter_facts_by_relevance()`,
+whereas chunk retrieval applies **no similarity floor** — it takes the top *k*
+and ranks them. Scores reach you, but low-relevance passages are not dropped
+for you.
 
 ### Full-text / keyword search
 
@@ -249,9 +257,9 @@ question never reaches the generation call. Three details matter in practice:
 - **Don't share one `Context` across both calls.** `Context` starts its clock
   when it is constructed and `remaining_budget_ms` never resets, so a `ctx`
   passed to `retrieve()` and then reused for `completion()` charges the gate's
-  latency against the generation's budget — and the double retrieval makes that
-  budget roughly twice as tight. Build a fresh `Context` for the second call, or
-  size `latency_budget_ms` for the whole two-phase sequence.
+  latency against the generation's budget — and the gate is the cheap half.
+  Pass `ctx.child()` to the second call: it inherits the tenant, trace and
+  *remaining* budget, but starts its own clock.
 
 Tune the thresholds to your risk tolerance — for example, restrict the
 supporting sections to `"passages"` specifically if only source-text-grounded

--- a/docs/reducing-llm-hallucinations.mdx
+++ b/docs/reducing-llm-hallucinations.mdx
@@ -97,6 +97,8 @@ multi-hop paths) that text search can't express
 enabled — treat it as an opt-in capability to turn on once your ontology is
 stable, not a default-on feature:
 
+Given initialized `embedder`, `llm`, and `rag` instances:
+
 ```python
 from graphrag_sdk import ConnectionConfig, FalkorDBConnection, GraphStore, VectorStore
 from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval

--- a/docs/reducing-llm-hallucinations.mdx
+++ b/docs/reducing-llm-hallucinations.mdx
@@ -1,0 +1,329 @@
+---
+title: "Reducing LLM Hallucinations"
+description: "How grounded retrieval, source provenance, and an explicit abstention path make GraphRAG SDK answers verifiable instead of guessed."
+---
+
+FalkorDB GraphRAG helps applications reduce unsupported LLM answers by retrieving connected, source-linked facts before generation. It combines vector search, graph traversal, relationship expansion, and source provenance so developers can inspect the evidence used for an answer and define an abstention path when evidence is insufficient.
+
+<Note>
+No retrieval technique eliminates hallucinations. This page describes how to
+**reduce** unsupported answers, **ground** them in retrieved evidence, and
+**make grounding inspectable and verifiable** — not how to guarantee a
+correct answer every time.
+</Note>
+
+For the API-level reference — which class, parameter or returned field
+implements each of these concepts, and where the SDK deliberately leaves a
+decision to you — see [Reliability and Grounding](/reliability-and-grounding).
+
+## Why RAG systems produce unsupported answers
+
+A hallucination is a fluent answer the evidence does not support. In a RAG
+system it is usually a *retrieval* failure rather than a model failure: the
+model was handed context that never contained the answer, and it filled the
+gap anyway. A plain vector-search pipeline embeds the question, finds the *k*
+most similar chunks, and asks the LLM to answer from them. That fails in three
+common ways:
+
+- **Retrieval misses the connecting fact.** The answer requires combining two
+  facts from different documents (or different parts of the same document),
+  but no single chunk contains both, so similarity search never surfaces the
+  link between them. Multi-hop questions — "who manages the office that Acme
+  opened in 2026?" — are the usual casualty.
+- **Chunks are similar but not relevant.** Cosine similarity rewards
+  *topical* overlap, not *answer-bearing* content. A chunk can rank highly
+  because it shares vocabulary with the question while containing none of the
+  facts needed to answer it.
+- **The model fills the gap.** When the retrieved context is incomplete, an
+  LLM will usually still produce a fluent, confident-sounding answer rather
+  than say "I don't know" — because nothing in the pipeline checks whether
+  the context actually supports the claim before generation.
+
+GraphRAG SDK addresses the first two problems with multiple retrieval paths
+over a knowledge graph (instead of one similarity search over flat chunks),
+and gives applications the tools to address the third with an explicit
+abstention check (see [Defining an abstention path](#defining-an-abstention-path)
+below).
+
+## How each mechanism grounds an answer
+
+Retrieval is handled by `MultiPathRetrieval`
+([`multi_path.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/multi_path.py)),
+the SDK's default retrieval strategy. It runs several independent search
+mechanisms in parallel and merges their results, so a fact only needs to be
+found by *one* path to make it into the final context — see
+[Retrieval](/retrieval) for the full step-by-step breakdown. The mechanisms
+named in the opening paragraph map onto it like this:
+
+### Vector search
+
+Embedding similarity search runs in two places: over `Chunk` text (finds
+passages with similar meaning, even without shared keywords) and over
+`RELATES` edges (finds structured facts — `Entity —[REL]→ Entity` — by
+meaning). Both are implemented with FalkorDB's `db.idx.vector.queryNodes` and
+scored, so low-relevance results can be filtered before they reach the LLM
+(`search_relates_edges()` in
+[`entity_discovery.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/entity_discovery.py),
+`retrieve_chunks()` in
+[`chunk_retrieval.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/chunk_retrieval.py)).
+
+### Full-text / keyword search
+
+A fulltext index over chunk text and entity names catches exact keyword and
+name matches that embedding similarity sometimes misses — useful for rare
+proper nouns, IDs, or terms the embedding model doesn't weight heavily. This
+runs as an independent path alongside vector search rather than as a
+fallback, so both contribute candidates every query.
+
+### Graph traversal and relationship expansion
+
+Entities discovered in the question are expanded outward through the graph:
+1-hop direct relationships and 2-hop indirect connections
+(`expand_relationships()` in
+[`relationship_expansion.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/relationship_expansion.py)),
+plus `MENTIONED_IN` traversal from an entity back to the chunks it was
+extracted from. This is what lets the pipeline answer questions that require
+*connecting* two facts — the case a single similarity search misses — because
+the connection is a graph edge, not a coincidence of vocabulary.
+
+### Ontology-guided text-to-Cypher
+
+The LLM can optionally generate a read-only Cypher query against the graph
+schema for questions that need structural answers (counts, exact lists,
+multi-hop paths) that text search can't express
+(`execute_cypher_retrieval()` in
+[`cypher_generation.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/cypher_generation.py)).
+**This path is off by default** (`enable_cypher=False`) and adds latency when
+enabled — treat it as an opt-in capability to turn on once your ontology is
+stable, not a default-on feature:
+
+```python
+from graphrag_sdk import ConnectionConfig, FalkorDBConnection, GraphStore, VectorStore
+from graphrag_sdk.retrieval.strategies.multi_path import MultiPathRetrieval
+
+connection = FalkorDBConnection(ConnectionConfig(host="localhost", graph_name="my_graph"))
+
+strategy = MultiPathRetrieval(
+    graph_store=GraphStore(connection),
+    vector_store=VectorStore(connection, embedder=embedder, embedding_dimension=256),
+    embedder=embedder,
+    llm=llm,
+    enable_cypher=True,  # opt-in, off by default
+)
+result = await rag.completion("How many organizations are mentioned?", strategy=strategy)
+```
+
+### Cosine reranking
+
+Passage candidates gathered from every path are pooled, then reranked by
+cosine similarity against the question using the embeddings already stored on
+each `Chunk` node at ingestion time — no extra embedding API call
+(`rerank_chunks()` in
+[`result_assembly.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/result_assembly.py)).
+Knowledge-graph facts go through a separate, higher-threshold filter
+(`filter_facts_by_relevance()`) instead, since short fact strings have higher
+similarity variance than prose passages. Only the top-ranked, above-threshold
+evidence reaches the LLM prompt.
+
+## Inspecting the evidence
+
+Every extracted entity is linked back to its source text by a
+`MENTIONED_IN` edge (`__Entity__ → Chunk`), written during ingestion
+(see the [ingestion pipeline](/ingestion)). That edge is what lets the
+retrieval pipeline trace an entity mentioned in an answer back to the exact
+passage it came from, and it's what the `MENTIONED_IN` graph traversal path
+(above) uses to fetch supporting passages for the entities discovered in a
+question. Because the chunk is the unit that `MENTIONED_IN` points at, an
+answer can always be walked back to the document text that supports it.
+
+To see this trail yourself, pass `return_context=True` to `completion()`. The
+returned `RagResult.retriever_result` then contains the full set of retrieved
+items — a list of `RetrieverResultItem` objects, each with `content`, `score`
+and a `metadata` dict — including the `passages` section with each cited
+source chunk:
+
+<CodeGroup>
+
+```python Grounded answer with citations
+result = await rag.completion("What did Professor Harmon discover?", return_context=True)
+
+print(result.answer)
+
+for item in result.retriever_result.items:
+    if item.metadata.get("section") == "passages":
+        for passage in item.content.split("\n---\n"):
+            print(passage)
+```
+
+```python Retrieval only (no generation)
+context = await rag.retrieve("What did Professor Harmon discover?")
+
+print(len(context.items), "context items")
+for item in context.items:
+    print(item.metadata.get("section"), item.content[:120])
+```
+
+</CodeGroup>
+
+Each entry in the `passages` section is prefixed with `[Source: <document
+path>]` when the source document could be resolved, so you can confirm which
+document (and, via `MENTIONED_IN`, which chunk) backs a claim in the answer —
+rather than trusting the answer at face value.
+
+<Tip>
+`result.metadata` also carries `num_context_items` and `retrieval_query` —
+useful signals to log next to every answer you serve.
+</Tip>
+
+`retrieve()` runs the same retrieval path *without* calling the LLM, which
+makes it the natural place to put a gate: you decide whether to generate
+before paying for a generation.
+
+## Defining an abstention path
+
+Grounding only helps if the application acts on it. If retrieval comes back
+empty — or with no `passages` / `facts` evidence — the model still generates a
+fluent answer unless the application checks first. The pattern is small:
+retrieve, count the supporting items, and either answer or return an explicit
+evidence-insufficient response.
+
+```python
+INSUFFICIENT_EVIDENCE = (
+    "I don't have enough evidence in the knowledge graph to answer that question."
+)
+
+#: MultiPathRetrieval emits an answer-format hint section carrying no
+#: document evidence. Ignore it when deciding whether to abstain.
+NON_EVIDENCE_SECTIONS = frozenset({"hint"})
+
+
+async def answer_or_abstain(rag, question: str, *, min_items: int = 1, min_score=None):
+    """Answer from graph context, or abstain when the evidence is too thin."""
+    retrieved = await rag.retrieve(question)
+
+    supporting = [
+        item
+        for item in retrieved.items
+        if (item.content or "").strip()
+        and item.metadata.get("section") not in NON_EVIDENCE_SECTIONS
+        and (min_score is None or (item.score is not None and item.score >= min_score))
+    ]
+
+    if len(supporting) < min_items:
+        return INSUFFICIENT_EVIDENCE, []
+
+    result = await rag.completion(question, return_context=True)
+    return result.answer, result.retriever_result.items
+```
+
+Gating on `retrieve()` **before** generation is the point: an unsupported
+question costs zero LLM calls. Three details matter in practice:
+
+- **Filter non-evidence sections.** The default `MultiPathRetrieval` strategy
+  emits an answer-format `hint` section that carries no document evidence;
+  counting it would defeat the gate.
+- **Only threshold on scores when the pipeline produces them.**
+  `MultiPathRetrieval` returns section items with `score = None` — scoring
+  happens internally during fact filtering and passage reranking and is not
+  surfaced per section. Use `LocalRetrieval` or attach a `CosineReranker` if
+  you want a similarity floor, otherwise leave `min_score` unset and gate on
+  item count. See [Strategies](/strategies).
+- **Return a fixed refusal string**, rather than prose the model wrote, so
+  abstentions stay machine-detectable in logs and evaluations.
+
+Tune the thresholds to your risk tolerance — for example, restrict the
+supporting sections to `"passages"` specifically if only source-text-grounded
+answers are acceptable for your use case.
+
+<Warning>
+A retrieval-side relevance threshold is not an abstention mechanism on its
+own: `filter_facts_by_relevance()` keeps its top `min_keep=3` facts regardless
+of score, so a weak graph still yields a non-empty context. The explicit gate
+above is what turns that into a real refusal.
+</Warning>
+
+The runnable version of this pattern — including printing the cited source
+chunks — lives in
+[`examples/grounded_answers_with_abstention.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/examples/grounded_answers_with_abstention.py),
+and is covered by `graphrag_sdk/tests/test_grounded_abstention.py`.
+
+## Schema and ontology as a guardrail
+
+Extraction is constrained by the ontology you define: only entity labels and
+relationship patterns present in the schema are extracted and written to the
+graph (see [Graph Schema](/graph-schema) and [Extraction](/extraction)).
+Off-schema entities and relationships are pruned before the graph is written,
+so extraction output that doesn't fit is never silently promoted to a stored
+"fact":
+
+```python
+from graphrag_sdk import Entity, Ontology, Relation
+
+ontology = Ontology(
+    entities=[
+        Entity(label="Person", description="A human being"),
+        Entity(label="Organization", description="A company or institution"),
+    ],
+    relations=[
+        Relation(
+            label="WORKS_AT",
+            description="Is employed by",
+            patterns=[("Person", "Organization")],  # source -> target
+        ),
+    ],
+)
+```
+
+This matters for grounding because it constrains *what can be asserted
+later* — an ontology that only models `Person`, `Organization`, and
+`WORKS_AT` cannot retrieve (and therefore cannot ground an answer in) a
+relationship type it never captured. A narrower, well-scoped ontology
+produces fewer but more precise facts; a broad one captures more but with
+more noise for the reranker to filter. Fewer junk facts in the graph means
+fewer junk facts in the retrieved context — grounding is only as good as what
+got stored. See [Ontology Discovery](/ontology-discovery) if you would rather
+derive the schema from your corpus than write it by hand.
+
+## Verifying grounding
+
+Treat grounding as something you measure, not something you assume:
+
+1. **Check the trail.** Run `completion(question, return_context=True)` and
+   confirm the `passages` and `facts` sections contain the specific fact the
+   answer depends on — not just topically related text.
+2. **Cross-reference the source.** Compare `[Source: <document>]` tags against
+   the actual source document to confirm the passage says what the answer
+   claims.
+3. **Prefer structured evidence for high-stakes claims.** Questions
+   answerable from the `facts` section (`RELATES` edges) or a
+   `cypher_results` section beat free-text passages alone — structured graph
+   results are direct query output, not LLM-summarized prose.
+4. **Log the trail.** Store `retriever_result` items next to each served
+   answer so any claim can be re-checked later.
+5. **Test the refusal path.** Assert that a question with no supporting
+   context returns your evidence-insufficient response.
+6. **Track abstention rate.** A rate near zero usually means the gate is too
+   loose; a rate that spikes usually means ingestion or `finalize()` coverage
+   regressed.
+
+<Warning>
+The [benchmark](/benchmark) numbers measure task performance — accuracy
+against a fixed, offline question set — not hallucination rate on your data.
+A high benchmark score says the pipeline finds and uses relevant evidence
+well on that dataset. It does not say anything about how complete or
+accurate *your* source corpus is, how narrowly *you've* scoped retrieval, how
+your prompts are written, or what abstention threshold your application
+enforces. All four are yours to set, and all four affect real-world
+reliability as much as the retrieval pipeline itself.
+</Warning>
+
+## Related
+
+- [Reliability and Grounding](/reliability-and-grounding) — the API-level
+  reference behind every mechanism on this page
+- [Architecture](/architecture) — how chunks, entities and `MENTIONED_IN`
+  edges fit together
+- [Retrieval](/retrieval) — the retrieval paths that gather evidence
+- [Strategies](/strategies) — retrieval and reranking strategies, including
+  scored ones
+- [Benchmark](/benchmark) — measured accuracy and reproduction instructions

--- a/docs/reducing-llm-hallucinations.mdx
+++ b/docs/reducing-llm-hallucinations.mdx
@@ -237,6 +237,16 @@ Tune the thresholds to your risk tolerance — for example, restrict the
 supporting sections to `"passages"` specifically if only source-text-grounded
 answers are acceptable for your use case.
 
+<Note>
+The gate is not free on the answered path. `completion()` retrieves again
+internally, and `MultiPathRetrieval` issues an LLM keyword-extraction call on
+every retrieval — so a question that *is* answered costs three LLM calls
+instead of two, and repeats the graph and vector work. A question that is
+refused costs zero. The pattern pays off when a meaningful share of your
+traffic is unanswerable; when almost everything is answerable, gate on a
+cheaper signal or rely on prompt-level abstention.
+</Note>
+
 <Warning>
 A retrieval-side relevance threshold is not an abstention mechanism on its
 own: `filter_facts_by_relevance()` keeps its top `min_keep=3` facts regardless

--- a/docs/reducing-llm-hallucinations.mdx
+++ b/docs/reducing-llm-hallucinations.mdx
@@ -227,15 +227,23 @@ question costs zero LLM calls. Three details matter in practice:
 - **Only threshold on scores when the pipeline produces them.**
   `MultiPathRetrieval` returns section items with `score = None` — scoring
   happens internally during fact filtering and passage reranking and is not
-  surfaced per section. Use `LocalRetrieval` or attach a `CosineReranker` if
-  you want a similarity floor, otherwise leave `min_score` unset and gate on
-  item count. See [Strategies](/strategies).
+  surfaced per section. Attach a `CosineReranker` (or use `LocalRetrieval`)
+  to populate `item.score` before setting `min_score`. See
+  [Strategies](/strategies).
+- **A count-only gate barely gates.** No retrieval path applies a similarity
+  floor: chunk vector search takes its top 15 hits and reranking takes the
+  top *k* of those, neither with a threshold. A populated graph therefore
+  returns *something* for almost any question, however unrelated, so
+  `min_items` alone fires only on an empty graph, a failed ingestion or a
+  retrieval error. Scores are what make the gate discriminating.
 - **Return a fixed refusal string**, rather than prose the model wrote, so
   abstentions stay machine-detectable in logs and evaluations.
 
 Tune the thresholds to your risk tolerance — for example, restrict the
 supporting sections to `"passages"` specifically if only source-text-grounded
-answers are acceptable for your use case.
+answers are acceptable for your use case. A `min_score` is corpus- and
+embedding-model-dependent: read real scores off your own questions before
+picking one.
 
 <Note>
 The gate is not free on the answered path. `completion()` retrieves again

--- a/docs/reducing-llm-hallucinations.mdx
+++ b/docs/reducing-llm-hallucinations.mdx
@@ -219,7 +219,7 @@ async def answer_or_abstain(rag, question: str, *, min_items: int = 1, min_score
 ```
 
 Gating on `retrieve()` **before** generation is the point: an unsupported
-question costs zero LLM calls. Three details matter in practice:
+question never reaches the generation call. Three details matter in practice:
 
 - **Filter non-evidence sections.** The default `MultiPathRetrieval` strategy
   emits an answer-format `hint` section that carries no document evidence;
@@ -246,13 +246,14 @@ embedding-model-dependent: read real scores off your own questions before
 picking one.
 
 <Note>
-The gate is not free on the answered path. `completion()` retrieves again
-internally, and `MultiPathRetrieval` issues an LLM keyword-extraction call on
-every retrieval — so a question that *is* answered costs three LLM calls
-instead of two, and repeats the graph and vector work. A question that is
-refused costs zero. The pattern pays off when a meaningful share of your
-traffic is unanswerable; when almost everything is answerable, gate on a
-cheaper signal or rely on prompt-level abstention.
+The gate is not free, on either path. `MultiPathRetrieval` issues an LLM
+keyword-extraction call on *every* retrieval, so a refused question still
+costs one LLM call — it saves the generation call, not all of them. And
+because `completion()` retrieves again internally, an answered question costs
+three LLM calls instead of two and repeats the graph and vector work. The
+pattern pays off when a meaningful share of your traffic is unanswerable;
+when almost everything is answerable, gate on a cheaper signal or rely on
+prompt-level abstention.
 </Note>
 
 <Warning>

--- a/docs/reducing-llm-hallucinations.mdx
+++ b/docs/reducing-llm-hallucinations.mdx
@@ -111,6 +111,10 @@ strategy = MultiPathRetrieval(
     embedder=embedder,
     llm=llm,
     enable_cypher=True,  # opt-in, off by default
+    # Required: GraphRAG injects the ontology only into its own default
+    # strategy, never into one you pass as `strategy=`. Without this, the
+    # text-to-Cypher prompt is built against an empty schema.
+    ontology=await rag.get_ontology(),
 )
 result = await rag.completion("How many organizations are mentioned?", strategy=strategy)
 ```
@@ -153,7 +157,10 @@ print(result.answer)
 
 for item in result.retriever_result.items:
     if item.metadata.get("section") == "passages":
-        for passage in item.content.split("\n---\n"):
+        # The section content opens with a "## Source Document Passages"
+        # header glued to the first passage — strip it before splitting.
+        body = item.content.removeprefix("## Source Document Passages\n")
+        for passage in body.split("\n---\n"):
             print(passage)
 ```
 
@@ -177,9 +184,10 @@ rather than trusting the answer at face value.
 useful signals to log next to every answer you serve.
 </Tip>
 
-`retrieve()` runs the same retrieval path *without* calling the LLM, which
-makes it the natural place to put a gate: you decide whether to generate
-before paying for a generation.
+`retrieve()` runs the same retrieval path *without* reaching the generation
+call, which makes it the natural place to put a gate: you decide whether to
+generate before paying for a generation. (It is not LLM-free — see the cost
+note below.)
 
 ## Defining an abstention path
 
@@ -238,6 +246,12 @@ question never reaches the generation call. Three details matter in practice:
   retrieval error. Scores are what make the gate discriminating.
 - **Return a fixed refusal string**, rather than prose the model wrote, so
   abstentions stay machine-detectable in logs and evaluations.
+- **Don't share one `Context` across both calls.** `Context` starts its clock
+  when it is constructed and `remaining_budget_ms` never resets, so a `ctx`
+  passed to `retrieve()` and then reused for `completion()` charges the gate's
+  latency against the generation's budget — and the double retrieval makes that
+  budget roughly twice as tight. Build a fresh `Context` for the second call, or
+  size `latency_budget_ms` for the whole two-phase sequence.
 
 Tune the thresholds to your risk tolerance — for example, restrict the
 supporting sections to `"passages"` specifically if only source-text-grounded

--- a/docs/reliability-and-grounding.mdx
+++ b/docs/reliability-and-grounding.mdx
@@ -332,7 +332,8 @@ descending.
 | `chunk_top_k` | `MultiPathRetrieval` — passages after cosine reranking | `15` |
 | `rel_top_k` | `MultiPathRetrieval` — RELATES edge vector hits | `15` |
 | `max_entities` / `max_relationships` | `MultiPathRetrieval` graph expansion caps | `30` / `20` |
-| `top_k` | `VectorStore.search_chunks()` / `search_entities()` / `search_relationships()` | `5` |
+| `top_k` | `VectorStore.search_chunks()` / `search_entities()` | `5` |
+| `top_k` | `VectorStore.search_relationships()` | `15` |
 | `top_k` | `CosineReranker` | `15` |
 
 Facts use a higher threshold than passages on purpose: short structured strings

--- a/docs/reliability-and-grounding.mdx
+++ b/docs/reliability-and-grounding.mdx
@@ -1,0 +1,556 @@
+---
+title: "Reliability and Grounding"
+description: "Grounded retrieval, source provenance, evidence trails, confidence thresholds, abstention and retrieval validation — mapped to the APIs that implement them."
+---
+
+This page is the vocabulary map for evaluating GraphRAG SDK as a **trustworthy,
+citable** RAG system. Each term below is tied to a concrete class, parameter or
+returned field, with the honest answer about what the SDK enforces and what it
+leaves to you.
+
+<Note>
+  Everything here describes shipped behaviour. Where a capability is **not**
+  built in — abstention enforcement and declarative metadata filters are the two
+  cases — the page says so and shows the supported workaround.
+</Note>
+
+<Tip>
+  Looking for the narrative version — why RAG systems produce unsupported
+  answers and how to design around it? Start with
+  [Reducing LLM Hallucinations](/reducing-llm-hallucinations). This page is the
+  API-level reference behind it.
+</Tip>
+
+---
+
+## Vocabulary map
+
+| Term | What implements it in the SDK |
+| --- | --- |
+| Grounded retrieval | `GraphRAG.completion()` answers only from the assembled `<context>` block, under a system prompt that forbids outside knowledge |
+| Source provenance | `Document` → `PART_OF` → `Chunk` → `MENTIONED_IN` → `__Entity__` chain, plus the `[Source: <path>]` tag on every retrieved passage |
+| Evidence trail | `RagResult.retriever_result.items` → passages → chunk ids → `Document.path` |
+| Relationship-aware retrieval | `MultiPathRetrieval` — RELATES edge vector search, entity discovery, 1-hop and 2-hop expansion, `MENTIONED_IN` chunk traversal |
+| Metadata filtering | Loader-supplied metadata persisted as `Document` / `Chunk` properties, filtered with Cypher or by graph scoping (no `filter=` parameter) |
+| Confidence thresholds | `filter_facts_by_relevance(min_score=0.25, ...)`, `chunk_top_k`, `rel_top_k`, `top_k` on vector search, `CosineReranker(top_k=...)` |
+| Abstention behavior | Prompt-level only (system prompt rule 6); enforce programmatically with `retrieve()` + a score gate — see [Reducing LLM Hallucinations](/reducing-llm-hallucinations#defining-an-abstention-path) |
+| Unsupported claims | `completion(return_context=True)` gives the exact evidence an answer may be checked against |
+| Retrieval validation | `GraphRAG.retrieve()` / `retrieve_sync()` — context without generation |
+| Factual accuracy | [GraphRAG-Bench results](/benchmark) — ACC, ROUGE-L, Coverage, Faithfulness |
+
+---
+
+## Grounded retrieval
+
+**Grounded retrieval** means the generated answer is produced *only* from
+context retrieved out of the knowledge graph — never from the model's
+parametric memory.
+
+`GraphRAG.completion()` retrieves first, assembles the retrieved items into a
+single context string, wraps it in a `<context>` block and sends it with a
+system prompt that opens with *"Answer questions using ONLY the context
+provided in the user message"*. The numbered rules that follow require the model
+to base the answer strictly on that context, to preserve exact names, dates and
+negations, and — rule 6 — to state that the context is insufficient rather than
+invent details.
+
+```python
+result = await rag.completion("Who founded Acme Corp?")
+
+print(result.answer)
+print(result.metadata["num_context_items"])  # how many context sections were sent
+print(result.metadata["strategy"])           # e.g. "MultiPathRetrieval"
+print(result.metadata["retrieval_query"])    # the query actually used for retrieval
+```
+
+Two grounding safeguards run automatically when you use the default prompt
+template:
+
+- Retrieved document text is scanned for a forged `</context>` closing tag and
+  neutralised, so untrusted source text cannot break out of the context block
+  and issue instructions.
+- The delimited system prompt explicitly tells the model that everything inside
+  `<context>` is data, not instructions.
+
+<Warning>
+  Passing your own `prompt_template=` disables both safeguards — the SDK assumes
+  a custom template owns its escaping rules, and it applies the shorter,
+  non-delimited system prompt. If you supply a template, keep the "answer only
+  from the context" instruction in it.
+</Warning>
+
+---
+
+## Source provenance
+
+Every ingested document produces a mandatory provenance chain in the graph. It
+is not optional and not a post-processing step — the ingestion pipeline builds
+it before extraction results are written.
+
+```
+Document ──PART_OF──▶ Chunk ──NEXT_CHUNK──▶ Chunk
+                        ▲
+                        │ MENTIONED_IN
+                        │
+                   __Entity__ ──RELATES──▶ __Entity__
+```
+
+| Element | Key fields |
+| --- | --- |
+| `Document` | `id` (the `document_id` you passed to `ingest()`, or the normalised source path), `path`, `content_hash`, plus any loader metadata |
+| `Chunk` | `id` (the chunk uid), `text`, `index`, `embedding` |
+| `__Entity__` | `id`, `name`, `description`, `type`, `label`, `embedding` |
+| `RELATES` | `src_name`, `rel_type`, `tgt_name`, `fact`, `description`, `source_chunk_ids`, `embedding` |
+
+Two provenance details are worth calling out:
+
+- **`RELATES.source_chunk_ids`** records which chunks produced each extracted
+  relationship, so a graph fact traces back to the passages that justify it.
+- **Retrieved passages are tagged inline.** `MultiPathRetrieval` batch-resolves
+  each candidate chunk's `Document.path` through `PART_OF` and prefixes the
+  passage with `[Source: <path>]` before it reaches the LLM. The path is stored
+  exactly as it was at ingestion time (typically relative to the ingestion
+  root), because bare filenames are ambiguous across directories.
+
+Pass an explicit `document_id` at ingestion time when you need a stable
+citation key — a content hash, a repo-relative path, or a slug:
+
+```python
+await rag.ingest(text=article_text, document_id="kb/acme-corp-history")
+```
+
+---
+
+## Evidence trail
+
+The **evidence trail** is the chain from an answer back to the source document.
+Ask for the context alongside the answer and walk it:
+
+<CodeGroup>
+
+```python Answer + evidence
+result = await rag.completion(
+    "Where is Acme Corp headquartered?",
+    return_context=True,
+)
+
+print(result.answer)
+
+for item in result.retriever_result.items:
+    print(item.metadata["section"], "->", item.content[:120])
+```
+
+```python Cited passages only
+result = await rag.completion("Where is Acme Corp headquartered?", return_context=True)
+
+passages = [
+    item.content
+    for item in result.retriever_result.items
+    if item.metadata.get("section") == "passages"
+]
+# Each passage inside this section is prefixed with "[Source: <document path>]"
+print("\n---\n".join(passages))
+```
+
+</CodeGroup>
+
+`MultiPathRetrieval` returns one item per context section, and
+`item.metadata["section"]` is one of `hint`, `cypher_results`, `entities`,
+`relationships`, `facts` or `passages`. The `passages` section carries the
+document attribution; `facts` and `relationships` carry the graph-level
+evidence.
+
+To close the loop from a chunk id back to its document, query the graph
+directly:
+
+```python
+from graphrag_sdk import ConnectionConfig, FalkorDBConnection, GraphStore
+
+connection = FalkorDBConnection(ConnectionConfig(host="localhost", graph_name="my_graph"))
+graph = GraphStore(connection)
+
+evidence = await graph.query_raw(
+    "MATCH (d:Document)-[:PART_OF]->(c:Chunk {id: $chunk_id}) "
+    "RETURN d.id AS document_id, d.path AS path, c.index AS chunk_index",
+    {"chunk_id": chunk_id},
+)
+print(evidence.result_set)
+```
+
+And from an entity back to the passages that mention it:
+
+```python
+mentions = await graph.query_raw(
+    "MATCH (e:__Entity__ {name: $name})-[:MENTIONED_IN]->(c:Chunk)"
+    "<-[:PART_OF]-(d:Document) "
+    "RETURN d.path AS source, c.id AS chunk_id, c.text AS text LIMIT 10",
+    {"name": "Acme Corp"},
+)
+```
+
+---
+
+## Relationship-aware retrieval
+
+Top-k vector search over chunks answers "which passages look like this
+question". It cannot answer "what is connected to this entity". The default
+strategy, `MultiPathRetrieval`, runs graph traversal alongside vector search so
+connected evidence is retrieved even when it is not lexically or semantically
+close to the question:
+
+| Path | Mechanism |
+| --- | --- |
+| RELATES vector search | Embedded relationship facts searched directly, returning `src —[type]→ tgt: fact` strings and entry-point entities |
+| Entity discovery | Name `CONTAINS` matching plus fulltext search over entity names and descriptions |
+| Relationship expansion | 1-hop and 2-hop traversal from discovered entities |
+| `MENTIONED_IN` chunks | Entity → the chunks it was extracted from |
+| 2-hop chunks | Entity → related entity → that neighbour's chunks |
+| Text-to-Cypher | Opt-in ontology-guided graph query, results bypass reranking |
+
+```python
+from graphrag_sdk import GraphStore, MultiPathRetrieval, VectorStore
+
+strategy = MultiPathRetrieval(
+    graph_store=GraphStore(connection),
+    vector_store=VectorStore(connection, embedder=embedder, embedding_dimension=256),
+    embedder=embedder,
+    llm=llm,
+    chunk_top_k=15,        # passages kept after reranking
+    max_entities=30,       # entities carried into relationship expansion
+    max_relationships=20,  # cap on expanded RELATES edges
+    rel_top_k=15,          # RELATES edge vector search results
+    enable_cypher=True,    # opt-in graph query path
+)
+
+result = await rag.completion("How is Acme Corp connected to Initech?", strategy=strategy)
+```
+
+Measured in isolation, no single path matches the fused pipeline — see the
+per-path numbers in [Retrieval](/retrieval#isolated-path-performance). For the
+simpler alternative (vector search plus optional 1-hop entity context), use
+`LocalRetrieval` from
+`graphrag_sdk.retrieval.strategies.local` — see [Strategies](/strategies).
+
+---
+
+## Metadata filtering
+
+<Warning>
+  `retrieve()` and `completion()` do **not** accept a metadata filter argument.
+  Metadata is persisted on the graph, and filtering is done with Cypher or by
+  scoping the graph. Do not expect declarative `filter=` semantics.
+</Warning>
+
+Loader-supplied document metadata is flattened onto the `Document` node at
+ingestion time, and chunk metadata onto each `Chunk` node. The built-in loaders
+contribute keys such as `loader`, `size_bytes`, `suffix` (text and markdown) and
+`page_count`, `pdf_backend` (PDF). A custom `LoaderStrategy` that returns a
+`DocumentInfo` with your own `metadata` dictionary makes those keys queryable
+properties:
+
+<AccordionGroup>
+  <Accordion title="Attach custom metadata at ingestion">
+
+```python
+from graphrag_sdk.core.context import Context
+from graphrag_sdk.core.models import DocumentInfo, DocumentOutput
+from graphrag_sdk.ingestion.loaders.base import LoaderStrategy
+
+class TenantLoader(LoaderStrategy):
+    async def load(self, source: str, ctx: Context) -> DocumentOutput:
+        with open(source, encoding="utf-8") as handle:
+            text = handle.read()
+        return DocumentOutput(
+            text=text,
+            document_info=DocumentInfo(
+                path=source,
+                metadata={"tenant": "acme", "classification": "public"},
+            ),
+        )
+
+await rag.ingest("reports/q4.md", loader=TenantLoader())
+```
+
+  </Accordion>
+  <Accordion title="Filter retrieval by that metadata">
+
+```python
+rows = await graph.query_raw(
+    "MATCH (d:Document)-[:PART_OF]->(c:Chunk) "
+    "WHERE d.tenant = $tenant AND d.classification = 'public' "
+    "RETURN c.id AS chunk_id, c.text AS text LIMIT 20",
+    {"tenant": "acme"},
+)
+```
+
+Feed the resulting passages to your own prompt, or post-filter the output of
+`retrieve()` against the allowed document set.
+
+  </Accordion>
+  <Accordion title="Hard isolation: one graph per scope">
+
+The strongest filter is a separate graph. `ConnectionConfig(graph_name=...)`
+scopes an entire `GraphRAG` instance, so a tenant's retrieval can never reach
+another tenant's chunks. This is the layout used for the
+[benchmark](/benchmark) run, which indexes one graph per corpus document.
+
+```python
+rag = GraphRAG(
+    connection=ConnectionConfig(host="localhost", graph_name="tenant_acme"),
+    llm=llm,
+    embedder=embedder,
+)
+```
+
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Confidence thresholds
+
+Every similarity score returned by the storage layer is a **similarity, not a
+distance — higher means closer.** Chunk, entity and relationship vector searches
+all return `(1 - score)` from the FalkorDB cosine index and order by that value
+descending.
+
+<Note>
+  This was corrected recently: earlier releases ordered by raw distance, which
+  ranked the *least* similar results first. If you pinned a threshold against
+  the old behaviour, invert it.
+</Note>
+
+| Cutoff | Where | Default |
+| --- | --- | --- |
+| `min_score` | `filter_facts_by_relevance()` — RELATES facts below this similarity are dropped | `0.25` |
+| `max_facts` | `filter_facts_by_relevance()` — cap on facts in context | `12` |
+| `min_keep` | `filter_facts_by_relevance()` — top facts always kept, threshold or not | `3` |
+| `chunk_top_k` | `MultiPathRetrieval` — passages after cosine reranking | `15` |
+| `rel_top_k` | `MultiPathRetrieval` — RELATES edge vector hits | `15` |
+| `max_entities` / `max_relationships` | `MultiPathRetrieval` graph expansion caps | `30` / `20` |
+| `top_k` | `VectorStore.search_chunks()` / `search_entities()` / `search_relationships()` | `5` |
+| `top_k` | `CosineReranker` | `15` |
+
+Facts use a higher threshold than passages on purpose: short structured strings
+(`Alice —[WORKS_AT]→ Acme`) have much higher cosine variance than prose
+paragraphs, so a passage-tuned threshold would let noise through. The `min_keep`
+floor guarantees the pipeline never returns an empty fact section purely because
+of the threshold — which is exactly why a threshold alone is not an abstention
+mechanism.
+
+To obtain explicit per-item scores, apply the reranker — it is the component
+that populates `RetrieverResultItem.score`:
+
+```python
+from graphrag_sdk import CosineReranker
+
+reranker = CosineReranker(embedder=embedder, top_k=10)
+retrieved = await rag.retrieve("Where is Acme Corp headquartered?", reranker=reranker)
+
+for item in retrieved.items:
+    print(round(item.score, 3), item.metadata.get("section"), item.content[:80])
+```
+
+<Warning>
+  Without a reranker, `MultiPathRetrieval` returns section items with
+  `score = None` — scoring happens internally during fact filtering and passage
+  reranking and is not surfaced per section. `LocalRetrieval` items do carry the
+  chunk's vector similarity in `score`.
+</Warning>
+
+---
+
+## Abstention behavior
+
+**Abstention is prompt-level, not enforced.** The SDK ships no confidence score
+on the answer, no "insufficient context" marker on `RagResult`, and no
+threshold that rejects a generation. What exists is rule 6 of the built-in
+system prompt: *"If the context lacks sufficient information, say so briefly
+rather than inventing details."* A model may ignore it.
+
+If you need enforced abstention, gate the call yourself: retrieve first, decide,
+and only then generate. The [runnable pattern and its trade-offs](/reducing-llm-hallucinations#defining-an-abstention-path)
+are covered in the guide; the score-based variant looks like this:
+
+```python
+from graphrag_sdk import CosineReranker
+
+MIN_SCORE = 0.35
+MIN_ITEMS = 2
+
+reranker = CosineReranker(embedder=embedder, top_k=10)
+retrieved = await rag.retrieve(question, reranker=reranker)
+
+strong = [item for item in retrieved.items if (item.score or 0.0) >= MIN_SCORE]
+
+if len(strong) < MIN_ITEMS:
+    answer = "I don't have enough information in the knowledge base to answer that."
+else:
+    result = await rag.completion(question, reranker=reranker, return_context=True)
+    answer = result.answer
+```
+
+Tighten the prompt side as well, with a template that makes abstention the
+required output for weak context:
+
+```python
+ABSTAIN_TEMPLATE = (
+    "<context>\n{context}\n</context>\n\n"
+    "Answer the question using only the context above. "
+    "If the context does not contain the answer, reply exactly with "
+    "INSUFFICIENT_CONTEXT and nothing else.\n\n"
+    "Question: {question}\n\nAnswer:"
+)
+
+result = await rag.completion(question, prompt_template=ABSTAIN_TEMPLATE)
+if result.answer.strip() == "INSUFFICIENT_CONTEXT":
+    ...
+```
+
+<Warning>
+  A custom `prompt_template` must keep both `{context}` and `{question}`
+  placeholders, and it opts out of the `</context>` neutralisation and the
+  delimited system prompt described under
+  [Grounded retrieval](#grounded-retrieval).
+</Warning>
+
+The retrieval-side threshold is a partial gate on its own: `min_keep=3` in the
+fact filter means at least some facts always survive, so an empty or weak graph
+still yields a non-empty context. The score check above is what turns that into
+a real refusal.
+
+---
+
+## Unsupported claims
+
+An **unsupported claim** is a statement in the answer that the retrieved
+evidence does not back. The SDK does not detect these for you — it gives you the
+exact evidence the answer was allowed to use, which is what makes detection
+possible.
+
+```python
+result = await rag.completion(question, return_context=True)
+
+evidence = "\n---\n".join(item.content for item in result.retriever_result.items)
+
+verdict = await rag.llm.ainvoke(
+    "Evidence:\n" + evidence
+    + "\n\nAnswer:\n" + result.answer
+    + "\n\nList any statement in the answer that is not supported by the "
+    "evidence. Reply SUPPORTED if every statement is backed."
+)
+print(verdict.content)
+```
+
+Practices that reduce unsupported claims:
+
+- **Keep the default template.** Its system prompt already forbids outside
+  knowledge, preambles and verbatim quoting, and requires negations to be
+  preserved.
+- **Log the evidence with the answer.** `return_context=True` plus
+  `result.metadata["retrieval_query"]` reproduces exactly what the model saw,
+  including after a history rewrite.
+- **Raise the bar for context quality** rather than the amount: a higher
+  `min_score` on fact filtering and a reranker `top_k` that fits your model's
+  attention budget beat sending more marginal passages.
+- **Prefer explicit entity/relationship evidence.** The `facts` and
+  `relationships` sections carry the `fact` text extracted from source chunks,
+  and each `RELATES` edge keeps `source_chunk_ids`.
+
+---
+
+## Retrieval validation
+
+Answer quality problems are usually retrieval problems. `GraphRAG.retrieve()`
+runs the full retrieval and reranking pipeline and returns the context
+**without calling the generation model** — no LLM cost, no generation variance:
+
+<CodeGroup>
+
+```python Async
+retrieved = await rag.retrieve("Who founded Acme Corp?")
+
+print(retrieved.metadata)          # e.g. {'strategy': 'multi_path'}
+print(len(retrieved.items))
+
+for item in retrieved.items:
+    print("--", item.metadata.get("section"), item.score)
+    print(item.content[:200])
+```
+
+```python Sync
+retrieved = rag.retrieve_sync("Who founded Acme Corp?")
+
+for item in retrieved.items:
+    print(item.metadata.get("section"), item.score)
+```
+
+</CodeGroup>
+
+A validation checklist that works well before shipping a graph:
+
+<AccordionGroup>
+  <Accordion title="Is the expected document reachable?">
+    Check that a `passages` item carries the `[Source: <path>]` tag of the
+    document you expect. If not, the chunk never made it through any of the four
+    chunk paths — inspect chunking and the entity extraction for that document.
+  </Accordion>
+  <Accordion title="Are entities being found at all?">
+    An empty `entities` section means keyword extraction and fulltext matching
+    both missed. Verify the document was ingested, and that
+    `GraphRAG.finalize()` ran — without it, entity- and edge-level vector search
+    returns nothing and cross-document duplicates remain.
+  </Accordion>
+  <Accordion title="Are the scores plausible?">
+    Attach a `CosineReranker` and read `item.score`. Values clustered near zero
+    mean the question and corpus are semantically far apart — the threshold gate
+    from [Abstention behavior](#abstention-behavior) belongs in front of
+    generation.
+  </Accordion>
+  <Accordion title="Does the graph contain what you think?">
+    Query it directly with `GraphStore.query_raw()` and compare counts against
+    `GraphRAG.get_statistics()`. See [Graph Schema](/graph-schema) for the node
+    and relationship reference.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Factual accuracy
+
+Grounding claims are only credible if they are measured. GraphRAG SDK is
+evaluated on [GraphRAG-Bench](/benchmark) (Xiang et al., ICLR 2026) across both
+subsets and all four task categories, with the SDK's own defaults preserved
+rather than tuned to the benchmark, and the benchmark's unmodified evaluation
+script as judge.
+
+| Metric | What it measures |
+| --- | --- |
+| **ACC** | Judge-scored accuracy of the answer against the reference — the headline number |
+| **ROUGE-L** | Lexical overlap with the reference answer, on fact-retrieval and reasoning tasks |
+| **Cov** (Coverage) | How much of the reference content a summary captures |
+| **FS** (Faithfulness) | Whether generated content stays consistent with the source material |
+
+Reported averages are 76.87 (Medical) and 66.09 (Novel), the unweighted mean of
+the four ACC values, which is the convention the GraphRAG-Bench leaderboard
+uses. The [Benchmark](/benchmark) page publishes the per-level breakdown, the
+full configuration, the two declared deviations from SDK defaults, and the
+hand-authored ontologies so the run is checkable.
+
+<Note>
+  These numbers measure *answer* accuracy end to end. For per-retrieval-path
+  contribution — including how each path scores in isolation — see
+  [Retrieval](/retrieval#benchmark-results).
+</Note>
+
+---
+
+## Related pages
+
+- [Reducing LLM Hallucinations](/reducing-llm-hallucinations) — the guide this page backs, with the runnable abstention pattern
+- [Retrieval](/retrieval) — the nine-step pipeline in detail
+- [Architecture](/architecture) — how ingestion, storage and retrieval fit together
+- [Configuration](/configuration) — connection, provider and strategy settings
+- [Graph Schema](/graph-schema) — node labels, relationship types and properties
+- [API Reference](/api-reference) — full signatures for every class named here
+- [Benchmark](/benchmark) — methodology and results

--- a/docs/reliability-and-grounding.mdx
+++ b/docs/reliability-and-grounding.mdx
@@ -160,25 +160,40 @@ print("\n---\n".join(passages))
 document attribution; `facts` and `relationships` carry the graph-level
 evidence.
 
-To close the loop from a chunk id back to its document, query the graph
-directly:
+A `chunk_id` in `item.metadata` is what lets you close the loop from a
+retrieved item back to its document. Only `LocalRetrieval` populates it —
+`MultiPathRetrieval` sets `metadata` to `{"section": ...}` and rerankers copy
+that metadata through unchanged, so under the default strategy the list below
+is empty and you should use the `[Source: <path>]` prefix on `passages`
+entries instead:
 
 ```python
-from graphrag_sdk import ConnectionConfig, FalkorDBConnection, GraphStore
+from graphrag_sdk import ConnectionConfig, FalkorDBConnection, GraphStore, VectorStore
+from graphrag_sdk.retrieval.strategies.local import LocalRetrieval
 
 connection = FalkorDBConnection(ConnectionConfig(host="localhost", graph_name="my_graph"))
 graph = GraphStore(connection)
-chunk_item = next(
-    item for item in result.retriever_result.items if item.metadata.get("chunk_id")
-)
-chunk_id = chunk_item.metadata["chunk_id"]
 
-evidence = await graph.query_raw(
-    "MATCH (d:Document)-[:PART_OF]->(c:Chunk {id: $chunk_id}) "
-    "RETURN d.id AS document_id, d.path AS path, c.index AS chunk_index",
-    {"chunk_id": chunk_id},
+retrieved = await rag.retrieve(
+    "What did Professor Harmon discover?",
+    strategy=LocalRetrieval(
+        graph_store=graph,
+        vector_store=VectorStore(connection, embedder=embedder, embedding_dimension=256),
+        embedder=embedder,
+        top_k=5,
+    ),
 )
-print(evidence.result_set)
+
+for item in retrieved.items:
+    chunk_id = item.metadata.get("chunk_id")
+    if chunk_id is None:
+        continue
+    evidence = await graph.query_raw(
+        "MATCH (d:Document)-[:PART_OF]->(c:Chunk {id: $chunk_id}) "
+        "RETURN d.id AS document_id, d.path AS path, c.index AS chunk_index",
+        {"chunk_id": chunk_id},
+    )
+    print(evidence.result_set)
 ```
 
 And from an entity back to the passages that mention it:
@@ -224,6 +239,10 @@ strategy = MultiPathRetrieval(
     max_relationships=20,  # cap on expanded RELATES edges
     rel_top_k=15,          # RELATES edge vector search results
     enable_cypher=True,    # opt-in graph query path
+    # Required: a strategy you construct yourself never receives the ontology.
+    # GraphRAG only injects it into its own default strategy, so text-to-Cypher
+    # would otherwise generate against an empty schema.
+    ontology=await rag.get_ontology(),
 )
 
 result = await rag.completion("How is Acme Corp connected to Initech?", strategy=strategy)
@@ -361,6 +380,14 @@ for item in retrieved.items:
   `score = None` — scoring happens internally during fact filtering and passage
   reranking and is not surfaced per section. `LocalRetrieval` items do carry the
   chunk's vector similarity in `score`.
+
+  Attaching a reranker populates `score`, but note what it scores: a
+  `MultiPathRetrieval` item is a whole concatenated section, so `CosineReranker`
+  embeds that entire block against the question. One highly relevant passage is
+  diluted by everything else in the same section, and the resulting number is
+  systematically lower than a per-chunk similarity. Calibrate section-level
+  thresholds against your own corpus rather than reusing a chunk-level value —
+  a `LocalRetrieval`-derived threshold will over-abstain here.
 </Warning>
 
 ---
@@ -468,7 +495,10 @@ Practices that reduce unsupported claims:
 
 Answer quality problems are usually retrieval problems. `GraphRAG.retrieve()`
 runs the full retrieval and reranking pipeline and returns the context
-**without calling the generation model** — no LLM cost, no generation variance:
+**without calling the generation model** — no generation cost, no generation
+variance. It is not free, though: the default `MultiPathRetrieval` still issues
+an LLM keyword-extraction call, plus a text-to-Cypher call when
+`enable_cypher=True`.
 
 <CodeGroup>
 

--- a/docs/reliability-and-grounding.mdx
+++ b/docs/reliability-and-grounding.mdx
@@ -9,7 +9,7 @@ returned field, with the honest answer about what the SDK enforces and what it
 leaves to you.
 
 <Note>
-  Everything here describes shipped behaviour. Where a capability is **not**
+  Everything here describes shipped behavior. Where a capability is **not**
   built in — abstention enforcement and declarative metadata filters are the two
   cases — the page says so and shows the supported workaround.
 </Note>
@@ -67,7 +67,7 @@ Two grounding safeguards run automatically when you use the default prompt
 template:
 
 - Retrieved document text is scanned for a forged `</context>` closing tag and
-  neutralised, so untrusted source text cannot break out of the context block
+  neutralized, so untrusted source text cannot break out of the context block
   and issue instructions.
 - The delimited system prompt explicitly tells the model that everything inside
   `<context>` is data, not instructions.
@@ -97,7 +97,7 @@ Document ──PART_OF──▶ Chunk ──NEXT_CHUNK──▶ Chunk
 
 | Element | Key fields |
 | --- | --- |
-| `Document` | `id` (the `document_id` you passed to `ingest()`, or the normalised source path), `path`, `content_hash`, plus any loader metadata |
+| `Document` | `id` (the `document_id` you passed to `ingest()`, or the normalized source path), `path`, `content_hash`, plus any loader metadata |
 | `Chunk` | `id` (the chunk uid), `text`, `index`, `embedding` |
 | `__Entity__` | `id`, `name`, `description`, `type`, `label`, `embedding` |
 | `RELATES` | `src_name`, `rel_type`, `tgt_name`, `fact`, `description`, `source_chunk_ids`, `embedding` |
@@ -321,7 +321,7 @@ descending.
 <Note>
   This was corrected recently: earlier releases ordered by raw distance, which
   ranked the *least* similar results first. If you pinned a threshold against
-  the old behaviour, invert it.
+  the old behavior, invert it.
 </Note>
 
 | Cutoff | Where | Default |
@@ -414,7 +414,7 @@ if result.answer.strip() == "INSUFFICIENT_CONTEXT":
 
 <Warning>
   A custom `prompt_template` must keep both `{context}` and `{question}`
-  placeholders, and it opts out of the `</context>` neutralisation and the
+  placeholders, and it opts out of the `</context>` neutralization and the
   delimited system prompt described under
   [Grounded retrieval](#grounded-retrieval).
 </Warning>

--- a/docs/reliability-and-grounding.mdx
+++ b/docs/reliability-and-grounding.mdx
@@ -168,6 +168,10 @@ from graphrag_sdk import ConnectionConfig, FalkorDBConnection, GraphStore
 
 connection = FalkorDBConnection(ConnectionConfig(host="localhost", graph_name="my_graph"))
 graph = GraphStore(connection)
+chunk_item = next(
+    item for item in result.retriever_result.items if item.metadata.get("chunk_id")
+)
+chunk_id = chunk_item.metadata["chunk_id"]
 
 evidence = await graph.query_raw(
     "MATCH (d:Document)-[:PART_OF]->(c:Chunk {id: $chunk_id}) "

--- a/docs/retrieval.mdx
+++ b/docs/retrieval.mdx
@@ -5,7 +5,7 @@ description: "How questions get answered using multiple parallel retrieval paths
 
 When you ask GraphRAG a question, it doesn't just search for keywords. It uses **multiple retrieval paths** in parallel — like asking five different experts to find relevant information, then combining their best findings into one answer.
 
-This document explains how each path works, what it contributes, and how they perform individually and together.
+This document explains how each path works, what it contributes, and how they perform individually and together. See [Reducing LLM Hallucinations](/reducing-llm-hallucinations) for how this multi-path strategy grounds answers in retrieved evidence and how to inspect that evidence at answer time.
 
 ---
 

--- a/graphrag_sdk/README.md
+++ b/graphrag_sdk/README.md
@@ -9,6 +9,8 @@
 
 GraphRAG SDK builds knowledge graphs from documents and answers questions over them using retrieval-augmented generation. Every algorithmic concern (chunking, extraction, resolution, retrieval, reranking) is a swappable strategy behind an abstract interface. The default pipeline scores **~85% accuracy** on a 100-question benchmark using GPT-4.1.
 
+It is designed to **reduce LLM hallucinations**: answers are grounded in context retrieved from the knowledge graph and remain traceable to their source chunks via `MENTIONED_IN` provenance edges, and your application can abstain when the graph holds no supporting evidence. See the [Reducing LLM Hallucinations guide](https://docs.falkordb.com/graphrag/reducing-llm-hallucinations).
+
 ## Quick Start
 
 ```python
@@ -175,6 +177,7 @@ See the [benchmark page](https://docs.falkordb.com/graphrag/benchmark) for metho
 | 3 | [`03_custom_strategies.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/examples/03_custom_strategies.py) | Composing ingestion strategies explicitly |
 | 4 | [`04_custom_provider.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/examples/04_custom_provider.py) | Custom LLM/Embedder |
 | 5 | [`05_notebook_demo.ipynb`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/examples/05_notebook_demo.ipynb) | Interactive notebook walkthrough |
+| ★ | [`grounded_answers_with_abstention.py`](https://github.com/FalkorDB/GraphRAG-SDK/blob/main/graphrag_sdk/examples/grounded_answers_with_abstention.py) | Cited answers, and abstention when evidence is insufficient |
 
 ## Documentation
 
@@ -182,9 +185,11 @@ Full documentation: **<https://docs.falkordb.com/graphrag>**
 
 - [Getting Started](https://docs.falkordb.com/graphrag/getting-started) -- Install to first query
 - [Architecture](https://docs.falkordb.com/graphrag/architecture) -- Pipeline design and graph schema
+- [Reducing LLM Hallucinations](https://docs.falkordb.com/graphrag/reducing-llm-hallucinations) -- Grounded retrieval, provenance, and abstention
 - [Configuration](https://docs.falkordb.com/graphrag/configuration) -- Connection and provider reference
 - [Strategies](https://docs.falkordb.com/graphrag/strategies) -- All ABCs and built-in implementations
 - [Providers](https://docs.falkordb.com/graphrag/providers) -- LLM & embedder configuration
+- [Reliability and Grounding](https://docs.falkordb.com/graphrag/reliability-and-grounding) -- Grounding and abstention mapped to the APIs that implement them
 - [Benchmark](https://docs.falkordb.com/graphrag/benchmark) -- Methodology and reproduction
 - [Accuracy Benchmark: FalkorDB vs Vector RAG](https://docs.falkordb.com/graphrag/graphrag-accuracy-benchmark) -- 71.48 vs 55.39, limitations, how to cite
 - [API Reference](https://docs.falkordb.com/graphrag/api-reference) -- Full API documentation

--- a/graphrag_sdk/examples/grounded_answers_with_abstention.py
+++ b/graphrag_sdk/examples/grounded_answers_with_abstention.py
@@ -196,17 +196,17 @@ async def answer_or_abstain(
     completion_kwargs["rewrite_question_with_history"] = False
     result = await rag.completion(resolved_question, **completion_kwargs)
 
-    # ``return_context=True`` populates ``retriever_result``; fall back to the
-    # gate's own retrieval if a custom pipeline leaves it unset.
-    items = result.retriever_result.items if result.retriever_result else supporting
-    cited = [item for item in items if is_evidence(item, min_score)]
+    # ``completion()`` runs its own retrieval, so the two passes can disagree.
+    # Cite only what generation actually retrieved: substituting the gate's
+    # items would attach provenance the answer never saw, which is the exact
+    # failure this example exists to prevent. If generation's own evidence
+    # fails the same bar, refuse — a passing gate does not license an
+    # ungrounded answer.
+    generated_from = result.retriever_result.items if result.retriever_result else []
+    cited = [item for item in generated_from if is_evidence(item, min_score)]
 
-    # ``completion()`` retrieves independently of the gate above, and keyword
-    # extraction is an LLM call — the two passes can disagree. Never report a
-    # grounded answer with no provenance; fall back to the evidence the gate
-    # actually approved.
-    if not cited:
-        cited = supporting
+    if len(cited) < min_items:
+        return GroundedAnswer(question=question, answer=refusal, grounded=False)
 
     return GroundedAnswer(
         question=question,

--- a/graphrag_sdk/examples/grounded_answers_with_abstention.py
+++ b/graphrag_sdk/examples/grounded_answers_with_abstention.py
@@ -21,24 +21,32 @@ search takes the top 15 hits and reranking takes the top *k* of those, both
 without a threshold — so a non-empty graph nearly always returns *something*,
 however unrelated. A count-only gate therefore fires only in the degenerate
 cases (empty graph, no ingestion, retrieval error). To abstain on a question
-your corpus genuinely does not cover, you need per-item scores: attach a
-``CosineReranker`` (or use ``LocalRetrieval``) and pass ``min_score``, as
-``main()`` does below.
+your corpus genuinely does not cover, you need per-item scores.
+
+``main()`` uses ``LocalRetrieval`` for that, because its items are individual
+chunks and ``score`` is a real per-chunk similarity. Under
+``MultiPathRetrieval`` each item is a whole concatenated section instead, so a
+``CosineReranker`` scores the entire blob against the question — a diluted,
+section-level number. That still works, but the threshold has to be calibrated
+against measured section scores; do not carry ``MIN_SCORE`` across.
 
 ``answer_or_abstain()`` below is deliberately small and dependency-free so
 you can copy it into your own application (it is also exercised by
 ``graphrag_sdk/tests/test_grounded_abstention.py``).
 
 Cost note: the gate retrieves once, and ``completion()`` retrieves again
-internally. Because ``MultiPathRetrieval`` runs an LLM keyword-extraction
-call on every retrieval, an *answered* question costs three LLM calls
-instead of two (four instead of three with
-``rewrite_question_with_history=True``), and does the graph and vector work
-twice. An *unanswered* question still costs the retrieval keyword-extraction
-LLM call (plus the rewrite call when enabled), but avoids the generation call.
-That trade is worth it when a meaningful share of your traffic is unanswerable;
-if almost every question is answerable, gate on a cheaper signal or accept the
-prompt-level abstention in rule 6 of the default system prompt.
+internally, so the retrieval work always happens twice. What that costs
+depends entirely on the strategy. ``LocalRetrieval``, used by ``main()``,
+makes no LLM calls at all: a refused question is genuinely free, and an
+answered one costs exactly the one generation call. ``MultiPathRetrieval``
+runs an LLM keyword-extraction call on *every* retrieval, so there the gate
+is not free — a refused question still costs one call, and an answered one
+costs three instead of two.
+
+Either way the trade is worth it when a meaningful share of your traffic is
+unanswerable; if almost every question is answerable, gate on a cheaper
+signal or accept the prompt-level abstention in rule 6 of the default system
+prompt.
 
 Prerequisites:
     docker run -p 6379:6379 falkordb/falkordb
@@ -57,12 +65,14 @@ from typing import Any
 
 from graphrag_sdk import (
     ConnectionConfig,
-    Context,
-    CosineReranker,
+    FalkorDBConnection,
     GraphRAG,
+    GraphStore,
     LiteLLM,
     LiteLLMEmbedder,
+    VectorStore,
 )
+from graphrag_sdk.retrieval.strategies.local import LocalRetrieval
 
 TEXT = (
     "Acme Corp was founded in 2015 by Alice Johnson and is headquartered in London. "
@@ -150,7 +160,12 @@ async def answer_or_abstain(
         min_score: Optional minimum retrieval score per item.
         refusal: Response returned when the gate fires.
         **completion_kwargs: Forwarded to ``rag.completion()`` (for example
-            ``history=`` or ``strategy=``).
+            ``history=`` or ``strategy=``). ``rewrite_question_with_history``
+            is rejected — pass an already-resolved question instead.
+
+    Raises:
+        ValueError: If ``min_items`` is negative, or if
+            ``rewrite_question_with_history=True`` is passed.
 
     Returns:
         A ``GroundedAnswer``. When ``grounded`` is False the answer is the
@@ -159,26 +174,19 @@ async def answer_or_abstain(
     if min_items < 0:
         raise ValueError("min_items must be non-negative")
 
-    resolved_question = question
-    rewrite_question = completion_kwargs.pop("rewrite_question_with_history", False)
-    history = completion_kwargs.get("history")
-    if rewrite_question and history:
-        ctx = completion_kwargs.get("ctx")
-        if ctx is None:
-            ctx = Context()
-            completion_kwargs["ctx"] = ctx
-        # CAVEAT: ``_validate_history`` and ``_rewrite_question_with_history``
-        # are private. The SDK exposes no public way to resolve a follow-up
-        # question *before* generation, and the gate needs the resolved text —
-        # retrieving on a bare "What did she build?" finds nothing useful, and
-        # ``completion()``'s own rewrite happens too late to gate on. If you
-        # copy this into an application, pin your graphrag-sdk version or
-        # rewrite the question yourself and pass the resolved text instead.
-        validated_history = rag._validate_history(history)
-        resolved_question = await rag._rewrite_question_with_history(
-            question,
-            validated_history,
-            ctx=ctx,
+    # A follow-up question has to be resolved *before* the gate runs —
+    # retrieving on a bare "What did she build?" finds nothing useful. But
+    # ``completion()`` rewrites internally, after its own retrieval, so there
+    # is no public hook to reuse here. Rather than reach into private methods
+    # (this file gets copied into applications), require the caller to pass
+    # text that already stands on its own.
+    if completion_kwargs.pop("rewrite_question_with_history", False):
+        raise ValueError(
+            "rewrite_question_with_history=True is not supported by this gate: "
+            "the gate must retrieve on a self-contained question, and the SDK "
+            "resolves follow-ups only inside completion(), after retrieval. "
+            "Resolve the question yourself and pass the resolved text as "
+            "`question`."
         )
 
     retrieval_kwargs = {
@@ -186,15 +194,14 @@ async def answer_or_abstain(
         for key in ("strategy", "reranker", "ctx")
         if key in completion_kwargs
     }
-    retrieved = await rag.retrieve(resolved_question, **retrieval_kwargs)
+    retrieved = await rag.retrieve(question, **retrieval_kwargs)
     supporting = [item for item in retrieved.items if is_evidence(item, min_score)]
 
     if len(supporting) < min_items:
         return GroundedAnswer(question=question, answer=refusal, grounded=False)
 
     completion_kwargs["return_context"] = True
-    completion_kwargs["rewrite_question_with_history"] = False
-    result = await rag.completion(resolved_question, **completion_kwargs)
+    result = await rag.completion(question, **completion_kwargs)
 
     # ``completion()`` runs its own retrieval, so the two passes can disagree.
     # Cite only what generation actually retrieved: substituting the gate's
@@ -231,13 +238,31 @@ async def main():
     llm = LiteLLM(model="openai/gpt-5.5")
     embedder = LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=256)
 
-    # Scores are what make the gate discriminating. Without a reranker the
-    # default strategy leaves ``score`` unset on every item, and the gate
-    # degrades to "did retrieval return anything at all?".
-    reranker = CosineReranker(embedder=embedder, top_k=10)
+    connection = FalkorDBConnection(
+        ConnectionConfig(host="localhost", graph_name="grounded_abstention")
+    )
+
+    # Why LocalRetrieval here, and not the default MultiPathRetrieval:
+    # MultiPathRetrieval emits one item per *section*, so a reranker scores a
+    # whole concatenated markdown blob (up to 15 passages joined together)
+    # against the question. That similarity is diluted by everything else in
+    # the blob, which makes MIN_SCORE a section-level quantity no reader can
+    # predict. LocalRetrieval items are individual chunks, so a similarity
+    # floor means exactly what it says and the demo behaves the same way on
+    # your machine as it does here.
+    #
+    # The trade-off is real: you lose the graph-traversal paths. Use
+    # MultiPathRetrieval when you need them, but calibrate MIN_SCORE against
+    # measured section scores rather than reusing this value.
+    scored_strategy = LocalRetrieval(
+        graph_store=GraphStore(connection),
+        vector_store=VectorStore(connection, embedder=embedder, embedding_dimension=256),
+        embedder=embedder,
+        top_k=5,
+    )
 
     async with GraphRAG(
-        connection=ConnectionConfig(host="localhost", graph_name="grounded_abstention"),
+        connection=connection,
         llm=llm,
         embedder=embedder,
         embedding_dimension=256,
@@ -252,25 +277,25 @@ async def main():
                 rag,
                 "Who founded Acme Corp?",
                 min_score=MIN_SCORE,
-                reranker=reranker,
+                strategy=scored_strategy,
             )
         )
 
         # ── 3. A question the corpus says nothing about → abstain ──
         # The corpus covers Acme's founding, offices and staff, but says
-        # nothing about revenue. Retrieval still returns the Acme chunks —
-        # they share vocabulary with the question — so the abstention
-        # depends on those chunks scoring below MIN_SCORE, not on retrieval
-        # coming back empty. Tune MIN_SCORE against your own corpus: print
-        # the scores first (see the "Are the scores plausible?" check in the
-        # Reliability and Grounding docs), then set the floor just under the
-        # weakest answer you would still accept.
+        # nothing about revenue. Vector search still returns the Acme chunks —
+        # they share vocabulary with the question — so the abstention depends
+        # on those chunks scoring below MIN_SCORE, not on retrieval coming
+        # back empty. Because these are per-chunk similarities, that is a
+        # quantity you can inspect: print the scores first (see the "Are the
+        # scores plausible?" check in the Reliability and Grounding docs),
+        # then set the floor just under the weakest answer you would accept.
         report(
             await answer_or_abstain(
                 rag,
                 "What was Acme Corp's revenue in 2024?",
                 min_score=MIN_SCORE,
-                reranker=reranker,
+                strategy=scored_strategy,
             )
         )
 

--- a/graphrag_sdk/examples/grounded_answers_with_abstention.py
+++ b/graphrag_sdk/examples/grounded_answers_with_abstention.py
@@ -19,6 +19,15 @@ The pattern has two halves:
 you can copy it into your own application (it is also exercised by
 ``graphrag_sdk/tests/test_grounded_abstention.py``).
 
+Cost note: the gate retrieves once, and ``completion()`` retrieves again
+internally. Because ``MultiPathRetrieval`` runs an LLM keyword-extraction
+call on every retrieval, an *answered* question costs three LLM calls
+instead of two, and does the graph and vector work twice. An *unanswered*
+question costs zero LLM calls. That trade is worth it when a meaningful
+share of your traffic is unanswerable; if almost every question is
+answerable, gate on a cheaper signal or accept the prompt-level abstention
+in rule 6 of the default system prompt.
+
 Prerequisites:
     docker run -p 6379:6379 falkordb/falkordb
     pip install graphrag-sdk[litellm]
@@ -142,6 +151,13 @@ async def answer_or_abstain(
     # gate's own retrieval if a custom pipeline leaves it unset.
     items = result.retriever_result.items if result.retriever_result else supporting
     cited = [item for item in items if is_evidence(item, min_score)]
+
+    # ``completion()`` retrieves independently of the gate above, and keyword
+    # extraction is an LLM call — the two passes can disagree. Never report a
+    # grounded answer with no provenance; fall back to the evidence the gate
+    # actually approved.
+    if not cited:
+        cited = supporting
 
     return GroundedAnswer(
         question=question,

--- a/graphrag_sdk/examples/grounded_answers_with_abstention.py
+++ b/graphrag_sdk/examples/grounded_answers_with_abstention.py
@@ -15,6 +15,16 @@ The pattern has two halves:
      trail comes back alongside the answer and every claim can be traced
      to its source chunks.
 
+Counting items is not enough on its own. No path in the default
+``MultiPathRetrieval`` strategy applies a similarity floor — chunk vector
+search takes the top 15 hits and reranking takes the top *k* of those, both
+without a threshold — so a non-empty graph nearly always returns *something*,
+however unrelated. A count-only gate therefore fires only in the degenerate
+cases (empty graph, no ingestion, retrieval error). To abstain on a question
+your corpus genuinely does not cover, you need per-item scores: attach a
+``CosineReranker`` (or use ``LocalRetrieval``) and pass ``min_score``, as
+``main()`` does below.
+
 ``answer_or_abstain()`` below is deliberately small and dependency-free so
 you can copy it into your own application (it is also exercised by
 ``graphrag_sdk/tests/test_grounded_abstention.py``).
@@ -43,7 +53,13 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
-from graphrag_sdk import ConnectionConfig, GraphRAG, LiteLLM, LiteLLMEmbedder
+from graphrag_sdk import (
+    ConnectionConfig,
+    CosineReranker,
+    GraphRAG,
+    LiteLLM,
+    LiteLLMEmbedder,
+)
 
 TEXT = (
     "Acme Corp was founded in 2015 by Alice Johnson and is headquartered in London. "
@@ -62,6 +78,10 @@ INSUFFICIENT_EVIDENCE = (
 #: MultiPathRetrieval emits an answer-format hint section that carries no
 #: document evidence. Ignore it when deciding whether to abstain.
 NON_EVIDENCE_SECTIONS = frozenset({"hint"})
+
+#: Similarity floor for a reranked item to count as evidence. Corpus- and
+#: embedding-model-dependent: measure your own scores before trusting it.
+MIN_SCORE = 0.35
 
 
 @dataclass
@@ -182,6 +202,11 @@ async def main():
     llm = LiteLLM(model="openai/gpt-5.5")
     embedder = LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=256)
 
+    # Scores are what make the gate discriminating. Without a reranker the
+    # default strategy leaves ``score`` unset on every item, and the gate
+    # degrades to "did retrieval return anything at all?".
+    reranker = CosineReranker(embedder=embedder, top_k=10)
+
     async with GraphRAG(
         connection=ConnectionConfig(host="localhost", graph_name="grounded_abstention"),
         llm=llm,
@@ -193,12 +218,32 @@ async def main():
         await rag.finalize()
 
         # ── 2. A question the corpus supports → grounded answer ────
-        report(await answer_or_abstain(rag, "Who founded Acme Corp?"))
+        report(
+            await answer_or_abstain(
+                rag,
+                "Who founded Acme Corp?",
+                min_score=MIN_SCORE,
+                reranker=reranker,
+            )
+        )
 
         # ── 3. A question the corpus says nothing about → abstain ──
-        # Nothing in the graph mentions revenue, so the gate fires
-        # before the LLM ever sees the question.
-        report(await answer_or_abstain(rag, "What was Acme Corp's revenue in 2024?"))
+        # The corpus covers Acme's founding, offices and staff, but says
+        # nothing about revenue. Retrieval still returns the Acme chunks —
+        # they share vocabulary with the question — so the abstention
+        # depends on those chunks scoring below MIN_SCORE, not on retrieval
+        # coming back empty. Tune MIN_SCORE against your own corpus: print
+        # the scores first (see the "Are the scores plausible?" check in the
+        # Reliability and Grounding docs), then set the floor just under the
+        # weakest answer you would still accept.
+        report(
+            await answer_or_abstain(
+                rag,
+                "What was Acme Corp's revenue in 2024?",
+                min_score=MIN_SCORE,
+                reranker=reranker,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/graphrag_sdk/examples/grounded_answers_with_abstention.py
+++ b/graphrag_sdk/examples/grounded_answers_with_abstention.py
@@ -201,6 +201,18 @@ async def answer_or_abstain(
         return GroundedAnswer(question=question, answer=refusal, grounded=False)
 
     completion_kwargs["return_context"] = True
+
+    # Don't hand the same Context to generation. ``Context`` measures its
+    # budget as time-since-construction, so a ctx already spent on the gate
+    # arrives at generation with a silently shorter deadline — and the gate is
+    # the cheap half. ``child()`` gives generation a fresh start time while
+    # carrying over only the budget that actually remains, so the two-phase
+    # sequence stays inside the caller's overall cap without the second call
+    # inheriting the first call's elapsed time.
+    gate_ctx = completion_kwargs.get("ctx")
+    if gate_ctx is not None:
+        completion_kwargs["ctx"] = gate_ctx.child()
+
     result = await rag.completion(question, **completion_kwargs)
 
     # ``completion()`` runs its own retrieval, so the two passes can disagree.

--- a/graphrag_sdk/examples/grounded_answers_with_abstention.py
+++ b/graphrag_sdk/examples/grounded_answers_with_abstention.py
@@ -124,13 +124,19 @@ async def answer_or_abstain(
         A ``GroundedAnswer``. When ``grounded`` is False the answer is the
         refusal string and no generation happened.
     """
-    retrieved = await rag.retrieve(question)
+    retrieval_kwargs = {
+        key: completion_kwargs[key]
+        for key in ("strategy", "reranker", "ctx")
+        if key in completion_kwargs
+    }
+    retrieved = await rag.retrieve(question, **retrieval_kwargs)
     supporting = [item for item in retrieved.items if is_evidence(item, min_score)]
 
     if len(supporting) < min_items:
         return GroundedAnswer(question=question, answer=refusal, grounded=False)
 
-    result = await rag.completion(question, return_context=True, **completion_kwargs)
+    completion_kwargs["return_context"] = True
+    result = await rag.completion(question, **completion_kwargs)
 
     # ``return_context=True`` populates ``retriever_result``; fall back to the
     # gate's own retrieval if a custom pipeline leaves it unset.

--- a/graphrag_sdk/examples/grounded_answers_with_abstention.py
+++ b/graphrag_sdk/examples/grounded_answers_with_abstention.py
@@ -1,0 +1,183 @@
+"""
+GraphRAG SDK -- Grounded Answers with Abstention
+===================================================
+Reduce LLM hallucinations by answering only from retrieved graph context,
+and abstaining explicitly when the graph holds no supporting evidence.
+
+The pattern has two halves:
+
+  1. Gate on retrieval — call ``rag.retrieve(question)`` first. If nothing
+     comes back (or everything is below your score threshold), return an
+     "evidence-insufficient" response instead of paying for a generation
+     the model would have to guess at.
+  2. Ground the answer — when evidence exists, call
+     ``rag.completion(question, return_context=True)`` so the retrieval
+     trail comes back alongside the answer and every claim can be traced
+     to its source chunks.
+
+``answer_or_abstain()`` below is deliberately small and dependency-free so
+you can copy it into your own application (it is also exercised by
+``graphrag_sdk/tests/test_grounded_abstention.py``).
+
+Prerequisites:
+    docker run -p 6379:6379 falkordb/falkordb
+    pip install graphrag-sdk[litellm]
+    export OPENAI_API_KEY="sk-..."
+
+Run:
+    python graphrag_sdk/examples/grounded_answers_with_abstention.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from graphrag_sdk import ConnectionConfig, GraphRAG, LiteLLM, LiteLLMEmbedder
+
+TEXT = (
+    "Acme Corp was founded in 2015 by Alice Johnson and is headquartered in London. "
+    "Alice Johnson is the CTO and leads the backend team. "
+    "Acme Corp builds cloud infrastructure for logistics companies. "
+    "In 2026 Acme Corp opened a second office in Berlin, managed by Clara Wei."
+)
+
+#: Returned verbatim when the graph holds no supporting evidence. Make this
+#: string explicit — a caller (or an eval harness) must be able to tell an
+#: abstention apart from a real answer without parsing prose.
+INSUFFICIENT_EVIDENCE = (
+    "I don't have enough evidence in the knowledge graph to answer that question."
+)
+
+#: MultiPathRetrieval emits an answer-format hint section that carries no
+#: document evidence. Ignore it when deciding whether to abstain.
+NON_EVIDENCE_SECTIONS = frozenset({"hint"})
+
+
+@dataclass
+class GroundedAnswer:
+    """An answer plus the provenance that justifies it.
+
+    ``grounded`` is False exactly when the abstention gate fired, in which
+    case ``answer`` is the ``refusal`` string and no LLM call was made.
+    """
+
+    question: str
+    answer: str
+    grounded: bool
+    citations: list[str] = field(default_factory=list)
+    context: list[Any] = field(default_factory=list)
+
+
+def is_evidence(item: Any, min_score: float | None) -> bool:
+    """Decide whether one retrieved item counts as supporting evidence.
+
+    Items are dropped when they are empty, when they belong to a
+    non-evidence section, or when a ``min_score`` threshold is set and the
+    item scores below it. Items without a score are kept only when no
+    threshold is requested — the default ``MultiPathRetrieval`` strategy
+    does not populate ``score``, so pass ``min_score`` only with a scoring
+    strategy (``LocalRetrieval``) or a reranker (``CosineReranker``).
+    """
+    if not (item.content or "").strip():
+        return False
+    if item.metadata.get("section") in NON_EVIDENCE_SECTIONS:
+        return False
+    if min_score is None:
+        return True
+    return item.score is not None and item.score >= min_score
+
+
+def citation_of(item: Any, position: int) -> str:
+    """Best-effort provenance label for a retrieved item."""
+    metadata = item.metadata or {}
+    for key in ("chunk_id", "document_id", "source", "section"):
+        value = metadata.get(key)
+        if value:
+            return f"{key}={value}"
+    return f"item[{position}]"
+
+
+async def answer_or_abstain(
+    rag: GraphRAG,
+    question: str,
+    *,
+    min_items: int = 1,
+    min_score: float | None = None,
+    refusal: str = INSUFFICIENT_EVIDENCE,
+    **completion_kwargs: Any,
+) -> GroundedAnswer:
+    """Answer from graph context, or abstain when the evidence is too thin.
+
+    Args:
+        rag: An initialized ``GraphRAG`` instance.
+        question: The user's question.
+        min_items: Minimum number of supporting context items required
+            before the LLM is allowed to answer.
+        min_score: Optional minimum retrieval score per item.
+        refusal: Response returned when the gate fires.
+        **completion_kwargs: Forwarded to ``rag.completion()`` (for example
+            ``history=`` or ``strategy=``).
+
+    Returns:
+        A ``GroundedAnswer``. When ``grounded`` is False the answer is the
+        refusal string and no generation happened.
+    """
+    retrieved = await rag.retrieve(question)
+    supporting = [item for item in retrieved.items if is_evidence(item, min_score)]
+
+    if len(supporting) < min_items:
+        return GroundedAnswer(question=question, answer=refusal, grounded=False)
+
+    result = await rag.completion(question, return_context=True, **completion_kwargs)
+
+    # ``return_context=True`` populates ``retriever_result``; fall back to the
+    # gate's own retrieval if a custom pipeline leaves it unset.
+    items = result.retriever_result.items if result.retriever_result else supporting
+    cited = [item for item in items if is_evidence(item, min_score)]
+
+    return GroundedAnswer(
+        question=question,
+        answer=result.answer,
+        grounded=True,
+        citations=[citation_of(item, i) for i, item in enumerate(cited)],
+        context=cited,
+    )
+
+
+def report(result: GroundedAnswer) -> None:
+    """Print an answer together with the evidence that backs it."""
+    print(f"\nQ: {result.question}")
+    print(f"A: {result.answer}")
+    print(f"   grounded={result.grounded}")
+    for citation, item in zip(result.citations, result.context):
+        snippet = " ".join(item.content.split())[:160]
+        print(f"   ↳ [{citation}] {snippet}")
+
+
+async def main():
+    llm = LiteLLM(model="openai/gpt-5.5")
+    embedder = LiteLLMEmbedder(model="openai/text-embedding-3-large", dimensions=256)
+
+    async with GraphRAG(
+        connection=ConnectionConfig(host="localhost", graph_name="grounded_abstention"),
+        llm=llm,
+        embedder=embedder,
+        embedding_dimension=256,
+    ) as rag:
+        # ── 1. Ingest a small, self-contained corpus ───────────────
+        await rag.ingest(text=TEXT, document_id="acme_facts")
+        await rag.finalize()
+
+        # ── 2. A question the corpus supports → grounded answer ────
+        report(await answer_or_abstain(rag, "Who founded Acme Corp?"))
+
+        # ── 3. A question the corpus says nothing about → abstain ──
+        # Nothing in the graph mentions revenue, so the gate fires
+        # before the LLM ever sees the question.
+        report(await answer_or_abstain(rag, "What was Acme Corp's revenue in 2024?"))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/graphrag_sdk/examples/grounded_answers_with_abstention.py
+++ b/graphrag_sdk/examples/grounded_answers_with_abstention.py
@@ -167,6 +167,13 @@ async def answer_or_abstain(
         if ctx is None:
             ctx = Context()
             completion_kwargs["ctx"] = ctx
+        # CAVEAT: ``_validate_history`` and ``_rewrite_question_with_history``
+        # are private. The SDK exposes no public way to resolve a follow-up
+        # question *before* generation, and the gate needs the resolved text —
+        # retrieving on a bare "What did she build?" finds nothing useful, and
+        # ``completion()``'s own rewrite happens too late to gate on. If you
+        # copy this into an application, pin your graphrag-sdk version or
+        # rewrite the question yourself and pass the resolved text instead.
         validated_history = rag._validate_history(history)
         resolved_question = await rag._rewrite_question_with_history(
             question,

--- a/graphrag_sdk/examples/grounded_answers_with_abstention.py
+++ b/graphrag_sdk/examples/grounded_answers_with_abstention.py
@@ -32,11 +32,13 @@ you can copy it into your own application (it is also exercised by
 Cost note: the gate retrieves once, and ``completion()`` retrieves again
 internally. Because ``MultiPathRetrieval`` runs an LLM keyword-extraction
 call on every retrieval, an *answered* question costs three LLM calls
-instead of two, and does the graph and vector work twice. An *unanswered*
-question costs zero LLM calls. That trade is worth it when a meaningful
-share of your traffic is unanswerable; if almost every question is
-answerable, gate on a cheaper signal or accept the prompt-level abstention
-in rule 6 of the default system prompt.
+instead of two (four instead of three with
+``rewrite_question_with_history=True``), and does the graph and vector work
+twice. An *unanswered* question still costs the retrieval keyword-extraction
+LLM call (plus the rewrite call when enabled), but avoids the generation call.
+That trade is worth it when a meaningful share of your traffic is unanswerable;
+if almost every question is answerable, gate on a cheaper signal or accept the
+prompt-level abstention in rule 6 of the default system prompt.
 
 Prerequisites:
     docker run -p 6379:6379 falkordb/falkordb
@@ -55,6 +57,7 @@ from typing import Any
 
 from graphrag_sdk import (
     ConnectionConfig,
+    Context,
     CosineReranker,
     GraphRAG,
     LiteLLM,
@@ -89,7 +92,7 @@ class GroundedAnswer:
     """An answer plus the provenance that justifies it.
 
     ``grounded`` is False exactly when the abstention gate fired, in which
-    case ``answer`` is the ``refusal`` string and no LLM call was made.
+    case ``answer`` is the ``refusal`` string and no generation call was made.
     """
 
     question: str
@@ -153,19 +156,38 @@ async def answer_or_abstain(
         A ``GroundedAnswer``. When ``grounded`` is False the answer is the
         refusal string and no generation happened.
     """
+    if min_items < 0:
+        raise ValueError("min_items must be non-negative")
+
+    resolved_question = question
+    rewrite_question = completion_kwargs.pop("rewrite_question_with_history", False)
+    history = completion_kwargs.get("history")
+    if rewrite_question and history:
+        ctx = completion_kwargs.get("ctx")
+        if ctx is None:
+            ctx = Context()
+            completion_kwargs["ctx"] = ctx
+        validated_history = rag._validate_history(history)
+        resolved_question = await rag._rewrite_question_with_history(
+            question,
+            validated_history,
+            ctx=ctx,
+        )
+
     retrieval_kwargs = {
         key: completion_kwargs[key]
         for key in ("strategy", "reranker", "ctx")
         if key in completion_kwargs
     }
-    retrieved = await rag.retrieve(question, **retrieval_kwargs)
+    retrieved = await rag.retrieve(resolved_question, **retrieval_kwargs)
     supporting = [item for item in retrieved.items if is_evidence(item, min_score)]
 
     if len(supporting) < min_items:
         return GroundedAnswer(question=question, answer=refusal, grounded=False)
 
     completion_kwargs["return_context"] = True
-    result = await rag.completion(question, **completion_kwargs)
+    completion_kwargs["rewrite_question_with_history"] = False
+    result = await rag.completion(resolved_question, **completion_kwargs)
 
     # ``return_context=True`` populates ``retriever_result``; fall back to the
     # gate's own retrieval if a custom pipeline leaves it unset.

--- a/graphrag_sdk/tests/test_grounded_abstention.py
+++ b/graphrag_sdk/tests/test_grounded_abstention.py
@@ -17,7 +17,7 @@ import pytest
 
 from graphrag_sdk.api.main import GraphRAG
 from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
-from graphrag_sdk.core.models import RetrieverResult, RetrieverResultItem
+from graphrag_sdk.core.models import RagResult, RetrieverResult, RetrieverResultItem
 from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
 
 from .conftest import MockLLM
@@ -29,6 +29,8 @@ _EXAMPLE_PATH = (
 
 def _load_example():
     spec = importlib.util.spec_from_file_location("grounded_answers_with_abstention", _EXAMPLE_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load example module from {_EXAMPLE_PATH}")
     module = importlib.util.module_from_spec(spec)
     # Register before exec: @dataclass resolves annotations via sys.modules.
     sys.modules[spec.name] = module
@@ -133,6 +135,36 @@ class TestAbstention:
 
 
 class TestGroundedAnswer:
+    async def test_retrieval_options_match_generation(self):
+        item = RetrieverResultItem(content="Evidence.", metadata={"chunk_id": "c1"})
+        retriever_result = RetrieverResult(items=[item])
+        rag = MagicMock(spec=GraphRAG)
+        rag.retrieve = AsyncMock(return_value=retriever_result)
+        rag.completion = AsyncMock(
+            return_value=RagResult(answer="Grounded.", retriever_result=retriever_result)
+        )
+        strategy = MagicMock()
+        reranker = MagicMock()
+        ctx = MagicMock()
+
+        await example.answer_or_abstain(
+            rag,
+            "Q?",
+            strategy=strategy,
+            reranker=reranker,
+            ctx=ctx,
+            return_context=False,
+        )
+
+        rag.retrieve.assert_awaited_once_with("Q?", strategy=strategy, reranker=reranker, ctx=ctx)
+        rag.completion.assert_awaited_once_with(
+            "Q?",
+            strategy=strategy,
+            reranker=reranker,
+            ctx=ctx,
+            return_context=True,
+        )
+
     async def test_supported_question_returns_grounded_answer_with_citations(
         self, mock_conn, embedder
     ):

--- a/graphrag_sdk/tests/test_grounded_abstention.py
+++ b/graphrag_sdk/tests/test_grounded_abstention.py
@@ -165,6 +165,31 @@ class TestGroundedAnswer:
             return_context=True,
         )
 
+    async def test_divergent_second_retrieval_still_reports_citations(self):
+        """A grounded answer must never come back with empty provenance.
+
+        ``completion()`` retrieves independently of the gate, so the two
+        passes can disagree. When the second pass yields no usable evidence
+        the gate's own supporting items are cited instead.
+        """
+        supporting = RetrieverResultItem(content="Evidence.", metadata={"chunk_id": "c1"})
+        rag = MagicMock(spec=GraphRAG)
+        rag.retrieve = AsyncMock(return_value=RetrieverResult(items=[supporting]))
+        rag.completion = AsyncMock(
+            return_value=RagResult(
+                answer="Grounded.",
+                retriever_result=RetrieverResult(
+                    items=[RetrieverResultItem(content="", metadata={"chunk_id": "c9"})]
+                ),
+            )
+        )
+
+        result = await example.answer_or_abstain(rag, "Q?")
+
+        assert result.grounded is True
+        assert result.citations == ["chunk_id=c1"]
+        assert result.context == [supporting]
+
     async def test_supported_question_returns_grounded_answer_with_citations(
         self, mock_conn, embedder
     ):

--- a/graphrag_sdk/tests/test_grounded_abstention.py
+++ b/graphrag_sdk/tests/test_grounded_abstention.py
@@ -78,6 +78,15 @@ def _rag_with_context(mock_conn, embedder, items, *, answer="Alice Johnson found
 
 
 class TestAbstention:
+    async def test_negative_min_items_is_rejected_before_retrieval(self):
+        rag = MagicMock(spec=GraphRAG)
+
+        with pytest.raises(ValueError, match="min_items must be non-negative"):
+            await example.answer_or_abstain(rag, "Q?", min_items=-1)
+
+        rag.retrieve.assert_not_awaited()
+        rag.completion.assert_not_awaited()
+
     async def test_no_context_returns_evidence_insufficient(self, mock_conn, embedder):
         """No supporting context → explicit refusal, no generation."""
         rag, llm = _rag_with_context(mock_conn, embedder, items=[])
@@ -163,7 +172,46 @@ class TestGroundedAnswer:
             reranker=reranker,
             ctx=ctx,
             return_context=True,
+            rewrite_question_with_history=False,
         )
+
+    async def test_history_rewrite_is_reused_for_gate_and_completion(self):
+        item = RetrieverResultItem(content="Evidence.", metadata={"chunk_id": "c1"})
+        retriever_result = RetrieverResult(items=[item])
+        rag = MagicMock(spec=GraphRAG)
+        rag.retrieve = AsyncMock(return_value=retriever_result)
+        rag.completion = AsyncMock(
+            return_value=RagResult(answer="Grounded.", retriever_result=retriever_result)
+        )
+        rag._rewrite_question_with_history = AsyncMock(return_value="Resolved question?")
+        validated_history = [MagicMock()]
+        rag._validate_history.return_value = validated_history
+        history = [{"role": "user", "content": "Who founded Acme?"}]
+        ctx = MagicMock()
+
+        result = await example.answer_or_abstain(
+            rag,
+            "What did she build?",
+            history=history,
+            rewrite_question_with_history=True,
+            ctx=ctx,
+        )
+
+        rag._rewrite_question_with_history.assert_awaited_once_with(
+            "What did she build?",
+            validated_history,
+            ctx=ctx,
+        )
+        rag._validate_history.assert_called_once_with(history)
+        rag.retrieve.assert_awaited_once_with("Resolved question?", ctx=ctx)
+        rag.completion.assert_awaited_once_with(
+            "Resolved question?",
+            history=history,
+            ctx=ctx,
+            return_context=True,
+            rewrite_question_with_history=False,
+        )
+        assert result.question == "What did she build?"
 
     async def test_divergent_second_retrieval_still_reports_citations(self):
         """A grounded answer must never come back with empty provenance.

--- a/graphrag_sdk/tests/test_grounded_abstention.py
+++ b/graphrag_sdk/tests/test_grounded_abstention.py
@@ -176,10 +176,34 @@ class TestGroundedAnswer:
             reranker=reranker,
             ctx=ctx,
             return_context=True,
-            rewrite_question_with_history=False,
         )
 
-    async def test_history_rewrite_is_reused_for_gate_and_completion(self):
+    async def test_history_rewrite_is_rejected_before_retrieval(self):
+        """The gate must retrieve on a self-contained question.
+
+        ``completion()`` resolves follow-ups internally, *after* its own
+        retrieval, so the gate cannot see the resolved text. Rather than call
+        private SDK methods to rewrite early, the caller is told to resolve
+        the question themselves.
+        """
+        rag = MagicMock(spec=GraphRAG)
+        rag.retrieve = AsyncMock()
+        rag.completion = AsyncMock()
+        history = [{"role": "user", "content": "Who founded Acme?"}]
+
+        with pytest.raises(ValueError, match="rewrite_question_with_history=True"):
+            await example.answer_or_abstain(
+                rag,
+                "What did she build?",
+                history=history,
+                rewrite_question_with_history=True,
+            )
+
+        rag.retrieve.assert_not_awaited()
+        rag.completion.assert_not_awaited()
+
+    async def test_history_is_forwarded_without_rewrite(self):
+        """A resolved question still gets `history` passed to generation."""
         item = RetrieverResultItem(content="Evidence.", metadata={"chunk_id": "c1"})
         retriever_result = RetrieverResult(items=[item])
         rag = MagicMock(spec=GraphRAG)
@@ -187,35 +211,22 @@ class TestGroundedAnswer:
         rag.completion = AsyncMock(
             return_value=RagResult(answer="Grounded.", retriever_result=retriever_result)
         )
-        rag._rewrite_question_with_history = AsyncMock(return_value="Resolved question?")
-        validated_history = [MagicMock()]
-        rag._validate_history.return_value = validated_history
         history = [{"role": "user", "content": "Who founded Acme?"}]
-        ctx = MagicMock()
 
         result = await example.answer_or_abstain(
             rag,
-            "What did she build?",
+            "What did Alice Johnson build?",
             history=history,
-            rewrite_question_with_history=True,
-            ctx=ctx,
         )
 
-        rag._rewrite_question_with_history.assert_awaited_once_with(
-            "What did she build?",
-            validated_history,
-            ctx=ctx,
-        )
-        rag._validate_history.assert_called_once_with(history)
-        rag.retrieve.assert_awaited_once_with("Resolved question?", ctx=ctx)
+        rag.retrieve.assert_awaited_once_with("What did Alice Johnson build?")
         rag.completion.assert_awaited_once_with(
-            "Resolved question?",
+            "What did Alice Johnson build?",
             history=history,
-            ctx=ctx,
             return_context=True,
-            rewrite_question_with_history=False,
         )
-        assert result.question == "What did she build?"
+        assert result.question == "What did Alice Johnson build?"
+        assert result.grounded is True
 
     async def test_divergent_second_retrieval_abstains(self):
         """Gate-only evidence must never be cited for a second-pass answer.

--- a/graphrag_sdk/tests/test_grounded_abstention.py
+++ b/graphrag_sdk/tests/test_grounded_abstention.py
@@ -80,6 +80,10 @@ def _rag_with_context(mock_conn, embedder, items, *, answer="Alice Johnson found
 class TestAbstention:
     async def test_negative_min_items_is_rejected_before_retrieval(self):
         rag = MagicMock(spec=GraphRAG)
+        # Explicit AsyncMocks: this test asserts non-invocation, so signature
+        # fidelity from the spec buys nothing, and the intent reads clearer.
+        rag.retrieve = AsyncMock()
+        rag.completion = AsyncMock()
 
         with pytest.raises(ValueError, match="min_items must be non-negative"):
             await example.answer_or_abstain(rag, "Q?", min_items=-1)
@@ -213,12 +217,13 @@ class TestGroundedAnswer:
         )
         assert result.question == "What did she build?"
 
-    async def test_divergent_second_retrieval_still_reports_citations(self):
-        """A grounded answer must never come back with empty provenance.
+    async def test_divergent_second_retrieval_abstains(self):
+        """Gate-only evidence must never be cited for a second-pass answer.
 
         ``completion()`` retrieves independently of the gate, so the two
         passes can disagree. When the second pass yields no usable evidence
-        the gate's own supporting items are cited instead.
+        the answer is ungrounded: citing the gate's items instead would
+        attach provenance the generated answer never saw.
         """
         supporting = RetrieverResultItem(content="Evidence.", metadata={"chunk_id": "c1"})
         rag = MagicMock(spec=GraphRAG)
@@ -234,9 +239,10 @@ class TestGroundedAnswer:
 
         result = await example.answer_or_abstain(rag, "Q?")
 
-        assert result.grounded is True
-        assert result.citations == ["chunk_id=c1"]
-        assert result.context == [supporting]
+        assert result.grounded is False
+        assert result.answer == example.INSUFFICIENT_EVIDENCE
+        assert result.citations == []
+        assert result.context == []
 
     async def test_supported_question_returns_grounded_answer_with_citations(
         self, mock_conn, embedder

--- a/graphrag_sdk/tests/test_grounded_abstention.py
+++ b/graphrag_sdk/tests/test_grounded_abstention.py
@@ -17,6 +17,7 @@ import pytest
 
 from graphrag_sdk.api.main import GraphRAG
 from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
+from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import RagResult, RetrieverResult, RetrieverResultItem
 from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
 
@@ -158,7 +159,9 @@ class TestGroundedAnswer:
         )
         strategy = MagicMock()
         reranker = MagicMock()
-        ctx = MagicMock()
+        ctx = MagicMock(spec=Context)
+        child_ctx = MagicMock(spec=Context)
+        ctx.child.return_value = child_ctx
 
         await example.answer_or_abstain(
             rag,
@@ -169,14 +172,59 @@ class TestGroundedAnswer:
             return_context=False,
         )
 
+        # The gate runs on the caller's ctx; generation gets a child so its
+        # deadline isn't shortened by the time the gate already spent.
         rag.retrieve.assert_awaited_once_with("Q?", strategy=strategy, reranker=reranker, ctx=ctx)
+        ctx.child.assert_called_once_with()
         rag.completion.assert_awaited_once_with(
             "Q?",
             strategy=strategy,
             reranker=reranker,
-            ctx=ctx,
+            ctx=child_ctx,
             return_context=True,
         )
+
+    async def test_generation_context_inherits_remaining_budget(self):
+        """The child context carries the remaining budget, not a fresh one.
+
+        Uses a real ``Context`` rather than a mock so the budget arithmetic
+        is exercised: generation must start its own clock but inherit only
+        what the gate left behind.
+        """
+        item = RetrieverResultItem(content="Evidence.", metadata={"chunk_id": "c1"})
+        retriever_result = RetrieverResult(items=[item])
+        rag = MagicMock(spec=GraphRAG)
+        rag.retrieve = AsyncMock(return_value=retriever_result)
+        rag.completion = AsyncMock(
+            return_value=RagResult(answer="Grounded.", retriever_result=retriever_result)
+        )
+        ctx = Context(latency_budget_ms=5_000, tenant_id="acme")
+
+        await example.answer_or_abstain(rag, "Q?", ctx=ctx)
+
+        passed_ctx = rag.completion.await_args.kwargs["ctx"]
+        assert passed_ctx is not ctx
+        assert passed_ctx.tenant_id == "acme"
+        assert passed_ctx.trace_id == ctx.trace_id
+        # Inherited the remainder, not the original 5s.
+        assert passed_ctx.latency_budget_ms <= 5_000
+        # Its own clock, so nearly the whole inherited budget is still available.
+        assert passed_ctx.remaining_budget_ms > passed_ctx.latency_budget_ms - 1_000
+
+    async def test_context_is_optional(self):
+        """No ctx supplied → nothing is invented for either call."""
+        item = RetrieverResultItem(content="Evidence.", metadata={"chunk_id": "c1"})
+        retriever_result = RetrieverResult(items=[item])
+        rag = MagicMock(spec=GraphRAG)
+        rag.retrieve = AsyncMock(return_value=retriever_result)
+        rag.completion = AsyncMock(
+            return_value=RagResult(answer="Grounded.", retriever_result=retriever_result)
+        )
+
+        await example.answer_or_abstain(rag, "Q?")
+
+        rag.retrieve.assert_awaited_once_with("Q?")
+        rag.completion.assert_awaited_once_with("Q?", return_context=True)
 
     async def test_history_rewrite_is_rejected_before_retrieval(self):
         """The gate must retrieve on a self-contained question.

--- a/graphrag_sdk/tests/test_grounded_abstention.py
+++ b/graphrag_sdk/tests/test_grounded_abstention.py
@@ -1,0 +1,191 @@
+"""Tests for the grounded-answer / abstention example.
+
+Locks in the behavior the ``grounded_answers_with_abstention.py`` example
+advertises: a question with no supporting context in the graph returns an
+explicit evidence-insufficient response instead of a fabricated answer.
+The example module is imported directly so example and test cannot drift.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from graphrag_sdk.api.main import GraphRAG
+from graphrag_sdk.core.connection import ConnectionConfig, FalkorDBConnection
+from graphrag_sdk.core.models import RetrieverResult, RetrieverResultItem
+from graphrag_sdk.retrieval.strategies.base import RetrievalStrategy
+
+from .conftest import MockLLM
+
+_EXAMPLE_PATH = (
+    Path(__file__).resolve().parents[1] / "examples" / "grounded_answers_with_abstention.py"
+)
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("grounded_answers_with_abstention", _EXAMPLE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec: @dataclass resolves annotations via sys.modules.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+example = _load_example()
+
+
+# ── Fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_conn():
+    conn = MagicMock(spec=FalkorDBConnection)
+    result_mock = MagicMock()
+    result_mock.result_set = []
+    conn.query = AsyncMock(return_value=result_mock)
+    conn.config = ConnectionConfig()
+    ontology_graph = MagicMock()
+    ontology_graph.query = AsyncMock(return_value=result_mock)
+    conn._driver = MagicMock()
+    conn._driver.select_graph = MagicMock(return_value=ontology_graph)
+    conn._ensure_client = MagicMock()
+    return conn
+
+
+def _rag_with_context(mock_conn, embedder, items, *, answer="Alice Johnson founded Acme Corp."):
+    """A GraphRAG whose retrieval always returns ``items``."""
+    llm = MockLLM(responses=[answer])
+    rag = GraphRAG(
+        connection=mock_conn,
+        llm=llm,
+        embedder=embedder,
+        embedding_dimension=8,
+    )
+    strategy = MagicMock(spec=RetrievalStrategy)
+    strategy.search = AsyncMock(return_value=RetrieverResult(items=items))
+    rag._retrieval_strategy = strategy
+    return rag, llm
+
+
+# ── Abstention ──────────────────────────────────────────────────
+
+
+class TestAbstention:
+    async def test_no_context_returns_evidence_insufficient(self, mock_conn, embedder):
+        """No supporting context → explicit refusal, no generation."""
+        rag, llm = _rag_with_context(mock_conn, embedder, items=[])
+
+        retrieved = await rag.retrieve("What was Acme Corp's revenue in 2024?")
+        assert retrieved.items == []
+
+        result = await example.answer_or_abstain(rag, "What was Acme Corp's revenue in 2024?")
+
+        assert result.grounded is False
+        assert result.answer == example.INSUFFICIENT_EVIDENCE
+        assert result.citations == []
+        # The LLM was never asked to guess.
+        assert llm._call_index == 0
+
+    async def test_hint_only_context_is_not_evidence(self, mock_conn, embedder):
+        """A MultiPath answer-format hint carries no evidence → abstain."""
+        items = [
+            RetrieverResultItem(
+                content="Answer format: Name the place.", metadata={"section": "hint"}
+            ),
+            RetrieverResultItem(content="   ", metadata={"chunk_id": "c1"}),
+        ]
+        rag, llm = _rag_with_context(mock_conn, embedder, items=items)
+
+        result = await example.answer_or_abstain(rag, "Where is Acme Corp's Tokyo office?")
+
+        assert result.grounded is False
+        assert result.answer == example.INSUFFICIENT_EVIDENCE
+        assert llm._call_index == 0
+
+    async def test_below_threshold_context_abstains(self, mock_conn, embedder):
+        """Retrieved but low-scoring context is treated as insufficient."""
+        items = [
+            RetrieverResultItem(content="Weak match.", score=0.05, metadata={"chunk_id": "c1"})
+        ]
+        rag, llm = _rag_with_context(mock_conn, embedder, items=items)
+
+        result = await example.answer_or_abstain(rag, "Who founded Acme Corp?", min_score=0.5)
+
+        assert result.grounded is False
+        assert result.answer == example.INSUFFICIENT_EVIDENCE
+        assert llm._call_index == 0
+
+    async def test_custom_refusal_string(self, mock_conn, embedder):
+        rag, _ = _rag_with_context(mock_conn, embedder, items=[])
+
+        result = await example.answer_or_abstain(rag, "Unknown?", refusal="No evidence.")
+
+        assert result.answer == "No evidence."
+        assert result.grounded is False
+
+
+# ── Positive control ────────────────────────────────────────────
+
+
+class TestGroundedAnswer:
+    async def test_supported_question_returns_grounded_answer_with_citations(
+        self, mock_conn, embedder
+    ):
+        items = [
+            RetrieverResultItem(
+                content="Acme Corp was founded in 2015 by Alice Johnson.",
+                score=0.9,
+                metadata={"chunk_id": "acme_facts:0"},
+            )
+        ]
+        rag, llm = _rag_with_context(mock_conn, embedder, items=items)
+
+        result = await example.answer_or_abstain(rag, "Who founded Acme Corp?")
+
+        assert result.grounded is True
+        assert result.answer == "Alice Johnson founded Acme Corp."
+        assert result.citations == ["chunk_id=acme_facts:0"]
+        assert result.context[0].content.startswith("Acme Corp was founded")
+        assert llm._call_index == 1
+
+    async def test_min_items_gate_requires_multiple_sources(self, mock_conn, embedder):
+        items = [RetrieverResultItem(content="Single source.", metadata={"chunk_id": "c1"})]
+        rag, llm = _rag_with_context(mock_conn, embedder, items=items)
+
+        assert (await example.answer_or_abstain(rag, "Q?", min_items=2)).grounded is False
+        assert (await example.answer_or_abstain(rag, "Q?", min_items=1)).grounded is True
+        assert llm._call_index == 1
+
+
+# ── Helper units ────────────────────────────────────────────────
+
+
+class TestEvidenceHelpers:
+    def test_is_evidence_rules(self):
+        scored = RetrieverResultItem(content="text", score=0.4, metadata={"chunk_id": "c1"})
+        assert example.is_evidence(scored, None) is True
+        assert example.is_evidence(scored, 0.3) is True
+        assert example.is_evidence(scored, 0.9) is False
+
+        unscored = RetrieverResultItem(content="text")
+        assert example.is_evidence(unscored, None) is True
+        # A threshold cannot be satisfied by an item with no score.
+        assert example.is_evidence(unscored, 0.1) is False
+
+        assert example.is_evidence(RetrieverResultItem(content=""), None) is False
+
+    def test_citation_of_falls_back_through_metadata_keys(self):
+        assert (
+            example.citation_of(RetrieverResultItem(content="x", metadata={"chunk_id": "c1"}), 0)
+            == "chunk_id=c1"
+        )
+        assert (
+            example.citation_of(RetrieverResultItem(content="x", metadata={"section": "facts"}), 0)
+            == "section=facts"
+        )
+        assert example.citation_of(RetrieverResultItem(content="x"), 3) == "item[3]"


### PR DESCRIPTION
## Summary

Consolidates **#311**, **#312** and **#314** into a single coherent change. All three were opened independently against the same topic — grounding, provenance and abstention — and collided: **#312 and #314 both add a page titled "Reducing LLM Hallucinations"** at two different slugs, with roughly 85% overlapping content, while #311 adds a third page covering the same concepts at reference depth.

Merging them as-is would have shipped three competing pages, three conflicting `docs.json` navigation insertions, duplicate rows in both READMEs, and three different implementations of `answer_or_abstain()`.

The consolidated result is **two complementary pages** instead of three competing ones:

| Page | Role | Sourced from |
|---|---|---|
| `docs/reducing-llm-hallucinations.mdx` | Canonical narrative guide | #314 (slug, framing, per-mechanism breakdown, benchmark caveat) + #312 (failure modes, `retrieve()` vs `completion()`, ontology guardrail, verification checklist) |
| `docs/reliability-and-grounding.mdx` | API-level reference | #311, de-duplicated so its abstention section defers to the guide |

The two pages cross-link in both directions, so the guide answers "how do I design around this?" and the reference answers "which class or field implements it?".

## Changes

- **New** `docs/reducing-llm-hallucinations.mdx` — canonical guide, keeping #314's SEO slug (`docs.falkordb.com/graphrag/reducing-llm-hallucinations`) and its verbatim framing paragraph.
- **New** `docs/reliability-and-grounding.mdx` — #311's vocabulary map, provenance field tables, threshold defaults, metadata-filtering guidance and validation checklist.
- **New** `graphrag_sdk/examples/grounded_answers_with_abstention.py` and `graphrag_sdk/tests/test_grounded_abstention.py`, ported from #312.
- **Cross-links** from `docs/index.mdx` (entry card), `docs/architecture.mdx`, `docs/retrieval.mdx` and `docs/benchmark.mdx` (top + caveat), per #314.
- **Navigation**: one `docs.json` entry per page — guide in `Home` after `architecture`, reference in `Reference` after `api-reference`. This replaces #311's single-page `"Reliability"` group.
- **READMEs**: #312's positioning section and tagline, plus one documentation row per page instead of three overlapping insertions.
- **CHANGELOG**: single `### Added` entry covering all of it.

## Corrections applied while merging

The three PRs disagreed with each other on several factual points. Each was checked against the source before picking a winner:

- **`MENTIONS` → `MENTIONED_IN`.** `MENTIONS` appears nowhere in `graphrag_sdk/src`; the edge is `__Entity__ → Chunk`, declared in `graph_store.py`. #312's page and both its README edits propagated the wrong name. Also fixed a **pre-existing** occurrence on `main` (`README.md`) that would otherwise have contradicted the new pages three lines away.
- **`answer_or_abstain()` now gates on `retrieve()` before generation.** #314's variant called `completion()` first and then counted evidence — paying for exactly the LLM call the abstention path exists to avoid. #311 and #312 both gated correctly; the guide now matches the runnable example.
- **`GraphStore(connection)` instead of `rag.graph_store`.** `GraphRAG` exposes no such property — the attribute is `_graph_store`, and `schema` is the only `@property` on the class. #314's snippet would have raised `AttributeError`. (Several pre-existing pages have the same bug; left alone as out of scope, but flagged below.)
- **`Ontology` / `Entity` / `Relation` instead of `GraphSchema` / `EntityType` / `RelationType`.** #312's ontology example used the deprecated v1.2 aliases, which emit `DeprecationWarning` via `__getattr__`.
- **Scores documented accurately.** `MultiPathRetrieval._format()` builds items with only `content` and `metadata`, so `score` is `None` unless a `CosineReranker` is attached. Both the guide and the example say so, and the `min_score` parameter is opt-in as a result.

Verified-correct claims retained as-is: retrieval section names (`hint`, `cypher_results`, `entities`, `relationships`, `facts`, `passages`), constructor defaults (`chunk_top_k=15`, `rel_top_k=15`, `max_entities=30`, `max_relationships=20`, `enable_cypher=False`), and `filter_facts_by_relevance(min_score=0.25, max_facts=12, min_keep=3)`.

## Testing

- `pytest tests/test_grounded_abstention.py` — **8 passed**. Mock-only, no live LLM or FalkorDB; imports the helper from the example so the two cannot drift.
- `pytest tests/` — **1104 passed, 41 skipped**, no regressions.
- `ruff check src/` and `ruff format --check src/` — clean; both new Python files pass as well.
- `docs.json` parsed and navigation asserted; every internal link and anchor in both new pages resolves to an existing page (including `/retrieval#isolated-path-performance` and `/retrieval#benchmark-results`).

## Memory / Performance Impact

N/A — documentation, one example, and one mock-only test file. No SDK source changes.

## Related Issues

Supersedes and closes:

- Closes #311
- Closes #312
- Closes #314

## Follow-ups for a maintainer

Out of scope here, carried over from the original PRs:

- `rag.graph_store` / `rag.vector_store` appear in `configuration.mdx`, `getting-started.mdx`, `graph-schema.mdx`, `retrieval.mdx` and `storage.mdx`, but neither is a public property. Either expose them or correct those pages.
- Repository description and topics (from #312) — needs repo admin access.
- The GraphRAG landing page and agent-memory link targets (from #314) live outside this repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for grounded answers, source provenance, evidence inspection, retrieval validation, and abstention.
  * Added an example that declines to answer without sufficient evidence, avoiding unnecessary generation.
  * Added support for conversation-history question rewriting in the grounded-answer example.
  * Added documentation navigation and links for reliability and hallucination reduction.

* **Documentation**
  * Updated retrieval, architecture, benchmark, and README content with grounding and production reliability guidance.

* **Tests**
  * Added coverage for evidence thresholds, unsupported questions, custom refusals, citations, history rewriting, and grounded responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->