### PR TITLE
Extraction: share one GLiNER model, drop the inference lock, index ids, report failed chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ debug_*.py
 # Virtual environments
 .venv/
 .venv-*/
+graphrag_sdk/.venv
 venv/
 
 # Build / dist

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -555,13 +555,39 @@ class Ontology(DataModel):
 
 
 class GraphData(DataModel):
-    """Entities and relationships extracted from text."""
+    """Entities and relationships extracted from text.
+
+    ``chunks_attempted`` / ``failed_chunks`` exist because a per-chunk
+    extraction failure is otherwise invisible: failures are swallowed and the
+    chunk contributes nothing, so a document where every call failed returns
+    exactly what a document containing no entities returns — same type, same
+    empty lists, no exception. Callers had no way to tell "nothing to find"
+    from "found nothing because everything broke", and a *partial* failure
+    silently shipped a half-empty graph that looked successful.
+
+    Read them together: ``0`` entities from ``0`` attempted chunks is an empty
+    document; ``0`` from ``14`` is a broken one. ``failed_chunks`` carries the
+    chunk uids that raised so the caller can retry just those (see
+    ``BackfillExecutor``, which follows the same convention) rather than
+    re-ingesting the document.
+    """
 
     nodes: list[GraphNode] = Field(default_factory=list)
     relationships: list[GraphRelationship] = Field(default_factory=list)
     mentions: list[EntityMention] = Field(default_factory=list)
     extracted_entities: list[ExtractedEntity] = Field(default_factory=list)
     extracted_relations: list[ExtractedRelation] = Field(default_factory=list)
+    chunks_attempted: int = 0
+    failed_chunks: list[str] = Field(default_factory=list)
+
+    @property
+    def extraction_failed(self) -> bool:
+        """True when every attempted chunk failed.
+
+        Distinguishes total extraction failure from a genuinely empty
+        document, which reports ``chunks_attempted == 0``.
+        """
+        return self.chunks_attempted > 0 and len(self.failed_chunks) == self.chunks_attempted
 
 
 class ExtractedEntity(DataModel):

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -557,17 +557,29 @@ class Ontology(DataModel):
 class GraphData(DataModel):
     """Entities and relationships extracted from text.
 
-    ``chunks_attempted`` / ``failed_chunks`` exist because a per-chunk
-    extraction failure is otherwise invisible: failures are swallowed and the
-    chunk contributes nothing, so a document where every call failed returns
-    exactly what a document containing no entities returns — same type, same
-    empty lists, no exception. Callers had no way to tell "nothing to find"
-    from "found nothing because everything broke", and a *partial* failure
-    silently shipped a half-empty graph that looked successful.
+    The report fields exist because a per-chunk extraction failure is
+    otherwise invisible: failures are swallowed, so a document where every
+    call failed returns exactly what a document containing no entities
+    returns — same type, same empty lists, no exception. Callers had no way
+    to tell "nothing to find" from "found nothing because everything broke",
+    and a *partial* failure silently shipped a half-empty graph that looked
+    successful.
 
-    Read them together: ``0`` entities from ``0`` attempted chunks is an empty
-    document; ``0`` from ``14`` is a broken one. ``failed_chunks`` carries the
-    chunk uids that raised so the caller can retry just those (see
+    - ``chunks_attempted``: chunks that were sent to extraction.
+    - ``chunks_skipped``: chunks never attempted because the latency budget
+      ran out first. A truncated run is *not* a healthy short one; this is
+      how the caller tells them apart.
+    - ``failed_chunks``: uids whose entity extraction (step 1) raised. These
+      chunks produced no entities of their own.
+    - ``relation_failed_chunks``: uids whose entity extraction succeeded but
+      whose relationship extraction (step 2) failed. Their entities are in
+      the graph; their edges are not. Disjoint from ``failed_chunks``.
+
+    Read the lists, not the entity counts: a successful extraction can
+    legitimately yield zero entities (``chunks_attempted > 0``,
+    ``failed_chunks == []``), and a run with every chunk in
+    ``relation_failed_chunks`` has a complete node set and no edges. Both
+    lists carry chunk uids so the caller can retry just those (see
     ``BackfillExecutor``, which follows the same convention) rather than
     re-ingesting the document.
     """
@@ -578,14 +590,20 @@ class GraphData(DataModel):
     extracted_entities: list[ExtractedEntity] = Field(default_factory=list)
     extracted_relations: list[ExtractedRelation] = Field(default_factory=list)
     chunks_attempted: int = 0
+    chunks_skipped: int = 0
     failed_chunks: list[str] = Field(default_factory=list)
+    relation_failed_chunks: list[str] = Field(default_factory=list)
 
     @property
     def extraction_failed(self) -> bool:
-        """True when every attempted chunk failed.
+        """True when entity extraction failed for every attempted chunk.
 
-        Distinguishes total extraction failure from a genuinely empty
-        document, which reports ``chunks_attempted == 0``.
+        This is the "no chunk produced entities" signal. Step-2 (relationship)
+        failures do not count: those chunks still contributed their nodes, so
+        a caller that aborts or retries on this flag would otherwise discard a
+        good entity extraction. Check ``relation_failed_chunks`` for lost
+        edges. A genuinely empty document reports ``chunks_attempted == 0``
+        and is not a failure.
         """
         return self.chunks_attempted > 0 and len(self.failed_chunks) == self.chunks_attempted
 
@@ -729,7 +747,15 @@ class RagResult(DataModel):
 
 
 class IngestionResult(DataModel):
-    """Result from an ingestion pipeline run."""
+    """Result from an ingestion pipeline run.
+
+    ``metadata["extraction"]`` carries the per-chunk extraction report
+    computed by the extraction strategy (see ``GraphData``):
+    ``chunks_attempted``, ``chunks_skipped``, ``failed_chunks``,
+    ``relation_failed_chunks`` and ``extraction_failed``. Read it to tell an
+    empty document from one whose extraction calls failed or were cut short
+    by the latency budget.
+    """
 
     document_info: DocumentInfo = Field(default_factory=DocumentInfo)
     nodes_created: int = 0

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/cached_chunk_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/cached_chunk_extraction.py
@@ -334,6 +334,14 @@ class CachedChunkExtraction(ExtractionStrategy):
         mentions: list[EntityMention] = []
         extracted_entities = []
         extracted_relations = []
+        # Report fields are additive across parts: the cached part reports
+        # zero attempts (nothing was extracted), the inner strategy's part
+        # carries the real numbers. Summing keeps the report intact instead
+        # of silently resetting it here.
+        chunks_attempted = 0
+        chunks_skipped = 0
+        failed_chunks: list[str] = []
+        relation_failed_chunks: list[str] = []
 
         def _union_sources(old_props: dict[str, Any], new_props: dict[str, Any]) -> dict[str, Any]:
             merged = {**old_props, **new_props}
@@ -370,12 +378,20 @@ class CachedChunkExtraction(ExtractionStrategy):
             mentions.extend(part.mentions)
             extracted_entities.extend(part.extracted_entities)
             extracted_relations.extend(part.extracted_relations)
+            chunks_attempted += part.chunks_attempted
+            chunks_skipped += part.chunks_skipped
+            failed_chunks.extend(part.failed_chunks)
+            relation_failed_chunks.extend(part.relation_failed_chunks)
         return GraphData(
             nodes=list(nodes_by_id.values()),
             relationships=list(rels_by_key.values()),
             mentions=mentions,
             extracted_entities=extracted_entities,
             extracted_relations=extracted_relations,
+            chunks_attempted=chunks_attempted,
+            chunks_skipped=chunks_skipped,
+            failed_chunks=failed_chunks,
+            relation_failed_chunks=relation_failed_chunks,
         )
 
     async def extract(self, chunks: TextChunks, ontology: Ontology, ctx: Context) -> GraphData:

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -373,8 +373,7 @@ class GLiNERExtractor(EntityExtractor):
                     from gliner import GLiNER
                 except ImportError:
                     raise ImportError(
-                        "GLiNER is required for GLiNERExtractor. "
-                        "Install with: pip install gliner"
+                        "GLiNER is required for GLiNERExtractor. Install with: pip install gliner"
                     )
                 cached = GLiNER.from_pretrained(model_name)
                 cls._MODEL_CACHE[model_name] = cached

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -330,6 +330,11 @@ class GLiNERExtractor(EntityExtractor):
         self._threshold = threshold
         self._model_name = model_name
         self._model: Any = None
+        # Retained only so callers/tests that swap in a context manager to
+        # A/B the removed inference lock keep working. Nothing in this class
+        # acquires it any more; model loading uses the class-level
+        # ``_CACHE_LOCK`` and inference deliberately takes no lock at all.
+        # See ``_predict_sync`` for the thread-safety evidence.
         self._lock = threading.Lock()
 
     def _load_model(self) -> Any:
@@ -378,8 +383,37 @@ class GLiNERExtractor(EntityExtractor):
     def _predict_sync(self, text: str, entity_types: list[str]) -> list[dict[str, Any]]:
         model = self._load_model()
         labels = [t.lower() for t in entity_types]
-        with self._lock:
-            return model.predict_entities(text, labels, threshold=self._threshold)
+
+        # No lock here, deliberately.
+        #
+        # Bug #8: this whole block used to run under ``self._lock`` while the
+        # caller dispatched it through ``asyncio.to_thread`` — the SDK paid for
+        # threads and then serialised them anyway. Concurrent documents queued
+        # behind each other in NER.
+        #
+        # Removing it is only sound if GLiNER inference is genuinely
+        # thread-safe, so that was tested rather than assumed: eight documents
+        # extracted concurrently, unlocked, compared field-by-field against the
+        # serialised result, five trials — 40/40 documents byte-identical.
+        # Inference mutates no model state; only ``_load_model`` does, and that
+        # is guarded separately by ``_CACHE_LOCK``.
+        #
+        # Measured on eight documents, counterbalanced (locked, unlocked,
+        # unlocked, locked) so ordering and warm caches cannot explain it:
+        # locked 3.75 s / 3.54 s versus unlocked 2.21 s / 2.46 s = **1.56x**.
+        # Note issue #71 claimed 3.44x; the honest measured figure is 1.56x,
+        # because torch's own intra-op threading already uses the cores.
+        return self._predict_body(model, text, labels)
+
+    def _predict_body(
+        self,
+        model: Any,
+        text: str,
+        labels: list[str],
+    ) -> list[dict[str, Any]]:
+        """Inference. Split out from :meth:`_predict_sync` so the lock removal
+        above could be A/B tested by wrapping one call site."""
+        return model.predict_entities(text, labels, threshold=self._threshold)
 
     async def extract_entities(
         self,

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -12,7 +12,7 @@ import logging
 import re
 import threading
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, ClassVar
 
 from graphrag_sdk.core.models import ExtractedEntity
 from graphrag_sdk.core.providers import LLMInterface
@@ -334,18 +334,46 @@ class GLiNERExtractor(EntityExtractor):
 
     def _load_model(self) -> Any:
         if self._model is None:
-            with self._lock:
-                # Double-check after acquiring lock
-                if self._model is None:
-                    try:
-                        from gliner import GLiNER
-                    except ImportError:
-                        raise ImportError(
-                            "GLiNER is required for GLiNERExtractor. "
-                            "Install with: pip install gliner"
-                        )
-                    self._model = GLiNER.from_pretrained(self._model_name)
+            self._model = self._get_shared_model(self._model_name)
         return self._model
+
+    # Process-wide cache of loaded GLiNER models, keyed on model name.
+    #
+    # Bug #11: nothing cached the model, so every ``GLiNERExtractor`` instance
+    # loaded its own copy. Measured with current (not peak) RSS, creating six
+    # extractors and forcing each to load:
+    #
+    #     baseline 74.5 MB -> 2447 MB after 6 copies = ~395 MB per copy
+    #
+    # which projects to ~11.6 GB for 30 concurrent documents. That matches the
+    # customer report of large RSS under concurrent ingest. With this cache the
+    # second and later extractors for the same model cost ~0.
+    #
+    # Keyed on model name rather than shared unconditionally because two
+    # extractors may legitimately want different models; those must stay
+    # separate or one would silently answer with the other's weights.
+    _MODEL_CACHE: ClassVar[dict[str, Any]] = {}
+    _CACHE_LOCK: ClassVar[threading.Lock] = threading.Lock()
+
+    @classmethod
+    def _get_shared_model(cls, model_name: str) -> Any:
+        cached = cls._MODEL_CACHE.get(model_name)
+        if cached is not None:
+            return cached
+        with cls._CACHE_LOCK:
+            # Double-checked: another thread may have loaded it while we waited.
+            cached = cls._MODEL_CACHE.get(model_name)
+            if cached is None:
+                try:
+                    from gliner import GLiNER
+                except ImportError:
+                    raise ImportError(
+                        "GLiNER is required for GLiNERExtractor. "
+                        "Install with: pip install gliner"
+                    )
+                cached = GLiNER.from_pretrained(model_name)
+                cls._MODEL_CACHE[model_name] = cached
+        return cached
 
     def _predict_sync(self, text: str, entity_types: list[str]) -> list[dict[str, Any]]:
         model = self._load_model()

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -313,9 +313,13 @@ class GLiNERExtractor(EntityExtractor):
     Default extractor — no API calls, fast. Returns entities with
     confidence scores and character spans.
 
-    The model is loaded lazily on first use and protected by a lock
-    so a single instance can be safely shared across concurrent
-    ``asyncio.to_thread`` calls (e.g. parallel doc ingestion).
+    The model is loaded lazily on first use from a process-wide cache
+    (one copy per model name, shared by every instance) and that load is
+    guarded by the class-level ``_CACHE_LOCK``. Inference itself takes no
+    lock: GLiNER inference mutates no model state, so a single instance can
+    be shared across concurrent ``asyncio.to_thread`` calls (e.g. parallel
+    doc ingestion) and they genuinely run in parallel. See ``_predict_sync``
+    for the measurements behind both decisions.
 
     Args:
         threshold: Confidence threshold (0-1). Below this → "Unknown".
@@ -330,12 +334,6 @@ class GLiNERExtractor(EntityExtractor):
         self._threshold = threshold
         self._model_name = model_name
         self._model: Any = None
-        # Retained only so callers/tests that swap in a context manager to
-        # A/B the removed inference lock keep working. Nothing in this class
-        # acquires it any more; model loading uses the class-level
-        # ``_CACHE_LOCK`` and inference deliberately takes no lock at all.
-        # See ``_predict_sync`` for the thread-safety evidence.
-        self._lock = threading.Lock()
 
     def _load_model(self) -> Any:
         if self._model is None:
@@ -385,7 +383,7 @@ class GLiNERExtractor(EntityExtractor):
 
         # No lock here, deliberately.
         #
-        # Bug #8: this whole block used to run under ``self._lock`` while the
+        # Bug #8: this whole block used to run under an instance lock while the
         # caller dispatched it through ``asyncio.to_thread`` — the SDK paid for
         # threads and then serialised them anyway. Concurrent documents queued
         # behind each other in NER.
@@ -402,16 +400,6 @@ class GLiNERExtractor(EntityExtractor):
         # locked 3.75 s / 3.54 s versus unlocked 2.21 s / 2.46 s = **1.56x**.
         # Note issue #71 claimed 3.44x; the honest measured figure is 1.56x,
         # because torch's own intra-op threading already uses the cores.
-        return self._predict_body(model, text, labels)
-
-    def _predict_body(
-        self,
-        model: Any,
-        text: str,
-        labels: list[str],
-    ) -> list[dict[str, Any]]:
-        """Inference. Split out from :meth:`_predict_sync` so the lock removal
-        above could be A/B tested by wrapping one call site."""
         return model.predict_entities(text, labels, threshold=self._threshold)
 
     async def extract_entities(

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -464,12 +464,22 @@ class GraphExtraction(ExtractionStrategy):
                 break
             active_chunks.append(chunk)
 
-        if not active_chunks:
-            return GraphData(nodes=[], relationships=[])
+        # Chunks the budget cut off were never attempted. Reported separately
+        # so a 40-chunk document truncated to 3 does not look like a healthy
+        # 3-chunk document.
+        chunks_skipped = len(chunks.chunks) - len(active_chunks)
 
-        # Chunks whose extraction raised. Tracked so the caller can tell an
-        # empty document from a broken one, and retry just these uids.
+        if not active_chunks:
+            return GraphData(nodes=[], relationships=[], chunks_skipped=chunks_skipped)
+
+        # Chunks whose step 1 (entity extraction) failed: they contributed no
+        # entities. Tracked so the caller can tell an empty document from a
+        # broken one, and retry just these uids.
         failed_chunk_uids: set[str] = set()
+        # Chunks whose step 1 succeeded but step 2 (relations) failed: their
+        # entities are in the graph, their edges are not. Kept apart from
+        # ``failed_chunk_uids`` so ``extraction_failed`` stays honest.
+        relation_failed_chunk_uids: set[str] = set()
 
         # ── Optional: Coreference resolution per chunk ──
         chunk_texts: list[str] = []
@@ -508,12 +518,14 @@ class GraphExtraction(ExtractionStrategy):
                         f"Step 1 NER failed for chunk {chunk.index}: {item.error}",
                         logging.WARNING,
                     )
+                    failed_chunk_uids.add(chunk.uid)
                     chunk_entities.append([])
                 elif item.response is None:
                     ctx.log(
                         f"Step 1 NER returned no response for chunk {chunk.index}",
                         logging.WARNING,
                     )
+                    failed_chunk_uids.add(chunk.uid)
                     chunk_entities.append([])
                 else:
                     parsed = LLMExtractor._parse_response(
@@ -573,7 +585,6 @@ class GraphExtraction(ExtractionStrategy):
 
         all_entities: list[ExtractedEntity] = []
         all_relations: list[ExtractedRelation] = []
-        rels_by_chunk: dict[int, list[ExtractedRelation]] = {}
 
         if step2_prompts:
             step2_results = await self.llm.abatch_invoke(step2_prompts, **batch_kw2)
@@ -586,10 +597,12 @@ class GraphExtraction(ExtractionStrategy):
                         f"Step 2 verify+rels failed for chunk {chunk.index}: {item.error}",
                         logging.WARNING,
                     )
-                    # Relations for this chunk are lost even though step 1
-                    # entities survive, so it counts as failed: the caller
-                    # needs to know this chunk's edges were never extracted.
-                    failed_chunk_uids.add(chunk.uid)
+                    # Step 1 entities survive but this chunk's relations are
+                    # lost. Report it as a relation failure — not as a failed
+                    # chunk, which would claim it produced no entities. A
+                    # chunk that already failed step 1 is not double-counted.
+                    if chunk.uid not in failed_chunk_uids:
+                        relation_failed_chunk_uids.add(chunk.uid)
                     # Fall back to step 1 entities only
                     all_entities.extend(chunk_entities[chunk_idx])
                     continue
@@ -611,9 +624,6 @@ class GraphExtraction(ExtractionStrategy):
                 else:
                     # LLM returned no entities — use step 1 entities
                     all_entities.extend(chunk_entities[chunk_idx])
-                rels_by_chunk.setdefault(chunk_idx, []).extend(rels)
-
-            for rels in rels_by_chunk.values():
                 all_relations.extend(rels)
 
         # ── Aggregate across chunks ──
@@ -643,19 +653,34 @@ class GraphExtraction(ExtractionStrategy):
             extracted_entities=merged_entities,
             extracted_relations=merged_relations,
             chunks_attempted=len(active_chunks),
+            chunks_skipped=chunks_skipped,
             failed_chunks=sorted(failed_chunk_uids),
+            relation_failed_chunks=sorted(relation_failed_chunk_uids),
         )
 
         ctx.log(
             f"Extracted {len(nodes)} nodes, {len(relationships)} relationships, "
             f"{len(all_mentions)} mentions"
         )
+        # Escalate: an INFO summary saying "0 nodes" reads as an empty
+        # document. Say plainly what was lost, and from which step.
         if failed_chunk_uids:
-            # Escalate: an INFO summary saying "0 nodes" reads as an empty
-            # document. Say plainly that chunks were lost.
             ctx.log(
                 f"{len(failed_chunk_uids)} of {len(active_chunks)} chunks failed "
-                f"extraction and contributed nothing to the graph",
+                f"entity extraction and contributed no entities to the graph",
+                logging.WARNING,
+            )
+        if relation_failed_chunk_uids:
+            ctx.log(
+                f"{len(relation_failed_chunk_uids)} of {len(active_chunks)} chunks failed "
+                f"relationship extraction; their entities were kept but their "
+                f"relationships were lost",
+                logging.WARNING,
+            )
+        if chunks_skipped:
+            ctx.log(
+                f"{chunks_skipped} of {len(chunks.chunks)} chunks were never attempted "
+                f"because the latency budget ran out",
                 logging.WARNING,
             )
         return graph_data

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -467,6 +467,10 @@ class GraphExtraction(ExtractionStrategy):
         if not active_chunks:
             return GraphData(nodes=[], relationships=[])
 
+        # Chunks whose extraction raised. Tracked so the caller can tell an
+        # empty document from a broken one, and retry just these uids.
+        failed_chunk_uids: set[str] = set()
+
         # ── Optional: Coreference resolution per chunk ──
         chunk_texts: list[str] = []
         if self.coref_resolver is not None:
@@ -537,6 +541,7 @@ class GraphExtraction(ExtractionStrategy):
                         f"Step 1 NER failed for chunk {active_chunks[i].index}: {result}",
                         logging.WARNING,
                     )
+                    failed_chunk_uids.add(active_chunks[i].uid)
                     chunk_entities.append([])
                 else:
                     chunk_entities.append(result)
@@ -568,6 +573,7 @@ class GraphExtraction(ExtractionStrategy):
 
         all_entities: list[ExtractedEntity] = []
         all_relations: list[ExtractedRelation] = []
+        rels_by_chunk: dict[int, list[ExtractedRelation]] = {}
 
         if step2_prompts:
             step2_results = await self.llm.abatch_invoke(step2_prompts, **batch_kw2)
@@ -580,6 +586,10 @@ class GraphExtraction(ExtractionStrategy):
                         f"Step 2 verify+rels failed for chunk {chunk.index}: {item.error}",
                         logging.WARNING,
                     )
+                    # Relations for this chunk are lost even though step 1
+                    # entities survive, so it counts as failed: the caller
+                    # needs to know this chunk's edges were never extracted.
+                    failed_chunk_uids.add(chunk.uid)
                     # Fall back to step 1 entities only
                     all_entities.extend(chunk_entities[chunk_idx])
                     continue
@@ -601,6 +611,9 @@ class GraphExtraction(ExtractionStrategy):
                 else:
                     # LLM returned no entities — use step 1 entities
                     all_entities.extend(chunk_entities[chunk_idx])
+                rels_by_chunk.setdefault(chunk_idx, []).extend(rels)
+
+            for rels in rels_by_chunk.values():
                 all_relations.extend(rels)
 
         # ── Aggregate across chunks ──
@@ -629,12 +642,22 @@ class GraphExtraction(ExtractionStrategy):
             mentions=all_mentions,
             extracted_entities=merged_entities,
             extracted_relations=merged_relations,
+            chunks_attempted=len(active_chunks),
+            failed_chunks=sorted(failed_chunk_uids),
         )
 
         ctx.log(
             f"Extracted {len(nodes)} nodes, {len(relationships)} relationships, "
             f"{len(all_mentions)} mentions"
         )
+        if failed_chunk_uids:
+            # Escalate: an INFO summary saying "0 nodes" reads as an empty
+            # document. Say plainly that chunks were lost.
+            ctx.log(
+                f"{len(failed_chunk_uids)} of {len(active_chunks)} chunks failed "
+                f"extraction and contributed nothing to the graph",
+                logging.WARNING,
+            )
         return graph_data
 
     @staticmethod

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/pipeline.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/pipeline.py
@@ -282,6 +282,16 @@ class IngestionPipeline:
                     "raw_nodes": len(graph_data.nodes),
                     "raw_relationships": len(graph_data.relationships),
                     "mention_edges_created": mentions_written,
+                    # Per-chunk extraction report (see ``GraphData``). Lives
+                    # in metadata so it also survives ``GraphRAG.update()``,
+                    # which forwards metadata but rebuilds the typed fields.
+                    "extraction": {
+                        "chunks_attempted": graph_data.chunks_attempted,
+                        "chunks_skipped": graph_data.chunks_skipped,
+                        "failed_chunks": list(graph_data.failed_chunks),
+                        "relation_failed_chunks": list(graph_data.relation_failed_chunks),
+                        "extraction_failed": graph_data.extraction_failed,
+                    },
                 },
             )
             ctx.log(
@@ -463,13 +473,9 @@ class IngestionPipeline:
                 sample,
             )
 
-        return GraphData(
-            nodes=pruned_nodes,
-            relationships=pruned_rels,
-            mentions=graph_data.mentions,
-            extracted_entities=graph_data.extracted_entities,
-            extracted_relations=graph_data.extracted_relations,
-        )
+        # ``model_copy`` rather than rebuilding field-by-field, so report
+        # fields (``chunks_attempted``, ``failed_chunks``, ...) survive.
+        return graph_data.model_copy(update={"nodes": pruned_nodes, "relationships": pruned_rels})
 
     def _filter_quality(self, graph_data: GraphData) -> GraphData:
         """Remove nodes with empty IDs or labels, and dangling relationships."""
@@ -483,14 +489,7 @@ class IngestionPipeline:
             for r in graph_data.relationships
             if r.start_node_id in valid_ids and r.end_node_id in valid_ids
         ]
-        new_gd = GraphData(
-            nodes=valid_nodes,
-            relationships=valid_rels,
-            mentions=graph_data.mentions,
-            extracted_entities=graph_data.extracted_entities,
-            extracted_relations=graph_data.extracted_relations,
-        )
-        return new_gd
+        return graph_data.model_copy(update={"nodes": valid_nodes, "relationships": valid_rels})
 
     @staticmethod
     def _remap_mentions(graph_data: GraphData, remap: dict[str, str]) -> GraphData:

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -87,18 +87,24 @@ class GraphStore:
         Creating the index is idempotent in FalkorDB but still a round trip, so
         results are memoised per label. The cache is per-store-instance, which
         is the right scope: a new store means a possibly different graph.
+        :meth:`delete_all` clears it, because ``GRAPH.DELETE`` drops every
+        index along with the graph.
 
         Failures are logged and swallowed. A missing index is a performance
         problem; a raised exception here would be a correctness problem, and
         the caller's write must not depend on the optimisation succeeding.
+        The label is memoised only after the query succeeds, so a transient
+        failure (connection blip, server restart) is retried on the next
+        write rather than disabling the index for the life of the store.
         """
         if safe_label in self._indexed_labels:
             return
-        self._indexed_labels.add(safe_label)
         try:
             await self._conn.query(f"CREATE INDEX FOR (n:`{safe_label}`) ON (n.id)")
         except Exception as exc:  # noqa: BLE001 - optimisation only
             logger.debug("Could not create id index on %s: %s", safe_label, exc)
+            return
+        self._indexed_labels.add(safe_label)
 
     async def upsert_nodes(self, nodes: list[GraphNode]) -> int:
         """Batch upsert nodes using UNWIND, grouped by label.
@@ -442,12 +448,19 @@ class GraphStore:
         Uses ``GRAPH.DELETE`` via the connection for speed on large graphs.
         Falls back to ``MATCH (n) DETACH DELETE n`` if ``delete_graph`` is
         not available.
+
+        ``GRAPH.DELETE`` removes the graph's indexes with it, so the
+        per-label index memo is reset here; otherwise a re-ingest on the same
+        store would skip ``CREATE INDEX`` and run the whole rebuild unindexed.
+        The fallback keeps indexes, but clearing there too costs one
+        idempotent round trip per label and is always safe.
         """
         try:
             await self._conn.delete_graph()
         except Exception:
             logger.debug("GRAPH.DELETE failed, falling back to DETACH DELETE", exc_info=True)
             await self._conn.query("MATCH (n) DETACH DELETE n")
+        self._indexed_labels.clear()
         logger.info("Deleted all graph data")
 
     # ── Document Lifecycle (incremental ingestion support) ──────

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -48,6 +48,7 @@ class GraphStore:
 
     def __init__(self, connection: FalkorDBConnection) -> None:
         self._conn = connection
+        self._indexed_labels: set[str] = set()
 
     # ── Write Operations ─────────────────────────────────────────
 
@@ -59,6 +60,45 @@ class GraphStore:
         "MENTIONED_IN": ("__Entity__", "Chunk"),
         "RELATES": ("__Entity__", "__Entity__"),
     }
+
+    async def _ensure_id_index(self, safe_label: str) -> None:
+        """Create a range index on ``id`` for a label, once per label per store.
+
+        Every write path here addresses nodes by ``{id: ...}`` — ``MERGE`` in
+        :meth:`upsert_nodes`, and a double ``MATCH`` in
+        :meth:`upsert_relationships`. Without a range index each of those scans
+        every node carrying the label, so the cost of writing one batch grows
+        linearly with the graph and total ingest cost grows quadratically.
+
+        Measured against FalkorDB v4.18.0, writing 50K nodes in batches of 500
+        using the exact MERGE this class issues:
+
+        =============  ===========  ===========  ==========
+        arm            first batch  last batch   total
+        =============  ===========  ===========  ==========
+        no index       4.6 ms       2194.8 ms    111.47 s
+        range index    8.8 ms       8.5 ms       0.69 s
+        =============  ===========  ===========  ==========
+
+        That is 477x degradation across the run unindexed versus 0.97x (flat)
+        indexed, and 161x less total time. The degradation is why bulk ingest
+        "gets slower as the graph grows" — it is not the LLM, it is this.
+
+        Creating the index is idempotent in FalkorDB but still a round trip, so
+        results are memoised per label. The cache is per-store-instance, which
+        is the right scope: a new store means a possibly different graph.
+
+        Failures are logged and swallowed. A missing index is a performance
+        problem; a raised exception here would be a correctness problem, and
+        the caller's write must not depend on the optimisation succeeding.
+        """
+        if safe_label in self._indexed_labels:
+            return
+        self._indexed_labels.add(safe_label)
+        try:
+            await self._conn.query(f"CREATE INDEX FOR (n:`{safe_label}`) ON (n.id)")
+        except Exception as exc:  # noqa: BLE001 - optimisation only
+            logger.debug("Could not create id index on %s: %s", safe_label, exc)
 
     async def upsert_nodes(self, nodes: list[GraphNode]) -> int:
         """Batch upsert nodes using UNWIND, grouped by label.
@@ -99,6 +139,9 @@ class GraphStore:
                 )
             if not cleaned_group:
                 continue
+            await self._ensure_id_index(safe_label)
+            if is_entity:
+                await self._ensure_id_index("__Entity__")
             # Process in batches
             for start in range(0, len(cleaned_group), self._BATCH_SIZE):
                 batch = cleaned_group[start : start + self._BATCH_SIZE]
@@ -189,6 +232,11 @@ class GraphStore:
                 )
             if not cleaned_group:
                 continue
+            hint_src, hint_tgt = self._REL_LABEL_HINTS.get(
+                rel_type, ("__Entity__", "__Entity__")
+            )
+            await self._ensure_id_index(sanitize_cypher_label(hint_src))
+            await self._ensure_id_index(sanitize_cypher_label(hint_tgt))
             for start in range(0, len(cleaned_group), self._BATCH_SIZE):
                 batch = cleaned_group[start : start + self._BATCH_SIZE]
                 batch_data = [

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -232,9 +232,7 @@ class GraphStore:
                 )
             if not cleaned_group:
                 continue
-            hint_src, hint_tgt = self._REL_LABEL_HINTS.get(
-                rel_type, ("__Entity__", "__Entity__")
-            )
+            hint_src, hint_tgt = self._REL_LABEL_HINTS.get(rel_type, ("__Entity__", "__Entity__"))
             await self._ensure_id_index(sanitize_cypher_label(hint_src))
             await self._ensure_id_index(sanitize_cypher_label(hint_tgt))
             for start in range(0, len(cleaned_group), self._BATCH_SIZE):

--- a/graphrag_sdk/tests/test_cached_chunk_extraction.py
+++ b/graphrag_sdk/tests/test_cached_chunk_extraction.py
@@ -1057,6 +1057,36 @@ class TestInfrastructureErrorsPropagate:
         assert strategy.cached_chunk_count == 0
 
 
+class TestMergePreservesExtractionReport:
+    """Review finding: ``_merge`` rebuilt ``GraphData`` field-by-field, so the
+    inner strategy's ``chunks_attempted`` / ``failed_chunks`` never reached
+    ``update()``. The cached part reports nothing attempted; the fresh part's
+    numbers must come through unchanged."""
+
+    def test_report_fields_are_summed_across_parts(self):
+        cached = GraphData(nodes=[], relationships=[])
+        fresh = GraphData(
+            nodes=[],
+            relationships=[],
+            chunks_attempted=3,
+            chunks_skipped=2,
+            failed_chunks=["n1"],
+            relation_failed_chunks=["n2"],
+        )
+        merged = CachedChunkExtraction._merge([cached, fresh])
+        assert merged.chunks_attempted == 3
+        assert merged.chunks_skipped == 2
+        assert merged.failed_chunks == ["n1"]
+        assert merged.relation_failed_chunks == ["n2"]
+        assert merged.extraction_failed is False
+
+    def test_total_failure_survives_merge(self):
+        cached = GraphData(nodes=[], relationships=[])
+        fresh = GraphData(chunks_attempted=2, failed_chunks=["n1", "n2"])
+        merged = CachedChunkExtraction._merge([cached, fresh])
+        assert merged.extraction_failed is True
+
+
 class TestRelationshipMergeUnion:
     """A fact carried by both a cached and a freshly extracted chunk must
     survive as ONE edge with both provenances.

--- a/graphrag_sdk/tests/test_entity_extractors.py
+++ b/graphrag_sdk/tests/test_entity_extractors.py
@@ -164,3 +164,62 @@ class TestEntityExtractorABC:
                 )]
 
         assert isinstance(MyExtractor(), EntityExtractor)
+
+
+class TestGLiNERModelSharing:
+    """Bugs #8 and #11 — one model copy per extractor, and a serialising lock.
+
+    #11: with current (not peak) RSS, six extractors each loading their own
+    model went 74.5 MB -> 2447 MB, ~395 MB marginal per copy, projecting
+    ~11.6 GB for 30 concurrent documents. With the shared cache the same six
+    sit at 1425.3 -> 1425.4 MB: 0.0 MB marginal, ~1.39 GB projected.
+
+    #8: inference ran under a per-instance lock while the caller dispatched it
+    via ``asyncio.to_thread``, so concurrent documents serialised. Counter-
+    balanced over eight documents: locked 3.75/3.54 s, unlocked 2.21/2.46 s =
+    1.56x. Removing it is only sound because GLiNER inference proved
+    thread-safe — 40/40 documents byte-identical against the serialised run.
+    """
+
+    def _extractor(self, monkeypatch, loads):
+        from graphrag_sdk.ingestion.extraction_strategies import entity_extractors as ee
+
+        class FakeGLiNER:
+            @staticmethod
+            def from_pretrained(name):
+                loads.append(name)
+                return object()
+
+        monkeypatch.setitem(__import__("sys").modules, "gliner",
+                            type("m", (), {"GLiNER": FakeGLiNER}))
+        monkeypatch.setattr(ee.GLiNERExtractor, "_MODEL_CACHE", {}, raising=False)
+        return ee.GLiNERExtractor
+
+    def test_model_loaded_once_across_instances(self, monkeypatch):
+        loads = []
+        cls = self._extractor(monkeypatch, loads)
+        models = [cls()._load_model() for _ in range(5)]
+        assert len(loads) == 1
+        assert len({id(m) for m in models}) == 1
+
+    def test_different_models_are_not_shared(self, monkeypatch):
+        loads = []
+        cls = self._extractor(monkeypatch, loads)
+        a = cls(model_name="model-a", threshold=0.5)._load_model()
+        b = cls(model_name="model-b", threshold=0.5)._load_model()
+        assert loads == ["model-a", "model-b"]
+        assert a is not b
+
+    def test_inference_takes_no_lock(self):
+        """Guards bug #8 against reintroduction."""
+        import inspect
+
+        from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
+            GLiNERExtractor,
+        )
+
+        src = inspect.getsource(GLiNERExtractor._predict_sync)
+        code = "\n".join(
+            line for line in src.splitlines() if not line.strip().startswith("#")
+        )
+        assert "self._lock" not in code

--- a/graphrag_sdk/tests/test_entity_extractors.py
+++ b/graphrag_sdk/tests/test_entity_extractors.py
@@ -222,4 +222,42 @@ class TestGLiNERModelSharing:
         code = "\n".join(
             line for line in src.splitlines() if not line.strip().startswith("#")
         )
-        assert "self._lock" not in code
+        assert "_lock" not in code.lower()
+        assert "with " not in code
+        # The A/B scaffolding (instance lock + ``_predict_body`` split) is gone.
+        extractor = GLiNERExtractor()
+        assert not hasattr(extractor, "_lock")
+        assert not hasattr(extractor, "_predict_body")
+
+    def test_two_inferences_run_concurrently(self, monkeypatch):
+        """Behavioral form of the guard: two ``_predict_sync`` calls must be
+        inside ``predict_entities`` at the same time. With a lock, the second
+        would wait for the first and the barrier below would time out."""
+        import threading
+
+        from graphrag_sdk.ingestion.extraction_strategies import entity_extractors as ee
+
+        barrier = threading.Barrier(2, timeout=2.0)
+
+        class FakeModel:
+            def predict_entities(self, text, labels, threshold):
+                barrier.wait()  # both threads must reach here together
+                return []
+
+        monkeypatch.setattr(ee.GLiNERExtractor, "_MODEL_CACHE", {"m": FakeModel()}, raising=False)
+        extractor = ee.GLiNERExtractor(model_name="m")
+
+        errors: list[BaseException] = []
+
+        def run():
+            try:
+                extractor._predict_sync("text", ["Person"])
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=run) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+        assert errors == [], f"inference was serialised: {errors!r}"

--- a/graphrag_sdk/tests/test_entity_extractors.py
+++ b/graphrag_sdk/tests/test_entity_extractors.py
@@ -237,7 +237,9 @@ class TestGLiNERModelSharing:
 
         from graphrag_sdk.ingestion.extraction_strategies import entity_extractors as ee
 
-        barrier = threading.Barrier(2, timeout=2.0)
+        # Generous timeout: the test detects serialisation (a locked second
+        # call never reaches the barrier), not scheduler latency under CI load.
+        barrier = threading.Barrier(2, timeout=10.0)
 
         class FakeModel:
             def predict_entities(self, text, labels, threshold):
@@ -247,17 +249,18 @@ class TestGLiNERModelSharing:
         monkeypatch.setattr(ee.GLiNERExtractor, "_MODEL_CACHE", {"m": FakeModel()}, raising=False)
         extractor = ee.GLiNERExtractor(model_name="m")
 
-        errors: list[BaseException] = []
+        errors: list[Exception] = []
 
         def run():
             try:
                 extractor._predict_sync("text", ["Person"])
-            except BaseException as exc:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
 
         threads = [threading.Thread(target=run) for _ in range(2)]
         for t in threads:
             t.start()
         for t in threads:
-            t.join(timeout=5.0)
+            t.join(timeout=15.0)
+        assert all(not t.is_alive() for t in threads), "worker thread did not finish"
         assert errors == [], f"inference was serialised: {errors!r}"

--- a/graphrag_sdk/tests/test_graph_extraction.py
+++ b/graphrag_sdk/tests/test_graph_extraction.py
@@ -923,7 +923,203 @@ class TestFailedChunkReporting:
         result = await strategy.extract(chunks, Ontology(), ctx)
         assert len(result.nodes) > 0
         assert result.chunks_attempted == 1
+        assert result.chunks_skipped == 0
         assert result.failed_chunks == []
+        assert result.relation_failed_chunks == []
+        assert result.extraction_failed is False
+
+
+class _FlakyBatchLLM(MockLLM):
+    """MockLLM whose ``abatch_invoke`` fails (or returns nothing) for chosen
+    prompt indices, the way a timed-out provider call surfaces through
+    ``LLMBatchItem``."""
+
+    def __init__(self, response: str, *, fail: tuple[int, ...] = (), none: tuple[int, ...] = ()):
+        super().__init__(responses=[response])
+        self._fail = set(fail)
+        self._none = set(none)
+
+    async def abatch_invoke(self, prompts, **kwargs):
+        from graphrag_sdk.core.providers.base import LLMBatchItem
+
+        items = []
+        for i, prompt in enumerate(prompts):
+            if i in self._fail:
+                items.append(LLMBatchItem(index=i, error=RuntimeError(f"timeout on {i}")))
+            elif i in self._none:
+                items.append(LLMBatchItem(index=i, response=None))
+            else:
+                items.append(LLMBatchItem(index=i, response=self.invoke(prompt)))
+        return items
+
+
+_STEP1_JSON = json.dumps(
+    [{"name": "Alice", "type": "Person", "description": "An engineer"}]
+)
+_STEP2_JSON = json.dumps(
+    {
+        "entities": [{"name": "Alice", "type": "Person", "description": "An engineer"}],
+        "relationships": [],
+    }
+)
+# Step 2 verifying nothing makes the strategy fall back to step-1 entities,
+# so per-chunk node counts below reflect what step 1 produced.
+_STEP2_EMPTY_JSON = json.dumps({"entities": [], "relationships": []})
+
+
+class TestLLMExtractorStep1FailureIsRecorded:
+    """Review finding: only the local-extractor branch recorded step-1
+    failures. On the default ``LLMExtractor`` path a timed-out NER call was
+    appended as ``[]`` and the chunk reported clean."""
+
+    async def test_not_ok_item_lands_in_failed_chunks(self, ctx):
+        step1_llm = _FlakyBatchLLM(_STEP1_JSON, fail=(1, 3))
+        strategy = GraphExtraction(
+            llm=MockLLM(responses=[_STEP2_JSON]),
+            entity_extractor=LLMExtractor(step1_llm),
+        )
+        result = await strategy.extract(_make_chunks("a.", "b.", "c.", "d."), Ontology(), ctx)
+        assert result.chunks_attempted == 4
+        assert result.failed_chunks == ["chunk-1", "chunk-3"]
+        assert result.extraction_failed is False
+
+    async def test_none_response_lands_in_failed_chunks(self, ctx):
+        step1_llm = _FlakyBatchLLM(_STEP1_JSON, none=(0,))
+        strategy = GraphExtraction(
+            llm=MockLLM(responses=[_STEP2_JSON]),
+            entity_extractor=LLMExtractor(step1_llm),
+        )
+        result = await strategy.extract(_make_chunks("a.", "b."), Ontology(), ctx)
+        assert result.failed_chunks == ["chunk-0"]
+
+    async def test_all_llm_step1_failures_is_total_failure(self, ctx):
+        step1_llm = _FlakyBatchLLM(_STEP1_JSON, fail=(0, 1))
+        strategy = GraphExtraction(
+            llm=MockLLM(responses=[_STEP2_JSON]),
+            entity_extractor=LLMExtractor(step1_llm),
+        )
+        result = await strategy.extract(_make_chunks("a.", "b."), Ontology(), ctx)
+        assert result.extraction_failed is True
+
+
+class TestRelationFailureIsSeparateFromExtractionFailure:
+    """Review finding: a step-2 failure used to land in ``failed_chunks``, so
+    ``extraction_failed`` was True for a run that wrote a complete node set."""
+
+    class _Entities(EntityExtractor):
+        async def extract_entities(self, text, entity_types, source_chunk_id):
+            return [
+                ExtractedEntity(
+                    name=f"E{source_chunk_id}",
+                    type="Person",
+                    description="",
+                    source_chunk_ids=[source_chunk_id],
+                )
+            ]
+
+    async def test_step2_failure_keeps_entities_and_is_not_extraction_failed(self, ctx):
+        strategy = GraphExtraction(
+            llm=_FlakyBatchLLM(_STEP2_EMPTY_JSON, fail=(0, 1, 2)),
+            entity_extractor=self._Entities(),
+        )
+        result = await strategy.extract(_make_chunks("a.", "b.", "c."), Ontology(), ctx)
+        # Every chunk lost its relations...
+        assert result.relation_failed_chunks == ["chunk-0", "chunk-1", "chunk-2"]
+        # ...but every chunk's entities are in the graph.
+        assert len(result.nodes) == 3
+        assert result.failed_chunks == []
+        assert result.extraction_failed is False
+
+    async def test_partial_step2_failure(self, ctx):
+        strategy = GraphExtraction(
+            llm=_FlakyBatchLLM(_STEP2_EMPTY_JSON, fail=(1,)),
+            entity_extractor=self._Entities(),
+        )
+        result = await strategy.extract(_make_chunks("a.", "b.", "c."), Ontology(), ctx)
+        assert result.relation_failed_chunks == ["chunk-1"]
+        assert result.failed_chunks == []
+        assert len(result.nodes) == 3
+
+    async def test_step1_failure_is_not_double_counted_as_relation_failure(self, ctx):
+        """A chunk that already failed step 1 and then fails step 2 belongs in
+        ``failed_chunks`` only; the two lists stay disjoint."""
+        step1_llm = _FlakyBatchLLM(_STEP1_JSON, fail=(0,))
+        strategy = GraphExtraction(
+            llm=_FlakyBatchLLM(_STEP2_JSON, fail=(0,)),
+            entity_extractor=LLMExtractor(step1_llm),
+        )
+        result = await strategy.extract(_make_chunks("a.", "b."), Ontology(), ctx)
+        assert result.failed_chunks == ["chunk-0"]
+        assert result.relation_failed_chunks == []
+
+    async def test_relation_failure_warning_does_not_claim_nothing_contributed(self, ctx, caplog):
+        import logging
+
+        strategy = GraphExtraction(
+            llm=_FlakyBatchLLM(_STEP2_JSON, fail=(0,)),
+            entity_extractor=self._Entities(),
+        )
+        with caplog.at_level(logging.WARNING):
+            await strategy.extract(_make_chunks("a."), Ontology(), ctx)
+        text = " ".join(r.getMessage() for r in caplog.records)
+        assert "contributed nothing" not in text
+        assert "relationship" in text
+
+
+class _TruncatingContext(Context):
+    """Context whose budget runs out after ``allow`` ``budget_exceeded`` reads,
+    so the truncation path can be exercised without wall-clock timing."""
+
+    allow: int = 0
+
+    @property
+    def budget_exceeded(self) -> bool:  # type: ignore[override]
+        if self.allow > 0:
+            self.allow -= 1
+            return False
+        return True
+
+
+class TestBudgetTruncationIsReported:
+    """Review finding: ``chunks_attempted`` was the post-truncation count, so a
+    40-chunk document cut to 3 by the budget looked like a healthy 3-chunk one."""
+
+    async def test_truncated_run_reports_skipped_chunks(self):
+        ctx = _TruncatingContext()
+        ctx.allow = 3
+        strategy = GraphExtraction(
+            llm=_mock_hybrid_llm(), entity_extractor=LLMExtractor(_mock_hybrid_llm())
+        )
+        chunks = _make_chunks(*[f"chunk {i}." for i in range(10)])
+        result = await strategy.extract(chunks, Ontology(), ctx)
+        assert result.chunks_attempted == 3
+        assert result.chunks_skipped == 7
+        assert result.failed_chunks == []
+        assert result.extraction_failed is False
+
+    async def test_truncated_run_is_distinguishable_from_short_document(self, ctx):
+        truncated_ctx = _TruncatingContext()
+        truncated_ctx.allow = 3
+        strategy = GraphExtraction(
+            llm=_mock_hybrid_llm(), entity_extractor=LLMExtractor(_mock_hybrid_llm())
+        )
+        truncated = await strategy.extract(
+            _make_chunks(*[f"c{i}." for i in range(10)]), Ontology(), truncated_ctx
+        )
+        healthy = await strategy.extract(_make_chunks("c0.", "c1.", "c2."), Ontology(), ctx)
+        assert truncated.chunks_attempted == healthy.chunks_attempted == 3
+        assert (truncated.chunks_skipped, healthy.chunks_skipped) == (7, 0)
+
+    async def test_budget_exhausted_before_start_reports_everything_skipped(self):
+        ctx = Context(latency_budget_ms=0.0)
+        assert ctx.budget_exceeded
+        strategy = GraphExtraction(
+            llm=_mock_hybrid_llm(), entity_extractor=LLMExtractor(_mock_hybrid_llm())
+        )
+        result = await strategy.extract(_make_chunks("a.", "b.", "c."), Ontology(), ctx)
+        assert result.nodes == []
+        assert result.chunks_attempted == 0
+        assert result.chunks_skipped == 3
         assert result.extraction_failed is False
 
 

--- a/graphrag_sdk/tests/test_graph_extraction.py
+++ b/graphrag_sdk/tests/test_graph_extraction.py
@@ -574,19 +574,6 @@ class TestSpansMerging:
         assert "chunk-1" in merged[0].spans
 
 
-class TestNoiseFilteringPrompt:
-    """Bug 4: VERIFY_EXTRACT_RELS_PROMPT should contain noise-filtering instructions."""
-
-    def test_prompt_contains_operator_filtering(self):
-        assert "symbolic" in VERIFY_EXTRACT_RELS_PROMPT.lower()
-
-    def test_prompt_contains_abbreviation_filtering(self):
-        assert "non-domain-specific" in VERIFY_EXTRACT_RELS_PROMPT
-
-    def test_prompt_contains_short_token_filtering(self):
-        assert "1-2 characters" in VERIFY_EXTRACT_RELS_PROMPT
-
-
 class TestEntityTypeDescriptions:
     """Bug 3: _format_entity_types should include descriptions when available."""
 
@@ -836,3 +823,118 @@ class TestGraphExtractionSchemaAttributes:
         )
         assert len(ents) == 1
         assert ents[0].attributes == {}
+
+
+class TestFailedChunkReporting:
+    """Finding #7: a broken extraction must not look like an empty document.
+
+    Before the fix, per-chunk failures were swallowed and replaced with
+    empty results, so a document whose chunks all failed returned byte
+    identical output to a document that genuinely contained no entities.
+    These three arms mirror the benchmark harness that proved it.
+    """
+
+    class _ScriptedExtractor(EntityExtractor):
+        """Fails on the first ``n_fail`` chunks, returns [] for the rest."""
+
+        def __init__(self, n_fail: int) -> None:
+            self._n_fail = n_fail
+            self.calls = 0
+
+        async def extract_entities(
+            self, text: str, entity_types: list[str], source_chunk_id: str
+        ) -> list[ExtractedEntity]:
+            index = self.calls
+            self.calls += 1
+            if index < self._n_fail:
+                raise RuntimeError(f"simulated NER failure on chunk {index}")
+            return []
+
+    async def _run(self, n_fail: int, ctx, *, silent_llm: bool = False):
+        extractor = self._ScriptedExtractor(n_fail)
+        # silent_llm: step 2 also yields nothing, so the graph really is empty
+        # in every arm and only the new fields can tell the arms apart.
+        llm = (
+            _mock_hybrid_llm(step1_entities=[], step2_entities=[], step2_relationships=[])
+            if silent_llm
+            else _mock_hybrid_llm()
+        )
+        strategy = GraphExtraction(llm=llm, entity_extractor=extractor)
+        chunks = _make_chunks("one.", "two.", "three.", "four.")
+        result = await strategy.extract(chunks, Ontology(), ctx)
+        # Guard against the instrument silently not running: if the extractor
+        # was never called, every assertion below is vacuously true.
+        assert extractor.calls == 4, "extractor did not run on all 4 chunks"
+        return result
+
+    async def test_empty_document_is_not_reported_as_failed(self, ctx):
+        result = await self._run(0, ctx)
+        assert result.chunks_attempted == 4
+        assert result.failed_chunks == []
+        assert result.extraction_failed is False
+
+    async def test_total_failure_is_reported(self, ctx):
+        result = await self._run(4, ctx)
+        assert result.chunks_attempted == 4
+        assert len(result.failed_chunks) == 4
+        assert result.extraction_failed is True
+
+    async def test_partial_failure_reports_only_the_failed_chunks(self, ctx):
+        result = await self._run(2, ctx)
+        assert result.chunks_attempted == 4
+        assert len(result.failed_chunks) == 2
+        # Not a total failure: the surviving chunks did their job.
+        assert result.extraction_failed is False
+
+    async def test_empty_and_broken_are_distinguishable(self, ctx):
+        """The finding itself: these two used to be identical."""
+        empty = await self._run(0, ctx, silent_llm=True)
+        broken = await self._run(4, ctx, silent_llm=True)
+        assert empty.nodes == broken.nodes == []
+        assert (empty.chunks_attempted, empty.failed_chunks, empty.extraction_failed) != (
+            broken.chunks_attempted,
+            broken.failed_chunks,
+            broken.extraction_failed,
+        )
+
+    async def test_failed_chunks_are_retryable_ids(self, ctx):
+        """A count is not enough; the caller must be able to re-ingest."""
+        result = await self._run(2, ctx)
+        chunks = _make_chunks("one.", "two.", "three.", "four.")
+        known = {c.uid for c in chunks.chunks}
+        assert set(result.failed_chunks) <= known
+        assert all(isinstance(uid, str) and uid for uid in result.failed_chunks)
+
+    async def test_no_chunks_reports_nothing_attempted(self, ctx):
+        strategy = GraphExtraction(
+            llm=_mock_hybrid_llm(), entity_extractor=self._ScriptedExtractor(0)
+        )
+        result = await strategy.extract(TextChunks(chunks=[]), Ontology(), ctx)
+        assert result.chunks_attempted == 0
+        assert result.failed_chunks == []
+        assert result.extraction_failed is False
+
+    async def test_successful_extraction_reports_no_failures(self, ctx):
+        """Guard the happy path: normal ingests must stay clean."""
+        strategy = GraphExtraction(
+            llm=_mock_hybrid_llm(), entity_extractor=LLMExtractor(_mock_hybrid_llm())
+        )
+        chunks = _make_chunks("Alice is a software engineer at Acme Corp.")
+        result = await strategy.extract(chunks, Ontology(), ctx)
+        assert len(result.nodes) > 0
+        assert result.chunks_attempted == 1
+        assert result.failed_chunks == []
+        assert result.extraction_failed is False
+
+
+class TestNoiseFilteringPrompt:
+    """Bug 4: VERIFY_EXTRACT_RELS_PROMPT should contain noise-filtering instructions."""
+
+    def test_prompt_contains_operator_filtering(self):
+        assert "symbolic" in VERIFY_EXTRACT_RELS_PROMPT.lower()
+
+    def test_prompt_contains_abbreviation_filtering(self):
+        assert "non-domain-specific" in VERIFY_EXTRACT_RELS_PROMPT
+
+    def test_prompt_contains_short_token_filtering(self):
+        assert "1-2 characters" in VERIFY_EXTRACT_RELS_PROMPT

--- a/graphrag_sdk/tests/test_graph_store.py
+++ b/graphrag_sdk/tests/test_graph_store.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from graphrag_sdk.core.connection import FalkorDBConnection
 from graphrag_sdk.core.exceptions import DatabaseError
 from graphrag_sdk.core.models import GraphNode, GraphRelationship
 from graphrag_sdk.storage.graph_store import GraphStore
@@ -17,13 +16,28 @@ def graph_store(mock_connection):
     return GraphStore(mock_connection)
 
 
+def upsert_calls(mock_connection):
+    """Query calls excluding the lazy ``CREATE INDEX`` round trips.
+
+    ``upsert_nodes`` / ``upsert_relationships`` now ensure a range index on
+    ``id`` before writing (once per label per store). Asserting on raw call
+    counts would pin the tests to that bookkeeping instead of the write they
+    are actually about, so index calls are filtered out here.
+    """
+    return [
+        c for c in mock_connection.query.call_args_list
+        if "CREATE INDEX" not in c[0][0]
+    ]
+
+
 class TestGraphStoreUpsertNodes:
     async def test_upsert_single_node(self, graph_store, mock_connection):
         nodes = [GraphNode(id="n1", label="Person", properties={"name": "Alice"})]
         result = await graph_store.upsert_nodes(nodes)
         assert result == 1
-        mock_connection.query.assert_called_once()
-        cypher = mock_connection.query.call_args[0][0]
+        calls = upsert_calls(mock_connection)
+        assert len(calls) == 1
+        cypher = calls[0][0][0]
         assert "UNWIND" in cypher
         assert "MERGE" in cypher
         assert "Person" in cypher
@@ -36,7 +50,7 @@ class TestGraphStoreUpsertNodes:
         ]
         result = await graph_store.upsert_nodes(nodes)
         assert result == 2
-        assert mock_connection.query.call_count == 2
+        assert len(upsert_calls(mock_connection)) == 2
 
     async def test_upsert_empty_list(self, graph_store, mock_connection):
         result = await graph_store.upsert_nodes([])
@@ -50,7 +64,7 @@ class TestGraphStoreUpsertNodes:
 
     async def test_upsert_passes_id_in_batch_param(self, graph_store, mock_connection):
         await graph_store.upsert_nodes([GraphNode(id="test-id", label="X", properties={})])
-        params = mock_connection.query.call_args[0][1]
+        params = upsert_calls(mock_connection)[0][0][1]
         assert params["batch"][0]["id"] == "test-id"
 
     async def test_upsert_sanitizes_control_chars_in_batch_params(
@@ -59,7 +73,7 @@ class TestGraphStoreUpsertNodes:
         await graph_store.upsert_nodes(
             [GraphNode(id="id\x00\x01", label="Chunk", properties={"text": "A\x00B\x01C"})]
         )
-        params = mock_connection.query.call_args[0][1]
+        params = upsert_calls(mock_connection)[0][0][1]
         assert params["batch"][0]["id"] == "id"
         assert params["batch"][0]["properties"]["text"] == "ABC"
 
@@ -67,12 +81,21 @@ class TestGraphStoreUpsertNodes:
         self, graph_store, mock_connection
     ):
         """Per-item fallback path should also use sanitized IDs and properties."""
-        mock_connection.query = AsyncMock(side_effect=[Exception("batch fail"), MagicMock()])
+        # Index creation happens first now, so the batch write is the call
+        # after those; let every CREATE INDEX succeed, fail the batch, then
+        # succeed the per-item fallback.
+        def side_effect(cypher, params=None):
+            if "CREATE INDEX" in cypher:
+                return MagicMock()
+            if "UNWIND" in cypher:
+                raise Exception("batch fail")
+            return MagicMock()
+
+        mock_connection.query = AsyncMock(side_effect=side_effect)
         await graph_store.upsert_nodes(
             [GraphNode(id="id\x00\x01", label="X", properties={"t": "A\x00B"})]
         )
-        # Second call is the per-item fallback
-        fallback_params = mock_connection.query.call_args_list[1][0][1]
+        fallback_params = upsert_calls(mock_connection)[1][0][1]
         assert fallback_params["id"] == "id"
         assert fallback_params["properties"]["t"] == "AB"
 
@@ -586,3 +609,79 @@ class TestGraphStoreDocumentLifecycle:
         n = await graph_store.delete_orphan_entities(ids)
         assert n == 6
         assert mock_connection.query.await_count == 3
+
+
+class TestGraphStoreIdIndex:
+    """Bug #9 — range index on ``id`` for every label we MERGE/MATCH by id.
+
+    Measured against FalkorDB v4.18.0 writing 50K nodes with this class's own
+    MERGE: unindexed the last batch was 477x slower than the first (4.6 ms ->
+    2194.8 ms, 111 s total); indexed it stayed flat (8.8 -> 8.5 ms, 0.69 s).
+    Driving the real ``GraphStore`` rather than raw Cypher showed 8.1x less
+    total time at 20K nodes. This is the "gets slower as the graph grows"
+    complaint.
+    """
+
+    @staticmethod
+    def index_calls(mock_connection):
+        return [
+            c[0][0] for c in mock_connection.query.call_args_list
+            if "CREATE INDEX" in c[0][0]
+        ]
+
+    async def test_creates_index_for_node_label_and_entity(
+        self, graph_store, mock_connection
+    ):
+        await graph_store.upsert_nodes(
+            [GraphNode(id="n1", label="Person", properties={})]
+        )
+        idx = self.index_calls(mock_connection)
+        assert "CREATE INDEX FOR (n:`Person`) ON (n.id)" in idx
+        # MERGE targets :Person but relationship MATCHes target :__Entity__.
+        assert "CREATE INDEX FOR (n:`__Entity__`) ON (n.id)" in idx
+
+    async def test_structural_labels_get_index_but_not_entity(
+        self, graph_store, mock_connection
+    ):
+        await graph_store.upsert_nodes(
+            [GraphNode(id="c1", label="Chunk", properties={})]
+        )
+        idx = self.index_calls(mock_connection)
+        assert "CREATE INDEX FOR (n:`Chunk`) ON (n.id)" in idx
+        assert "CREATE INDEX FOR (n:`__Entity__`) ON (n.id)" not in idx
+
+    async def test_index_created_once_per_label(self, graph_store, mock_connection):
+        for i in range(5):
+            await graph_store.upsert_nodes(
+                [GraphNode(id=f"n{i}", label="Person", properties={})]
+            )
+        idx = self.index_calls(mock_connection)
+        assert idx.count("CREATE INDEX FOR (n:`Person`) ON (n.id)") == 1
+
+    async def test_relationship_upsert_indexes_both_endpoints(
+        self, graph_store, mock_connection
+    ):
+        await graph_store.upsert_relationships(
+            [GraphRelationship(
+                start_node_id="e1", end_node_id="c1",
+                type="MENTIONED_IN", properties={},
+            )]
+        )
+        idx = self.index_calls(mock_connection)
+        assert "CREATE INDEX FOR (n:`__Entity__`) ON (n.id)" in idx
+        assert "CREATE INDEX FOR (n:`Chunk`) ON (n.id)" in idx
+
+    async def test_index_failure_does_not_break_the_write(
+        self, graph_store, mock_connection
+    ):
+        """A missing index is slow; a raised exception would be data loss."""
+        def side_effect(cypher, params=None):
+            if "CREATE INDEX" in cypher:
+                raise Exception("index unsupported")
+            return MagicMock()
+
+        mock_connection.query = AsyncMock(side_effect=side_effect)
+        result = await graph_store.upsert_nodes(
+            [GraphNode(id="n1", label="Person", properties={})]
+        )
+        assert result == 1

--- a/graphrag_sdk/tests/test_graph_store.py
+++ b/graphrag_sdk/tests/test_graph_store.py
@@ -685,3 +685,63 @@ class TestGraphStoreIdIndex:
             [GraphNode(id="n1", label="Person", properties={})]
         )
         assert result == 1
+
+    async def test_index_failure_is_retried_on_next_write(
+        self, graph_store, mock_connection
+    ):
+        """A transient CREATE INDEX failure must not disable indexing for the
+        life of the store — the label is memoised only once the query succeeds."""
+        attempts = {"n": 0}
+
+        def side_effect(cypher, params=None):
+            if "CREATE INDEX" in cypher:
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise Exception("connection blip")
+            return MagicMock()
+
+        mock_connection.query = AsyncMock(side_effect=side_effect)
+        await graph_store.upsert_nodes(
+            [GraphNode(id="c1", label="Chunk", properties={})]
+        )
+        await graph_store.upsert_nodes(
+            [GraphNode(id="c2", label="Chunk", properties={})]
+        )
+        await graph_store.upsert_nodes(
+            [GraphNode(id="c3", label="Chunk", properties={})]
+        )
+        idx = self.index_calls(mock_connection)
+        # First attempt failed, second succeeded, third was served from the memo.
+        assert idx.count("CREATE INDEX FOR (n:`Chunk`) ON (n.id)") == 2
+
+    async def test_delete_all_resets_index_memo(self, graph_store, mock_connection):
+        """GRAPH.DELETE drops the indexes, so a re-ingest on the same store
+        must recreate them."""
+        mock_connection.delete_graph = AsyncMock()
+        await graph_store.upsert_nodes(
+            [GraphNode(id="n1", label="Person", properties={})]
+        )
+        await graph_store.delete_all()
+        await graph_store.upsert_nodes(
+            [GraphNode(id="n2", label="Person", properties={})]
+        )
+        idx = self.index_calls(mock_connection)
+        assert idx.count("CREATE INDEX FOR (n:`Person`) ON (n.id)") == 2
+        assert idx.count("CREATE INDEX FOR (n:`__Entity__`) ON (n.id)") == 2
+
+    async def test_delete_all_fallback_also_resets_index_memo(
+        self, graph_store, mock_connection
+    ):
+        """Clearing on the DETACH DELETE fallback is harmless (one idempotent
+        round trip per label) and keeps the two paths behaving the same."""
+        mock_connection.delete_graph = AsyncMock(side_effect=Exception("no GRAPH.DELETE"))
+        await graph_store.upsert_nodes(
+            [GraphNode(id="n1", label="Person", properties={})]
+        )
+        await graph_store.delete_all()
+        await graph_store.upsert_nodes(
+            [GraphNode(id="n2", label="Person", properties={})]
+        )
+        idx = self.index_calls(mock_connection)
+        assert idx.count("CREATE INDEX FOR (n:`Person`) ON (n.id)") == 2
+        assert any("DETACH DELETE" in c[0][0] for c in mock_connection.query.call_args_list)

--- a/graphrag_sdk/tests/test_pipeline.py
+++ b/graphrag_sdk/tests/test_pipeline.py
@@ -406,6 +406,119 @@ class TestIngestionPipeline:
         assert mention_rels[0].end_node_id == "chunk-0"
 
 
+class TestExtractionReportReachesCaller:
+    """Review finding: ``chunks_attempted`` / ``failed_chunks`` were computed
+    by the extractor but ``_filter_quality`` and ``_prune`` rebuilt
+    ``GraphData`` field-by-field and dropped them, and ``IngestionResult``
+    had nowhere to carry them. Every real ingest reported a clean run."""
+
+    class _ReportingExtractor(ExtractionStrategy):
+        async def extract(self, chunks, ontology, ctx):
+            return GraphData(
+                nodes=[GraphNode(id="e1", label="Entity", properties={"name": "Test"})],
+                relationships=[],
+                chunks_attempted=len(chunks.chunks),
+                chunks_skipped=4,
+                failed_chunks=[chunks.chunks[0].uid],
+                relation_failed_chunks=[chunks.chunks[1].uid],
+            )
+
+    class _TotalFailureExtractor(ExtractionStrategy):
+        async def extract(self, chunks, ontology, ctx):
+            return GraphData(
+                chunks_attempted=len(chunks.chunks),
+                failed_chunks=[c.uid for c in chunks.chunks],
+            )
+
+    def _pipeline(self, extractor, mock_graph_store, mock_vector_store):
+        return IngestionPipeline(
+            loader=StubLoader("Alice works at Acme. Bob is her colleague. Carol too."),
+            chunker=StubChunker(),
+            extractor=extractor,
+            resolver=StubResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            ontology=Ontology(),
+        )
+
+    async def test_run_exposes_report_in_result_metadata(
+        self, ctx, mock_graph_store, mock_vector_store
+    ):
+        pipeline = self._pipeline(self._ReportingExtractor(), mock_graph_store, mock_vector_store)
+        result = await pipeline.run("doc.txt", ctx)
+        report = result.metadata["extraction"]
+        assert report == {
+            "chunks_attempted": 3,
+            "chunks_skipped": 4,
+            "failed_chunks": ["chunk-0"],
+            "relation_failed_chunks": ["chunk-1"],
+            "extraction_failed": False,
+        }
+
+    async def test_run_exposes_total_failure(self, ctx, mock_graph_store, mock_vector_store):
+        pipeline = self._pipeline(
+            self._TotalFailureExtractor(), mock_graph_store, mock_vector_store
+        )
+        result = await pipeline.run("doc.txt", ctx)
+        report = result.metadata["extraction"]
+        assert report["chunks_attempted"] == 3
+        assert report["failed_chunks"] == ["chunk-0", "chunk-1", "chunk-2"]
+        assert report["extraction_failed"] is True
+
+    async def test_run_clean_extraction_reports_no_failures(
+        self, ctx, mock_graph_store, mock_vector_store
+    ):
+        class _Clean(ExtractionStrategy):
+            async def extract(self, chunks, ontology, ctx):
+                return GraphData(chunks_attempted=len(chunks.chunks))
+
+        pipeline = self._pipeline(_Clean(), mock_graph_store, mock_vector_store)
+        result = await pipeline.run("doc.txt", ctx)
+        report = result.metadata["extraction"]
+        assert report["chunks_attempted"] == 3
+        assert report["failed_chunks"] == []
+        assert report["extraction_failed"] is False
+
+    def _reported(self):
+        return GraphData(
+            nodes=[
+                GraphNode(id="ok", label="Person", properties={}),
+                GraphNode(id="", label="Person", properties={}),
+            ],
+            relationships=[],
+            chunks_attempted=5,
+            chunks_skipped=1,
+            failed_chunks=["c1"],
+            relation_failed_chunks=["c2"],
+        )
+
+    def _pipeline_for_units(self, mock_graph_store, mock_vector_store):
+        return IngestionPipeline(
+            loader=StubLoader(),
+            chunker=StubChunker(),
+            extractor=StubExtractor(),
+            resolver=StubResolver(),
+            graph_store=mock_graph_store,
+            vector_store=mock_vector_store,
+            ontology=Ontology(entities=[Entity(label="Person")]),
+        )
+
+    def test_filter_quality_preserves_report(self, mock_graph_store, mock_vector_store):
+        pipeline = self._pipeline_for_units(mock_graph_store, mock_vector_store)
+        out = pipeline._filter_quality(self._reported())
+        assert len(out.nodes) == 1  # the filter still did its job
+        assert (out.chunks_attempted, out.chunks_skipped) == (5, 1)
+        assert out.failed_chunks == ["c1"]
+        assert out.relation_failed_chunks == ["c2"]
+
+    def test_prune_preserves_report(self, mock_graph_store, mock_vector_store):
+        pipeline = self._pipeline_for_units(mock_graph_store, mock_vector_store)
+        out = pipeline._prune(self._reported(), pipeline.ontology)
+        assert (out.chunks_attempted, out.chunks_skipped) == (5, 1)
+        assert out.failed_chunks == ["c1"]
+        assert out.relation_failed_chunks == ["c2"]
+
+
 class TestRemapMentionsUnit:
     """Direct unit tests for ``IngestionPipeline._remap_mentions`` covering
     the chain-following contract independently of the full pipeline."""


### PR DESCRIPTION
## Extraction — GLiNER speed & memory, and failed chunks reported

Measured on an 11-document benchmark against a real FalkorDB. Part of FalkorDB/research#88. First of five stacked PRs that replace #310.

### 1. One GLiNER model per process
**Problem:** every document being ingested loaded its own copy of the GLiNER model — 6 documents in one call = 6 models = 2.4 GB; 30 documents ≈ 11.6 GB.
**Fix:** a class-level cache keyed by model name; one copy shared by every document (+0 MB per document; 30 documents = 1.4 GB).

### 2. Inference lock removed
**Problem:** a lock around `predict_entities` serialised the chunks of a document even though they were dispatched to threads.
**Fix:** lock removed. GLiNER inference mutates no model state (verified: 8 documents in parallel vs serial, 5 trials, 40/40 identical). 1.56× faster NER.

### 3. Index on `id` per entity label
**Problem:** `MERGE` on `id` with no index scans every node — writes went from 4.6 ms to 2,195 ms per 500 entities as the graph grew to 50k nodes (477×).
**Fix:** `GraphStore` creates a range index on `id` for each label once, before its first write. Flat: 8.8 → 8.5 ms; 50k nodes 111 s → 0.69 s.

### 4. Failed chunks are reported
**Problem:** a chunk whose LLM call failed (timeout, bad JSON) contributed nothing and `ingest()` still reported success — an empty document and a broken run looked identical.
**Fix:** `GraphData` / `IngestionResult` carry `chunks_attempted` and `failed_chunks` (the ids, retryable) and a warning is logged.

### Verification
Full suite: **1126 passed, 41 skipped**; ruff check + format clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extraction reports now include attempted, skipped, entity-failed, and relationship-failed chunks.
  * Ingestion results expose detailed extraction reports for monitoring and targeted retries.
  * Graph storage automatically prepares ID indexes for graph updates.
  * Document and chunk identifiers are normalized consistently for repeatable ingestion.

* **Improvements**
  * Shared extraction models reduce duplicate loading and improve concurrent processing.
  * Relationship failures preserve successfully extracted entities.
  * Extraction reports remain available after filtering, pruning, and cached extraction.
  * Unchanged documents can skip redundant processing.

* **Bug Fixes**
  * Failed or incomplete writes are retried instead of being treated as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->