### PR TITLE
Extraction: dates, acronyms, junk tokens and reserved labels — entity-name hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ debug_*.py
 
 # Virtual environments
 .venv/
+# No trailing slash: also ignore a .venv symlink, which `.venv/` does not match.
+graphrag_sdk/.venv
 .venv-*/
 venv/
 

--- a/graphrag_sdk/.venv
+++ b/graphrag_sdk/.venv
@@ -1,0 +1,1 @@
+/Users/naseemali/Documents/GitHub/GraphRAG-SDK/graphrag_sdk/.venv

--- a/graphrag_sdk/.venv
+++ b/graphrag_sdk/.venv
@@ -1,1 +1,0 @@
-/Users/naseemali/Documents/GitHub/GraphRAG-SDK/graphrag_sdk/.venv

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -38,6 +38,7 @@ from graphrag_sdk.core.models import (
     RagResult,
     RetrieverResult,
     UpdateResult,
+    reject_reserved_labels,
 )
 from graphrag_sdk.core.providers import Embedder, LLMInterface
 from graphrag_sdk.discovery import SchemaExtensionProposal, suggest_extensions
@@ -1019,6 +1020,9 @@ class GraphRAG:
         nothing else.
         """
         await self._ensure_ontology_initialized()
+        # A reserved label that reached the ontology (e.g. persisted before the
+        # register-time guard existed) must not become real ``:Document`` nodes.
+        reject_reserved_labels([label])
         entity = next(
             (e for e in self._global_ontology.entities if e.label == label),
             None,
@@ -1059,6 +1063,10 @@ class GraphRAG:
             or "(none)"
         )
         target_desc_line = f"- description: {entity.description}\n" if entity.description else ""
+        # The date gate keys off the whole ontology, not the label being filled:
+        # backfilling ``Product`` in a graph that declares ``Date`` must keep
+        # "747" exactly as the normal extraction path does.
+        ontology_labels = [e.label for e in self._global_ontology.entities]
 
         def _prompt(ctx: ChunkContext) -> str:
             return BACKFILL_ENTITY_PROMPT.format(
@@ -1083,10 +1091,12 @@ class GraphRAG:
             new_mentions: list[GraphRelationship] = []
             for ent in parsed:
                 ent_name = (ent.get("name") or "").strip()
-                if not is_valid_entity_name(ent_name, [label]):
+                if not is_valid_entity_name(ent_name, ontology_labels):
                     skipped += 1
                     continue
-                ent_id = compute_entity_id(label, ent_name)
+                # (name, type) -- the same id the extraction path assigns, so a
+                # backfilled entity merges with its extracted twin.
+                ent_id = compute_entity_id(ent_name, label)
                 props: dict[str, Any] = {
                     "name": ent_name,
                     "description": ent.get("description", ""),

--- a/graphrag_sdk/src/graphrag_sdk/api/main.py
+++ b/graphrag_sdk/src/graphrag_sdk/api/main.py
@@ -1083,7 +1083,7 @@ class GraphRAG:
             new_mentions: list[GraphRelationship] = []
             for ent in parsed:
                 ent_name = (ent.get("name") or "").strip()
-                if not is_valid_entity_name(ent_name):
+                if not is_valid_entity_name(ent_name, [label]):
                     skipped += 1
                     continue
                 ent_id = compute_entity_id(label, ent_name)

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -32,6 +32,14 @@ class DataModel(BaseModel):
 # ── Graph Data Types ─────────────────────────────────────────────
 
 
+#: Node labels the graph store reserves for corpus bookkeeping. They must not
+#: be used as entity types: an entity carrying one of these labels corrupts
+#: document-level queries and is never marked ``__Entity__``, so it silently
+#: disappears from deduplication and retrieval. Single source of truth for
+#: ``GraphStore._STRUCTURAL_LABELS`` and the extractor's config-time check.
+RESERVED_NODE_LABELS: frozenset[str] = frozenset({"Chunk", "Document"})
+
+
 class GraphNode(DataModel):
     """A node in the knowledge graph."""
 

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from enum import Enum
 from typing import Any, Generic, Literal, TypeVar
 from uuid import uuid4
@@ -36,8 +37,44 @@ class DataModel(BaseModel):
 #: be used as entity types: an entity carrying one of these labels corrupts
 #: document-level queries and is never marked ``__Entity__``, so it silently
 #: disappears from deduplication and retrieval. Single source of truth for
-#: ``GraphStore._STRUCTURAL_LABELS`` and the extractor's config-time check.
+#: ``GraphStore._STRUCTURAL_LABELS``, the Cypher generator's label allow-list
+#: and :py:func:`reject_reserved_labels`.
 RESERVED_NODE_LABELS: frozenset[str] = frozenset({"Chunk", "Document"})
+
+
+def reject_reserved_labels(types: Iterable[str]) -> list[str]:
+    """Reject entity types that collide with the store's structural labels.
+
+    ``Document`` and ``Chunk`` are used by the graph store for corpus
+    bookkeeping. An extracted entity carrying one of those labels fails two
+    ways at once, both silently:
+
+    1. Document-level queries (``MATCH (p:Document) ...``) start returning
+       extracted entities, so document counts and lookups are wrong. This was
+       found in the field as an 11-document corpus reporting 106 documents.
+    2. ``GraphStore._write_nodes`` marks a node as an entity only when its
+       label is *not* structural, so the node never receives ``__Entity__``
+       and is dropped from deduplication and retrieval. It is written, then
+       ignored.
+
+    Neither failure raises, so the graph just quietly degrades. Fail here
+    instead, before the label is persisted anywhere, where the caller can act
+    on it. The match is exact, like the store's own membership test and
+    FalkorDB's labels: ``document`` is a distinct (if confusing) label that
+    the store handles correctly, so it is not rejected.
+    """
+    types = list(types)
+    clashes = sorted({str(t).strip() for t in types if str(t).strip() in RESERVED_NODE_LABELS})
+    if clashes:
+        raise ValueError(
+            f"entity_types may not contain the reserved label(s) {clashes}. "
+            f"{sorted(RESERVED_NODE_LABELS)} are used internally for corpus "
+            "bookkeeping; reusing them silently corrupts document counts and "
+            "removes the entity from deduplication and retrieval. "
+            "Rename the type (e.g. 'Document' -> 'Publication', "
+            "'Chunk' -> 'TextSegment')."
+        )
+    return types
 
 
 class GraphNode(DataModel):

--- a/graphrag_sdk/src/graphrag_sdk/core/models.py
+++ b/graphrag_sdk/src/graphrag_sdk/core/models.py
@@ -67,8 +67,8 @@ def reject_reserved_labels(types: Iterable[str]) -> list[str]:
     clashes = sorted({str(t).strip() for t in types if str(t).strip() in RESERVED_NODE_LABELS})
     if clashes:
         raise ValueError(
-            f"entity_types may not contain the reserved label(s) {clashes}. "
-            f"{sorted(RESERVED_NODE_LABELS)} are used internally for corpus "
+            f"Entity label(s) {clashes} clash with the reserved label(s) "
+            f"{sorted(RESERVED_NODE_LABELS)}, which are used internally for corpus "
             "bookkeeping; reusing them silently corrupts document counts and "
             "removes the entity from deduplication and retrieval. "
             "Rename the type (e.g. 'Document' -> 'Publication', "

--- a/graphrag_sdk/src/graphrag_sdk/discovery/pipeline.py
+++ b/graphrag_sdk/src/graphrag_sdk/discovery/pipeline.py
@@ -37,6 +37,7 @@ from graphrag_sdk.core.models import (
     _PROPERTY_TYPES,
     _RESERVED_ATTRIBUTE_NAMES,
     _SDK_MANAGED_ATTRIBUTE_NAMES,
+    RESERVED_NODE_LABELS,
     Attribute,
     DocumentOutput,
     Entity,
@@ -165,6 +166,14 @@ def _validate_proposal(
 
     # Entity-level attribute checks.
     for e in proposal.entities:
+        # Returned as an error rather than raised so the retry loop can ask
+        # the LLM for a different label instead of aborting discovery.
+        if e.label in RESERVED_NODE_LABELS:
+            errors.append(
+                f"Entity label '{e.label}' is reserved for the graph store's "
+                f"own bookkeeping nodes ({', '.join(sorted(RESERVED_NODE_LABELS))}) "
+                f"— rename it (e.g. 'Document' -> 'Publication')."
+            )
         for a in e.properties:
             normalized = (a.type or "STRING").strip().upper()
             if normalized not in _PROPERTY_TYPES:

--- a/graphrag_sdk/src/graphrag_sdk/discovery/pipeline.py
+++ b/graphrag_sdk/src/graphrag_sdk/discovery/pipeline.py
@@ -167,8 +167,10 @@ def _validate_proposal(
     # Entity-level attribute checks.
     for e in proposal.entities:
         # Returned as an error rather than raised so the retry loop can ask
-        # the LLM for a different label instead of aborting discovery.
-        if e.label in RESERVED_NODE_LABELS:
+        # the LLM for a different label instead of aborting discovery.  Strip
+        # first so "Document " is caught here rather than raised from
+        # ``reject_reserved_labels`` (which strips) past the retry loop.
+        if e.label.strip() in RESERVED_NODE_LABELS:
             errors.append(
                 f"Entity label '{e.label}' is reserved for the graph store's "
                 f"own bookkeeping nodes ({', '.join(sorted(RESERVED_NODE_LABELS))}) "

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -176,7 +176,10 @@ def is_valid_entity_name(name: str) -> bool:
     stripped = name.strip()
     if len(stripped) < MIN_NAME_LEN or len(stripped) > MAX_NAME_LEN:
         return False
-    if stripped.lower() in _ENTITY_STOPLIST:
+    # "US" is a country, "us" is a pronoun, and casefolding the stoplist check
+    # conflates them. An all-caps short token is an acronym, not a pronoun.
+    is_acronym = len(stripped) <= 3 and stripped.isupper() and stripped.isalpha()
+    if not is_acronym and stripped.lower() in _ENTITY_STOPLIST:
         return False
     if is_specific_date(stripped):
         return False

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -67,7 +67,19 @@ _PRONOUNS: set[str] = {
     "its",
 }
 
-_ENTITY_STOPLIST: set[str] = _PRONOUNS | {
+# Shell and system abbreviations that read as entities to an NER model but name
+# nothing in any document domain.  Ported here from the extraction prompt, which
+# used to ask the LLM to remove them: a fixed list costs nothing, cannot vary
+# between runs, and cannot be quietly skipped the way the prompt instruction was
+# (see RESULTS.md P2.10).  Well-known two-letter acronyms - AI, US, UK, EU, UN,
+# Go - are deliberately absent and stay.
+_SHELL_TOKENS: frozenset[str] = frozenset({
+    "sh", "cd", "ls", "rm", "cp", "mv", "dt", "bg", "fg", "fn", "df", "du",
+    "ps", "cat", "pwd", "echo", "mkdir", "rmdir", "chmod", "chown", "grep",
+    "awk", "sed", "env", "sudo", "ssh", "tmp", "var", "usr", "bin", "etc",
+})
+
+_ENTITY_STOPLIST: set[str] = _PRONOUNS | _SHELL_TOKENS | {
     # Generic/anonymous references
     "narrator",
     "the narrator",
@@ -182,6 +194,10 @@ def is_valid_entity_name(name: str) -> bool:
     if not is_acronym and stripped.lower() in _ENTITY_STOPLIST:
         return False
     if is_specific_date(stripped):
+        return False
+    # Operator and punctuation tokens (+=, ->, ==, !=). A name with no letter or
+    # digit anywhere in it cannot be the name of anything.
+    if not any(ch.isalnum() for ch in stripped):
         return False
     return True
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -127,6 +127,48 @@ def _normalize_type_label(raw: str) -> str:
     return re.sub(r"[\s_\-/]+", "", s)
 
 
+# A date that pins down a single moment is an *attribute* of an event ("the
+# lamp was installed in 1823"), not something you can hold a conversation
+# about.  A date that names a *period* ("the 1820s", "the Abbasid era") is a
+# thing facts get attached to, so it stays.
+#
+# Measured on the 11-document benchmark: specific dates were 63 of 274 false
+# positive entities (23%).  Removing them lifted entity precision 0.577 -> 0.642
+# with recall unchanged at 0.644 (F1 0.609 -> 0.643) and cost nothing, because
+# every gold Date entity is a decade.  This also stops the graph accumulating
+# "X happened_in 1957" edges that carry no answerable content.
+_SPECIFIC_DATE_RE = re.compile(
+    r"""^(?:
+        (?:c\.?\s*|circa\s+|ca\.?\s*)?\d{3,4}\s*(?:ce|bce|ad|bc)?   # 1823, 1003 ce, c. 1200
+      | \d{1,2}\s+[a-z]+\s+\d{4}                                     # 14 january 1904
+      | [a-z]+\s+\d{1,2},?\s+\d{4}                                    # january 14, 1904
+      | \d{4}[-/]\d{1,2}(?:[-/]\d{1,2})?                              # 1904-01-14
+    )$""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Overrides the rule above: these name a span of time, not a moment.
+_DATE_PERIOD_RE = re.compile(
+    r"\d{3,4}s\b|centur|era\b|dynasty|period|decade|age\b", re.IGNORECASE
+)
+
+
+def is_specific_date(name: str) -> bool:
+    """True if name pins down one moment in time rather than naming a period.
+
+    Specific dates are rejected as entity names: they belong on the relation
+    that mentions them, not as nodes of their own.  Note the deliberate gap --
+    a product genuinely named for a number ("747", "1984") is indistinguishable
+    from a year here and will be dropped.  That trade was worth 63 false
+    positives against zero true positives on the benchmark corpus, but it is
+    the first thing to revisit if a domain uses numeric product names.
+    """
+    stripped = name.strip()
+    if _DATE_PERIOD_RE.search(stripped):
+        return False
+    return bool(_SPECIFIC_DATE_RE.match(stripped))
+
+
 def is_valid_entity_name(name: str) -> bool:
     """Return True if name passes quality gates for entity extraction."""
     if not name or not name.strip():
@@ -135,6 +177,8 @@ def is_valid_entity_name(name: str) -> bool:
     if len(stripped) < MIN_NAME_LEN or len(stripped) > MAX_NAME_LEN:
         return False
     if stripped.lower() in _ENTITY_STOPLIST:
+        return False
+    if is_specific_date(stripped):
         return False
     return True
 

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -200,8 +200,16 @@ _SPECIFIC_DATE_RE = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
-# Overrides the rule above: these name a span of time, not a moment.
-_DATE_PERIOD_RE = re.compile(r"\d{3,4}s\b|centur|era\b|dynasty|period|decade|age\b", re.IGNORECASE)
+# Overrides the rule above: these name a span of time, not a moment.  "era"
+# and "age" are whole words so "opera" and "package" are not periods.
+_DATE_PERIOD_RE = re.compile(
+    r"\d{3,4}s\b|centur|\bera\b|dynasty|period|decade|\bage\b", re.IGNORECASE
+)
+
+# Punctuation that extraction can leave on a date at a sentence boundary
+# ("1823.", "(14 January 1904)"); stripped before the date regexes run so it
+# cannot smuggle a date past the gate.
+_DATE_EDGE_PUNCTUATION = ".,;:!?()[]{}\"'"
 
 
 def is_specific_date(name: str) -> bool:
@@ -216,7 +224,7 @@ def is_specific_date(name: str) -> bool:
     positives against zero true positives on the benchmark corpus, but it is
     the first thing to revisit if a domain uses numeric product names.
     """
-    stripped = name.strip()
+    stripped = name.strip().strip(_DATE_EDGE_PUNCTUATION)
     if _DATE_PERIOD_RE.search(stripped):
         return False
     return bool(_SPECIFIC_DATE_RE.match(stripped))
@@ -247,7 +255,9 @@ def is_valid_entity_name(name: str, entity_types: list[str] | None = None) -> bo
     # conflates them. An all-caps short token is an acronym, not a pronoun --
     # but that only excuses it from the *pronoun* rows of the stoplist. "CD",
     # "ETC" or "MAN" in an all-caps heading are still the shell tokens and
-    # generic nouns they are in lower case.
+    # generic nouns they are in lower case.  The residual cost is that other
+    # all-caps pronouns ("HE", "WE", "MY") also pass: they cannot be told
+    # apart from "US" and "IT" without context, so the exemption keeps them.
     lowered = stripped.lower()
     is_acronym = len(stripped) <= 3 and stripped.isupper() and stripped.isalpha()
     if lowered in _ENTITY_STOPLIST and not (is_acronym and lowered in _PRONOUNS):

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -73,53 +73,87 @@ _PRONOUNS: set[str] = {
 # between runs, and cannot be quietly skipped the way the prompt instruction was
 # (see RESULTS.md P2.10).  Well-known two-letter acronyms - AI, US, UK, EU, UN,
 # Go - are deliberately absent and stay.
-_SHELL_TOKENS: frozenset[str] = frozenset({
-    "sh", "cd", "ls", "rm", "cp", "mv", "dt", "bg", "fg", "fn", "df", "du",
-    "ps", "cat", "pwd", "echo", "mkdir", "rmdir", "chmod", "chown", "grep",
-    "awk", "sed", "env", "sudo", "ssh", "tmp", "var", "usr", "bin", "etc",
-})
+_SHELL_TOKENS: frozenset[str] = frozenset(
+    {
+        "sh",
+        "cd",
+        "ls",
+        "rm",
+        "cp",
+        "mv",
+        "dt",
+        "bg",
+        "fg",
+        "fn",
+        "df",
+        "du",
+        "ps",
+        "cat",
+        "pwd",
+        "echo",
+        "mkdir",
+        "rmdir",
+        "chmod",
+        "chown",
+        "grep",
+        "awk",
+        "sed",
+        "env",
+        "sudo",
+        "ssh",
+        "tmp",
+        "var",
+        "usr",
+        "bin",
+        "etc",
+    }
+)
 
-_ENTITY_STOPLIST: set[str] = _PRONOUNS | _SHELL_TOKENS | {
-    # Generic/anonymous references
-    "narrator",
-    "the narrator",
-    "author",
-    "the author",
-    "reader",
-    "the reader",
-    "speaker",
-    "the speaker",
-    "listener",
-    "the listener",
-    "the man",
-    "the woman",
-    "the boy",
-    "the girl",
-    "the child",
-    "man",
-    "woman",
-    "boy",
-    "girl",
-    "child",
-    "people",
-    "person",
-    "someone",
-    "somebody",
-    "everyone",
-    "everybody",
-    "mistress",
-    "master",
-    # Meta-textual
-    "story",
-    "chapter",
-    "passage",
-    "book",
-    "text",
-    "narrative",
-    "paragraph",
-    "section",
-    "document",
-}
+_ENTITY_STOPLIST: set[str] = (
+    _PRONOUNS
+    | _SHELL_TOKENS
+    | {
+        # Generic/anonymous references
+        "narrator",
+        "the narrator",
+        "author",
+        "the author",
+        "reader",
+        "the reader",
+        "speaker",
+        "the speaker",
+        "listener",
+        "the listener",
+        "the man",
+        "the woman",
+        "the boy",
+        "the girl",
+        "the child",
+        "man",
+        "woman",
+        "boy",
+        "girl",
+        "child",
+        "people",
+        "person",
+        "someone",
+        "somebody",
+        "everyone",
+        "everybody",
+        "mistress",
+        "master",
+        # Meta-textual
+        "story",
+        "chapter",
+        "passage",
+        "book",
+        "text",
+        "narrative",
+        "paragraph",
+        "section",
+        "document",
+    }
+)
 
 
 # ── Entity Utility Functions ─────────────────────────────────────
@@ -164,9 +198,7 @@ _SPECIFIC_DATE_RE = re.compile(
 )
 
 # Overrides the rule above: these name a span of time, not a moment.
-_DATE_PERIOD_RE = re.compile(
-    r"\d{3,4}s\b|centur|era\b|dynasty|period|decade|age\b", re.IGNORECASE
-)
+_DATE_PERIOD_RE = re.compile(r"\d{3,4}s\b|centur|era\b|dynasty|period|decade|age\b", re.IGNORECASE)
 
 
 def is_specific_date(name: str) -> bool:

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -56,7 +56,6 @@ _PRONOUNS: set[str] = {
     "i",
     "we",
     "you",
-    "one",
     "me",
     "us",
     "my",
@@ -114,6 +113,7 @@ _ENTITY_STOPLIST: set[str] = (
     | _SHELL_TOKENS
     | {
         # Generic/anonymous references
+        "one",
         "narrator",
         "the narrator",
         "author",
@@ -179,14 +179,17 @@ def _normalize_type_label(raw: str) -> str:
 # thing facts get attached to, so it stays.
 #
 # This only applies when ``Date`` is not an entity type in the ontology.  An
-# ontology that declares ``Date`` (the defaults do) has asked for date nodes
-# and gets them; one that leaves it out gets no date nodes.
+# ontology that declares ``Date`` has asked for date nodes and gets them; one
+# that leaves it out gets no date nodes.  DEFAULT_ENTITY_TYPES declares
+# ``Date``, so on the out-of-the-box path this rule never fires: it is a gain
+# for custom ontologies that omit ``Date``, not for the default configuration.
 #
-# Measured on the 11-document benchmark: specific dates were 63 of 274 false
-# positive entities (23%).  Removing them lifted entity precision 0.577 -> 0.642
-# with recall unchanged at 0.644 (F1 0.609 -> 0.643) and cost nothing, because
-# every gold Date entity is a decade.  This also stops the graph accumulating
-# "X happened_in 1957" edges that carry no answerable content.
+# Measured on the 11-document benchmark with an ontology that omits ``Date``:
+# specific dates were 63 of 274 false positive entities (23%).  Removing them
+# lifted entity precision 0.577 -> 0.642 with recall unchanged at 0.644 (F1
+# 0.609 -> 0.643) and cost nothing, because every gold Date entity is a
+# decade.  This also stops the graph accumulating "X happened_in 1957" edges
+# that carry no answerable content.
 _SPECIFIC_DATE_RE = re.compile(
     r"""^(?:
         (?:c\.?\s*|circa\s+|ca\.?\s*)?\d{3,4}\s*(?:ce|bce|ad|bc)?   # 1823, 1003 ce, c. 1200
@@ -205,8 +208,9 @@ def is_specific_date(name: str) -> bool:
     """True if name pins down one moment in time rather than naming a period.
 
     Specific dates are rejected as entity names unless the ontology declares a
-    ``Date`` type (see ``is_valid_entity_name``): by default they belong on the
-    relation that mentions them, not as nodes of their own.  Note the deliberate gap --
+    ``Date`` type (see ``is_valid_entity_name``): when the ontology has no
+    ``Date`` type they belong on the relation that mentions them, not as nodes
+    of their own.  Note the deliberate gap --
     a product genuinely named for a number ("747", "1984") is indistinguishable
     from a year here and will be dropped.  That trade was worth 63 false
     positives against zero true positives on the benchmark corpus, but it is
@@ -218,17 +222,21 @@ def is_specific_date(name: str) -> bool:
     return bool(_SPECIFIC_DATE_RE.match(stripped))
 
 
-def _ontology_has_date_type(entity_types: list[str] | None) -> bool:
-    if not entity_types:
-        return False
+def _ontology_has_date_type(entity_types: list[str]) -> bool:
     return any(_normalize_type_label(t) == "date" for t in entity_types)
 
 
 def is_valid_entity_name(name: str, entity_types: list[str] | None = None) -> bool:
     """Return True if name passes quality gates for entity extraction.
 
-    Specific dates ("1823") are rejected unless ``entity_types`` contains
-    ``Date``: when the ontology asks for date nodes, dates are kept.
+    ``entity_types`` is the ontology's entity labels, when the caller has an
+    ontology.  Specific dates ("1823") are rejected when it is given and does
+    not contain ``Date``; when it does, the ontology has asked for date nodes
+    and they are kept.  With ``entity_types=None`` there is no ontology to
+    consult and dates pass: NER extractors receive a label list that is not
+    always an ontology (grounded discovery passes broad anchor labels), so
+    they call this without types and ``GraphExtraction`` applies the date
+    rule itself once the ontology is known.
     """
     if not name or not name.strip():
         return False
@@ -236,11 +244,19 @@ def is_valid_entity_name(name: str, entity_types: list[str] | None = None) -> bo
     if len(stripped) < MIN_NAME_LEN or len(stripped) > MAX_NAME_LEN:
         return False
     # "US" is a country, "us" is a pronoun, and casefolding the stoplist check
-    # conflates them. An all-caps short token is an acronym, not a pronoun.
+    # conflates them. An all-caps short token is an acronym, not a pronoun --
+    # but that only excuses it from the *pronoun* rows of the stoplist. "CD",
+    # "ETC" or "MAN" in an all-caps heading are still the shell tokens and
+    # generic nouns they are in lower case.
+    lowered = stripped.lower()
     is_acronym = len(stripped) <= 3 and stripped.isupper() and stripped.isalpha()
-    if not is_acronym and stripped.lower() in _ENTITY_STOPLIST:
+    if lowered in _ENTITY_STOPLIST and not (is_acronym and lowered in _PRONOUNS):
         return False
-    if not _ontology_has_date_type(entity_types) and is_specific_date(stripped):
+    if (
+        entity_types is not None
+        and not _ontology_has_date_type(entity_types)
+        and is_specific_date(stripped)
+    ):
         return False
     # Operator and punctuation tokens (+=, ->, ==, !=). A name with no letter or
     # digit anywhere in it cannot be the name of anything.
@@ -318,7 +334,10 @@ def _parse_predictions(
         if not isinstance(pred, dict):
             continue
         name = str(pred.get("text", "")).strip()
-        if not is_valid_entity_name(name, entity_types):
+        # No date gate here: ``entity_types`` may be NER anchor labels rather
+        # than the ontology (grounded discovery), so GraphExtraction applies
+        # the ontology-dependent rule after step 1.
+        if not is_valid_entity_name(name):
             continue
         raw_type = str(pred.get("label", "")).strip()
 
@@ -591,7 +610,7 @@ class LLMExtractor(EntityExtractor):
             if not isinstance(item, dict):
                 continue
             name = str(item.get("name", "")).strip()
-            if not is_valid_entity_name(name, entity_types):
+            if not is_valid_entity_name(name):
                 continue
             raw_type = str(item.get("type", "")).strip()
             description = str(item.get("description", "")).strip()

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/entity_extractors.py
@@ -144,6 +144,10 @@ def _normalize_type_label(raw: str) -> str:
 # about.  A date that names a *period* ("the 1820s", "the Abbasid era") is a
 # thing facts get attached to, so it stays.
 #
+# This only applies when ``Date`` is not an entity type in the ontology.  An
+# ontology that declares ``Date`` (the defaults do) has asked for date nodes
+# and gets them; one that leaves it out gets no date nodes.
+#
 # Measured on the 11-document benchmark: specific dates were 63 of 274 false
 # positive entities (23%).  Removing them lifted entity precision 0.577 -> 0.642
 # with recall unchanged at 0.644 (F1 0.609 -> 0.643) and cost nothing, because
@@ -168,8 +172,9 @@ _DATE_PERIOD_RE = re.compile(
 def is_specific_date(name: str) -> bool:
     """True if name pins down one moment in time rather than naming a period.
 
-    Specific dates are rejected as entity names: they belong on the relation
-    that mentions them, not as nodes of their own.  Note the deliberate gap --
+    Specific dates are rejected as entity names unless the ontology declares a
+    ``Date`` type (see ``is_valid_entity_name``): by default they belong on the
+    relation that mentions them, not as nodes of their own.  Note the deliberate gap --
     a product genuinely named for a number ("747", "1984") is indistinguishable
     from a year here and will be dropped.  That trade was worth 63 false
     positives against zero true positives on the benchmark corpus, but it is
@@ -181,8 +186,18 @@ def is_specific_date(name: str) -> bool:
     return bool(_SPECIFIC_DATE_RE.match(stripped))
 
 
-def is_valid_entity_name(name: str) -> bool:
-    """Return True if name passes quality gates for entity extraction."""
+def _ontology_has_date_type(entity_types: list[str] | None) -> bool:
+    if not entity_types:
+        return False
+    return any(_normalize_type_label(t) == "date" for t in entity_types)
+
+
+def is_valid_entity_name(name: str, entity_types: list[str] | None = None) -> bool:
+    """Return True if name passes quality gates for entity extraction.
+
+    Specific dates ("1823") are rejected unless ``entity_types`` contains
+    ``Date``: when the ontology asks for date nodes, dates are kept.
+    """
     if not name or not name.strip():
         return False
     stripped = name.strip()
@@ -193,7 +208,7 @@ def is_valid_entity_name(name: str) -> bool:
     is_acronym = len(stripped) <= 3 and stripped.isupper() and stripped.isalpha()
     if not is_acronym and stripped.lower() in _ENTITY_STOPLIST:
         return False
-    if is_specific_date(stripped):
+    if not _ontology_has_date_type(entity_types) and is_specific_date(stripped):
         return False
     # Operator and punctuation tokens (+=, ->, ==, !=). A name with no letter or
     # digit anywhere in it cannot be the name of anything.
@@ -271,7 +286,7 @@ def _parse_predictions(
         if not isinstance(pred, dict):
             continue
         name = str(pred.get("text", "")).strip()
-        if not is_valid_entity_name(name):
+        if not is_valid_entity_name(name, entity_types):
             continue
         raw_type = str(pred.get("label", "")).strip()
 
@@ -544,7 +559,7 @@ class LLMExtractor(EntityExtractor):
             if not isinstance(item, dict):
                 continue
             name = str(item.get("name", "")).strip()
-            if not is_valid_entity_name(name):
+            if not is_valid_entity_name(name, entity_types):
                 continue
             raw_type = str(item.get("type", "")).strip()
             description = str(item.get("description", "")).strip()

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -22,6 +22,7 @@ from graphrag_sdk.core.models import (
     GraphRelationship,
     Ontology,
     Relation,
+    RESERVED_NODE_LABELS,
     TextChunks,
 )
 from graphrag_sdk.core.providers import LLMInterface
@@ -336,6 +337,38 @@ def _optional_extras(obj: Any) -> dict[str, Any]:
     return extra
 
 
+def _reject_reserved_labels(types: list[str]) -> list[str]:
+    """Reject entity types that collide with the store's structural labels.
+
+    ``Document`` and ``Chunk`` are used by the graph store for corpus
+    bookkeeping. An extracted entity carrying one of those labels fails two
+    ways at once, both silently:
+
+    1. Document-level queries (``MATCH (p:Document) ...``) start returning
+       extracted entities, so document counts and lookups are wrong. This was
+       found in the field as an 11-document corpus reporting 106 documents.
+    2. ``GraphStore._write_nodes`` marks a node as an entity only when its
+       label is *not* structural, so the node never receives ``__Entity__``
+       and is dropped from deduplication and retrieval. It is written, then
+       ignored.
+
+    Neither failure raises, so the graph just quietly degrades. Fail here
+    instead, at configuration time, where the caller can act on it.
+    """
+    reserved = {label.casefold(): label for label in RESERVED_NODE_LABELS}
+    clashes = [t for t in types if str(t).strip().casefold() in reserved]
+    if clashes:
+        raise ValueError(
+            f"entity_types may not contain the reserved label(s) {sorted(set(clashes))}. "
+            f"{sorted(RESERVED_NODE_LABELS)} are used internally for corpus "
+            "bookkeeping; reusing them silently corrupts document counts and "
+            "removes the entity from deduplication and retrieval. "
+            "Rename the type (e.g. 'Document' -> 'Publication', "
+            "'Chunk' -> 'TextSegment')."
+        )
+    return list(types)
+
+
 def _format_entity_types(types: list[str], descs: dict[str, str] | None = None) -> str:
     """Format entity types for prompt injection.
 
@@ -431,7 +464,9 @@ class GraphExtraction(ExtractionStrategy):
         self.llm = llm
         self.entity_extractor = entity_extractor or GLiNERExtractor()
         self.coref_resolver = coref_resolver
-        self.entity_types = entity_types or list(DEFAULT_ENTITY_TYPES)
+        self.entity_types = _reject_reserved_labels(
+            entity_types or list(DEFAULT_ENTITY_TYPES)
+        )
         self._max_concurrency = max_concurrency
 
     async def extract(
@@ -442,7 +477,10 @@ class GraphExtraction(ExtractionStrategy):
     ) -> GraphData:
         # Resolve entity types: ontology overrides instance default
         if ontology.entities:
-            entity_types = [e.label for e in ontology.entities]
+            # Ontology labels bypass the constructor, so re-check here: an
+            # ontology declaring a reserved label must fail as loudly as
+            # passing one to entity_types would.
+            entity_types = _reject_reserved_labels([e.label for e in ontology.entities])
             entity_type_descs: dict[str, str] = {
                 e.label: e.description for e in ontology.entities if e.description
             }

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -13,6 +13,7 @@ from typing import Any
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import (
     _SDK_MANAGED_ATTRIBUTE_NAMES,
+    RESERVED_NODE_LABELS,
     Attribute,
     EntityMention,
     ExtractedEntity,
@@ -22,7 +23,6 @@ from graphrag_sdk.core.models import (
     GraphRelationship,
     Ontology,
     Relation,
-    RESERVED_NODE_LABELS,
     TextChunks,
 )
 from graphrag_sdk.core.providers import LLMInterface
@@ -464,9 +464,7 @@ class GraphExtraction(ExtractionStrategy):
         self.llm = llm
         self.entity_extractor = entity_extractor or GLiNERExtractor()
         self.coref_resolver = coref_resolver
-        self.entity_types = _reject_reserved_labels(
-            entity_types or list(DEFAULT_ENTITY_TYPES)
-        )
+        self.entity_types = _reject_reserved_labels(entity_types or list(DEFAULT_ENTITY_TYPES))
         self._max_concurrency = max_concurrency
 
     async def extract(

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -13,7 +13,6 @@ from typing import Any
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import (
     _SDK_MANAGED_ATTRIBUTE_NAMES,
-    RESERVED_NODE_LABELS,
     Attribute,
     EntityMention,
     ExtractedEntity,
@@ -24,6 +23,7 @@ from graphrag_sdk.core.models import (
     Ontology,
     Relation,
     TextChunks,
+    reject_reserved_labels,
 )
 from graphrag_sdk.core.providers import LLMInterface
 from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
@@ -338,35 +338,15 @@ def _optional_extras(obj: Any) -> dict[str, Any]:
 
 
 def _reject_reserved_labels(types: list[str]) -> list[str]:
-    """Reject entity types that collide with the store's structural labels.
+    """Reject ``Document``/``Chunk`` as entity types; see ``reject_reserved_labels``.
 
-    ``Document`` and ``Chunk`` are used by the graph store for corpus
-    bookkeeping. An extracted entity carrying one of those labels fails two
-    ways at once, both silently:
-
-    1. Document-level queries (``MATCH (p:Document) ...``) start returning
-       extracted entities, so document counts and lookups are wrong. This was
-       found in the field as an 11-document corpus reporting 106 documents.
-    2. ``GraphStore._write_nodes`` marks a node as an entity only when its
-       label is *not* structural, so the node never receives ``__Entity__``
-       and is dropped from deduplication and retrieval. It is written, then
-       ignored.
-
-    Neither failure raises, so the graph just quietly degrades. Fail here
-    instead, at configuration time, where the caller can act on it.
+    The primary guard lives in ``OntologyStore.register`` (so a reserved label
+    is refused before it is persisted) and in discovery's proposal validator.
+    This is the extractor-level backstop for ``entity_types`` passed directly
+    to the constructor and for ontologies handed to ``extract`` without going
+    through the store.
     """
-    reserved = {label.casefold(): label for label in RESERVED_NODE_LABELS}
-    clashes = [t for t in types if str(t).strip().casefold() in reserved]
-    if clashes:
-        raise ValueError(
-            f"entity_types may not contain the reserved label(s) {sorted(set(clashes))}. "
-            f"{sorted(RESERVED_NODE_LABELS)} are used internally for corpus "
-            "bookkeeping; reusing them silently corrupts document counts and "
-            "removes the entity from deduplication and retrieval. "
-            "Rename the type (e.g. 'Document' -> 'Publication', "
-            "'Chunk' -> 'TextSegment')."
-        )
-    return list(types)
+    return reject_reserved_labels(types)
 
 
 def _format_entity_types(types: list[str], descs: dict[str, str] | None = None) -> str:
@@ -475,9 +455,9 @@ class GraphExtraction(ExtractionStrategy):
     ) -> GraphData:
         # Resolve entity types: ontology overrides instance default
         if ontology.entities:
-            # Ontology labels bypass the constructor, so re-check here: an
-            # ontology declaring a reserved label must fail as loudly as
-            # passing one to entity_types would.
+            # Ontology labels bypass the constructor. OntologyStore.register
+            # already refuses reserved labels, but ``extract`` can be handed an
+            # ontology that never went through the store, so re-check here.
             entity_types = _reject_reserved_labels([e.label for e in ontology.entities])
             entity_type_descs: dict[str, str] = {
                 e.label: e.description for e in ontology.entities if e.description
@@ -581,6 +561,17 @@ class GraphExtraction(ExtractionStrategy):
                     chunk_entities.append([])
                 else:
                     chunk_entities.append(result)
+
+        # Extractors filter names without knowing the ontology (their label
+        # list is not always one: grounded discovery passes NER anchors), so
+        # the ontology-dependent rules -- currently the specific-date gate --
+        # are applied here, where ``entity_types`` really is the ontology.
+        # Step 2 re-applies them to the LLM's output; this pass covers the
+        # step-1 entities that survive a step-2 failure unverified.
+        chunk_entities = [
+            [e for e in ents if is_valid_entity_name(e.name, entity_types)]
+            for ents in chunk_entities
+        ]
 
         # ── Step 2: LLM verify + relationship extraction ──
         step2_prompts: list[str] = []

--- a/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
+++ b/graphrag_sdk/src/graphrag_sdk/ingestion/extraction_strategies/graph_extraction.py
@@ -780,7 +780,7 @@ class GraphExtraction(ExtractionStrategy):
             if not isinstance(item, dict):
                 continue
             name = str(item.get("name", "")).strip()
-            if not is_valid_entity_name(name):
+            if not is_valid_entity_name(name, entity_types):
                 continue
             raw_type = str(item.get("type", "")).strip()
             if "/" in raw_type or "(" in raw_type or ")" in raw_type:
@@ -815,7 +815,9 @@ class GraphExtraction(ExtractionStrategy):
             rel_type = str(item.get("type", "")).strip()
             if not source or not target or not rel_type:
                 continue
-            if not is_valid_entity_name(source) or not is_valid_entity_name(target):
+            if not is_valid_entity_name(source, entity_types) or not is_valid_entity_name(
+                target, entity_types
+            ):
                 continue
 
             description = str(item.get("description", "")).strip()

--- a/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/cypher_generation.py
+++ b/graphrag_sdk/src/graphrag_sdk/retrieval/strategies/cypher_generation.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.exceptions import LatencyBudgetExceededError
-from graphrag_sdk.core.models import Ontology
+from graphrag_sdk.core.models import RESERVED_NODE_LABELS, Ontology
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ _ENTITY_LABELS = frozenset(
     }
 )
 
-_STRUCTURAL_LABELS = frozenset({"Chunk", "Document", "__Entity__"})
+_STRUCTURAL_LABELS = RESERVED_NODE_LABELS | {"__Entity__"}
 
 _ALL_LABELS = _ENTITY_LABELS | _STRUCTURAL_LABELS
 

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -14,12 +14,12 @@ from typing import Any
 from graphrag_sdk.core.connection import FalkorDBConnection
 from graphrag_sdk.core.exceptions import DatabaseError
 from graphrag_sdk.core.models import (
+    RESERVED_NODE_LABELS,
     ChunkEntityRow,
     ChunkRelationshipRow,
     DocumentRecord,
     GraphNode,
     GraphRelationship,
-    RESERVED_NODE_LABELS,
 )
 from graphrag_sdk.utils.cypher import sanitize_cypher_label
 

--- a/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/graph_store.py
@@ -19,6 +19,7 @@ from graphrag_sdk.core.models import (
     DocumentRecord,
     GraphNode,
     GraphRelationship,
+    RESERVED_NODE_LABELS,
 )
 from graphrag_sdk.utils.cypher import sanitize_cypher_label
 
@@ -53,7 +54,7 @@ class GraphStore:
     # ── Write Operations ─────────────────────────────────────────
 
     _BATCH_SIZE = 500
-    _STRUCTURAL_LABELS = frozenset({"Chunk", "Document"})
+    _STRUCTURAL_LABELS = RESERVED_NODE_LABELS
     _REL_LABEL_HINTS: dict[str, tuple[str, str]] = {
         "PART_OF": ("Document", "Chunk"),
         "NEXT_CHUNK": ("Chunk", "Chunk"),

--- a/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
+++ b/graphrag_sdk/src/graphrag_sdk/storage/ontology_store.py
@@ -63,6 +63,7 @@ from graphrag_sdk.core.models import (
     Entity,
     Ontology,
     Relation,
+    reject_reserved_labels,
 )
 
 OwnerKind = Literal["entity", "relation"]
@@ -283,6 +284,10 @@ class OntologyStore:
             raise TypeError("register() missing required argument: 'ontology'")
         if not ontology.entities and not ontology.relations:
             return await self.load()
+
+        # Refuse ``Document``/``Chunk`` before anything is persisted: a stored
+        # reserved label would make every later ingest fail mid-pipeline.
+        reject_reserved_labels(e.label for e in ontology.entities)
 
         existing = await self.load()
         self._check_no_contradictions(existing, ontology)

--- a/graphrag_sdk/tests/test_backfill.py
+++ b/graphrag_sdk/tests/test_backfill.py
@@ -407,9 +407,7 @@ class TestBackfillEntity:
         rag._global_ontology = Ontology(
             entities=[Entity(label="Product"), Entity(label="Date")],
         )
-        rag.llm = MockLLM(
-            responses=[json.dumps({"entities": [{"name": "747", "attributes": {}}]})]
-        )
+        rag.llm = MockLLM(responses=[json.dumps({"entities": [{"name": "747", "attributes": {}}]})])
         rag._graph_store.list_chunks_for_entity_backfill = AsyncMock(
             return_value=[{"chunk_id": "c1", "chunk_text": "Boeing's 747"}]
         )

--- a/graphrag_sdk/tests/test_backfill.py
+++ b/graphrag_sdk/tests/test_backfill.py
@@ -389,6 +389,46 @@ class TestBackfillEntity:
         assert rel_call[0].type == "MENTIONED_IN"
         assert rel_call[0].end_node_id == "c1"
         assert result.values_filled == 1
+        # Same (name, type) id as the extraction path, so the backfilled node
+        # merges with an extracted "Bob" instead of living in its own namespace.
+        from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
+            compute_entity_id,
+        )
+
+        node = rag._graph_store.upsert_nodes.await_args.args[0][0]
+        assert node.id == compute_entity_id("Bob", "Person") == "bob__person"
+        assert rel_call[0].start_node_id == node.id
+
+    @pytest.mark.asyncio
+    async def test_date_gate_uses_the_ontology_not_the_target_label(self, rag):
+        """Backfilling `Product` in a graph whose ontology declares `Date` must
+        keep numeric names ("747") exactly as normal extraction would; only the
+        ontology as a whole says whether date-shaped names are wanted."""
+        rag._global_ontology = Ontology(
+            entities=[Entity(label="Product"), Entity(label="Date")],
+        )
+        rag.llm = MockLLM(
+            responses=[json.dumps({"entities": [{"name": "747", "attributes": {}}]})]
+        )
+        rag._graph_store.list_chunks_for_entity_backfill = AsyncMock(
+            return_value=[{"chunk_id": "c1", "chunk_text": "Boeing's 747"}]
+        )
+        rag._graph_store.upsert_nodes = AsyncMock(return_value=1)
+        rag._graph_store.upsert_relationships = AsyncMock(return_value=1)
+        result = await rag.backfill_entity("Product", scope="all")
+        assert result.values_filled == 1
+        assert result.values_skipped == 0
+
+    @pytest.mark.asyncio
+    async def test_reserved_label_is_refused(self, rag):
+        """Even if `Document` somehow reached the ontology, backfill must not
+        write real `:Document` nodes -- that is the "11 documents reported as
+        106" corruption."""
+        rag._global_ontology = Ontology(entities=[Entity(label="Document")])
+        rag._graph_store.upsert_nodes = AsyncMock()
+        with pytest.raises(ValueError, match="reserved label"):
+            await rag.backfill_entity("Document")
+        rag._graph_store.upsert_nodes.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_dry_run_returns_chunks_in_scope_without_llm(self, rag):

--- a/graphrag_sdk/tests/test_facade.py
+++ b/graphrag_sdk/tests/test_facade.py
@@ -18,6 +18,7 @@ from graphrag_sdk.core.models import (
     ApplyChangesResult,
     ChatMessage,
     DeleteDocumentResult,
+    GraphData,
     IngestionResult,
     RagResult,
     RawSearchResult,
@@ -1676,15 +1677,25 @@ class TestGraphRAGUpdate:
 
     async def test_complete_writes_record_content_hash_on_cutover(self, graphrag):
         """The cutover is where ``update()`` stamps the hash; a run with every
-        write reported in full certifies the document as complete."""
+        write reported in full certifies the document as complete.
+
+        Extraction is stubbed: a per-chunk extraction failure is itself an
+        incomplete write (#318 + #309), and the default GLiNER extractor
+        cannot load its tokenizer on every CI runner."""
         import hashlib
+
+        from graphrag_sdk.ingestion.extraction_strategies.base import ExtractionStrategy
+
+        class _CleanExtractor(ExtractionStrategy):
+            async def extract(self, chunks, ontology, ctx):
+                return GraphData(chunks_attempted=len(chunks.chunks))
 
         text = "Fresh content, fully written."
         _stub_graph_store_for_update(
             graphrag, existing_record={"path": "my-doc", "content_hash": "old-hash"}
         )
 
-        result = await graphrag.update(text=text, document_id="my-doc")
+        result = await graphrag.update(text=text, document_id="my-doc", extractor=_CleanExtractor())
 
         assert "incomplete_writes" not in result.metadata
         kwargs = graphrag._graph_store.rollforward_cutover.await_args.kwargs

--- a/graphrag_sdk/tests/test_graph_extraction.py
+++ b/graphrag_sdk/tests/test_graph_extraction.py
@@ -601,16 +601,36 @@ class TestNoiseFiltering:
     def test_generic_short_tokens_rejected(self, name):
         assert not is_valid_entity_name(name)
 
-    @pytest.mark.parametrize("name", ["AI", "US", "UK", "Go", "EU", "UN"])
+    @pytest.mark.parametrize("name", ["AI", "US", "UK", "Go", "EU", "UN", "IT"])
     def test_real_acronyms_kept(self, name):
         """The filter must not take widely-recognised acronyms with it."""
         assert is_valid_entity_name(name)
 
+    @pytest.mark.parametrize(
+        "name",
+        ["CD", "LS", "RM", "PS", "CAT", "ENV", "ETC", "VAR", "BIN", "USR", "SED", "AWK"],
+    )
+    def test_uppercase_shell_tokens_still_rejected(self, name):
+        """The acronym exemption excuses a token from the *pronoun* rows only.
+
+        Before, `is_acronym` skipped the whole stoplist, so an all-caps heading
+        or OCR'd text put `CD`/`ETC` straight into the graph and the shell-token
+        filter was defeated for uppercase input.
+        """
+        assert not is_valid_entity_name(name)
+
+    @pytest.mark.parametrize("name", ["ONE", "MAN", "BOY"])
+    def test_uppercase_generic_nouns_still_rejected(self, name):
+        assert not is_valid_entity_name(name)
+
+    @pytest.mark.parametrize("name", ["us", "it", "he", "we"])
+    def test_lowercase_pronouns_still_rejected(self, name):
+        assert not is_valid_entity_name(name)
+
     @pytest.mark.parametrize("name", ["1823", "1957", "1003 ce", "14 january 1904"])
-    def test_specific_dates_rejected_without_date_type(self, name):
+    def test_specific_dates_rejected_when_ontology_lacks_date_type(self, name):
         """A date pins down a moment; unless the ontology asks for Date nodes it
         is an attribute, not an entity."""
-        assert not is_valid_entity_name(name)
         assert not is_valid_entity_name(name, ["Person", "Location"])
 
     @pytest.mark.parametrize("name", ["1823", "1957", "1003 ce", "14 january 1904"])
@@ -618,6 +638,62 @@ class TestNoiseFiltering:
         """An ontology that declares Date (the defaults do) keeps date nodes."""
         assert is_valid_entity_name(name, DEFAULT_ENTITY_TYPES)
         assert is_valid_entity_name(name, ["Person", "date"])
+
+    @pytest.mark.parametrize("name", ["1823", "1984", "747"])
+    def test_dates_kept_without_an_ontology(self, name):
+        """No ontology, no date rule: the caller has not said dates are unwanted.
+
+        This is what lets grounded discovery see "1984" and "747" -- it has no
+        ontology yet, that is the point of discovery.
+        """
+        assert is_valid_entity_name(name)
+        assert is_valid_entity_name(name, None)
+
+    @pytest.mark.parametrize("name", ["1984", "747", "1969"])
+    def test_ner_anchor_labels_do_not_drive_the_date_gate(self, name):
+        """Grounded discovery hands NER its broad anchor labels, not an
+        ontology. Those must not make the parser drop numeric-looking mentions
+        before catalog linking, or `Book`/`Aircraft` never get discovered."""
+        from graphrag_sdk.discovery.pipeline import _NER_ANCHOR_LABELS
+        from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
+            _parse_predictions,
+        )
+
+        preds = [{"text": name, "label": "event", "score": 0.9, "start": 0, "end": 4}]
+        parsed = _parse_predictions(preds, _NER_ANCHOR_LABELS, "chunk-0", 0.5)
+        assert [e.name for e in parsed] == [name]
+        llm_parsed = LLMExtractor._parse_response(
+            json.dumps([{"name": name, "type": "event"}]), _NER_ANCHOR_LABELS, "chunk-0"
+        )
+        assert [e.name for e in llm_parsed] == [name]
+
+    async def test_extraction_applies_date_gate_to_step1_output(self, ctx):
+        """Extractors no longer know the ontology, so GraphExtraction must
+        apply the date rule itself -- including to step-1 entities that fall
+        through unverified when step 2 fails."""
+
+        class _DateExtractor(EntityExtractor):
+            async def extract_entities(self, text, entity_types, source_chunk_id):
+                return [
+                    ExtractedEntity(name=n, type=t, source_chunk_ids=[source_chunk_id])
+                    for n, t in (("Alice", "Person"), ("1823", "Date"))
+                ]
+
+        async def _names(ontology: Ontology) -> set[str]:
+            # Step 2 returns garbage, so the step-1 entities are used as-is.
+            strategy = GraphExtraction(
+                llm=MockLLM(responses=["not json"]), entity_extractor=_DateExtractor()
+            )
+            result = await strategy.extract(_make_chunks("Alice was born in 1823."), ontology, ctx)
+            return {n.properties["name"] for n in result.nodes}
+
+        no_date = await _names(
+            Ontology(entities=[Entity(label="Person"), Entity(label="Location")])
+        )
+        assert "Alice" in no_date and "1823" not in no_date
+
+        with_date = await _names(Ontology(entities=[Entity(label="Person"), Entity(label="Date")]))
+        assert {"Alice", "1823"} <= with_date
 
     @pytest.mark.parametrize("name", ["1820s", "19th century", "Abbasid era"])
     def test_periods_kept(self, name):
@@ -1001,7 +1077,7 @@ class TestReservedNodeLabels:
     the entity vanished from dedup and retrieval without any error.
     """
 
-    @pytest.mark.parametrize("bad", ["Document", "Chunk", "document", "cHuNk"])
+    @pytest.mark.parametrize("bad", ["Document", "Chunk"])
     def test_reserved_entity_type_is_rejected(self, bad):
         llm = MockLLM()
         with pytest.raises(ValueError, match="reserved label"):
@@ -1010,6 +1086,18 @@ class TestReservedNodeLabels:
                 entity_extractor=LLMExtractor(llm),
                 entity_types=["Person", bad],
             )
+
+    @pytest.mark.parametrize("ok", ["document", "chunk", "DOCUMENT"])
+    def test_match_is_exact_like_the_store(self, ok):
+        """FalkorDB labels are case-sensitive and `GraphStore._write_nodes`
+        tests membership exactly, so `document` is a distinct label the store
+        handles correctly (it gets `__Entity__`; `MATCH (d:Document)` never
+        sees it). Rejecting it would break configs that used to work."""
+        llm = MockLLM()
+        extractor = GraphExtraction(
+            llm=llm, entity_extractor=LLMExtractor(llm), entity_types=["Person", ok]
+        )
+        assert ok in extractor.entity_types
 
     def test_error_names_the_offending_label(self):
         llm = MockLLM()
@@ -1036,5 +1124,10 @@ class TestReservedNodeLabels:
             _reject_reserved_labels(["Person", "Document"])
 
     def test_store_and_extractor_share_one_definition(self):
-        """Two hardcoded copies would drift; the bug returns when they do."""
+        """Hardcoded copies would drift; the bug returns when they do."""
+        from graphrag_sdk.retrieval.strategies import cypher_generation
+
         assert GraphStore._STRUCTURAL_LABELS is RESERVED_NODE_LABELS
+        # The Cypher generator's allow-list is the third copy; it adds the
+        # `__Entity__` marker on top of the store's structural labels.
+        assert cypher_generation._STRUCTURAL_LABELS == RESERVED_NODE_LABELS | {"__Entity__"}

--- a/graphrag_sdk/tests/test_graph_extraction.py
+++ b/graphrag_sdk/tests/test_graph_extraction.py
@@ -4,31 +4,34 @@ from __future__ import annotations
 
 import json
 
-
 import pytest
 
 from graphrag_sdk.core.context import Context
 from graphrag_sdk.core.models import (
+    RESERVED_NODE_LABELS,
+    Entity,
     ExtractedEntity,
     Ontology,
-    Entity,
     Relation,
     TextChunk,
     TextChunks,
 )
 from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
+    DEFAULT_ENTITY_TYPES,
     EntityExtractor,
     LLMExtractor,
+    is_valid_entity_name,
 )
 from graphrag_sdk.ingestion.extraction_strategies.graph_extraction import (
-    GraphExtraction,
     VERIFY_EXTRACT_RELS_PROMPT,
+    GraphExtraction,
     _format_entity_types,
     _format_relation_patterns,
+    _reject_reserved_labels,
 )
+from graphrag_sdk.storage.graph_store import GraphStore
 
 from .conftest import MockLLM, MockLLMWithGraphExtraction
-
 
 # ── Helpers ────────────────────────────────────────────────────
 
@@ -574,6 +577,68 @@ class TestSpansMerging:
         assert "chunk-1" in merged[0].spans
 
 
+class TestNoiseFiltering:
+    """Bug 4: operator/abbreviation/short-token noise must be filtered out.
+
+    These rules used to live as instructions inside VERIFY_EXTRACT_RELS_PROMPT
+    and were asserted by checking the prompt's wording. They now live in
+    ``is_valid_entity_name`` instead, after measurement showed the LLM does not
+    reliably act on verification instructions (RESULTS.md P2.10). Asserting the
+    behaviour rather than the prompt text is also what these tests should have
+    done in the first place: the old version passed whether or not anything was
+    actually filtered.
+    """
+
+    @pytest.mark.parametrize("name", ["+=", "->", "++", "==", "!="])
+    def test_operator_tokens_rejected(self, name):
+        assert not is_valid_entity_name(name)
+
+    @pytest.mark.parametrize("name", ["sh", "cd", "ls", "rm", "cp", "mv"])
+    def test_shell_abbreviations_rejected(self, name):
+        assert not is_valid_entity_name(name)
+
+    @pytest.mark.parametrize("name", ["dt", "bg", "fn"])
+    def test_generic_short_tokens_rejected(self, name):
+        assert not is_valid_entity_name(name)
+
+    @pytest.mark.parametrize("name", ["AI", "US", "UK", "Go", "EU", "UN"])
+    def test_real_acronyms_kept(self, name):
+        """The filter must not take widely-recognised acronyms with it."""
+        assert is_valid_entity_name(name)
+
+    @pytest.mark.parametrize("name", ["1823", "1957", "1003 ce", "14 january 1904"])
+    def test_specific_dates_rejected_without_date_type(self, name):
+        """A date pins down a moment; unless the ontology asks for Date nodes it
+        is an attribute, not an entity."""
+        assert not is_valid_entity_name(name)
+        assert not is_valid_entity_name(name, ["Person", "Location"])
+
+    @pytest.mark.parametrize("name", ["1823", "1957", "1003 ce", "14 january 1904"])
+    def test_specific_dates_kept_when_ontology_has_date(self, name):
+        """An ontology that declares Date (the defaults do) keeps date nodes."""
+        assert is_valid_entity_name(name, DEFAULT_ENTITY_TYPES)
+        assert is_valid_entity_name(name, ["Person", "date"])
+
+    @pytest.mark.parametrize("name", ["1820s", "19th century", "Abbasid era"])
+    def test_periods_kept(self, name):
+        """A period is something facts attach to, so it stays a node."""
+        assert is_valid_entity_name(name)
+
+    @pytest.mark.parametrize("name", ["Boeing 747", "COVID-19"])
+    def test_numeric_names_not_mistaken_for_dates(self, name):
+        assert is_valid_entity_name(name)
+
+    def test_prompt_still_asks_the_llm_to_verify(self):
+        """Removing this instruction was tried and reverted (RESULTS.md P2.12).
+
+        Without it the LLM emitted 813 entities instead of 719 and entity
+        precision fell 0.645 -> 0.551. The code-side rules above are a floor,
+        not a replacement.
+        """
+        assert "REMOVE any entity" in VERIFY_EXTRACT_RELS_PROMPT
+        assert "VERIFY the entities" in VERIFY_EXTRACT_RELS_PROMPT
+
+
 class TestEntityTypeDescriptions:
     """Bug 3: _format_entity_types should include descriptions when available."""
 
@@ -927,14 +992,49 @@ class TestFailedChunkReporting:
         assert result.extraction_failed is False
 
 
-class TestNoiseFilteringPrompt:
-    """Bug 4: VERIFY_EXTRACT_RELS_PROMPT should contain noise-filtering instructions."""
+class TestReservedNodeLabels:
+    """`Document`/`Chunk` are the graph store's bookkeeping labels.
 
-    def test_prompt_contains_operator_filtering(self):
-        assert "symbolic" in VERIFY_EXTRACT_RELS_PROMPT.lower()
+    Reusing one as an entity type used to corrupt the graph silently: document
+    counts picked up extracted entities (an 11-document corpus reported 106),
+    and `GraphStore._write_nodes` skips `__Entity__` for structural labels, so
+    the entity vanished from dedup and retrieval without any error.
+    """
 
-    def test_prompt_contains_abbreviation_filtering(self):
-        assert "non-domain-specific" in VERIFY_EXTRACT_RELS_PROMPT
+    @pytest.mark.parametrize("bad", ["Document", "Chunk", "document", "cHuNk"])
+    def test_reserved_entity_type_is_rejected(self, bad):
+        llm = MockLLM()
+        with pytest.raises(ValueError, match="reserved label"):
+            GraphExtraction(
+                llm=llm,
+                entity_extractor=LLMExtractor(llm),
+                entity_types=["Person", bad],
+            )
 
-    def test_prompt_contains_short_token_filtering(self):
-        assert "1-2 characters" in VERIFY_EXTRACT_RELS_PROMPT
+    def test_error_names_the_offending_label(self):
+        llm = MockLLM()
+        with pytest.raises(ValueError, match="Document"):
+            GraphExtraction(
+                llm=llm,
+                entity_extractor=LLMExtractor(llm),
+                entity_types=["Document"],
+            )
+
+    def test_non_reserved_types_still_allowed(self):
+        llm = MockLLM()
+        extractor = GraphExtraction(
+            llm=llm,
+            entity_extractor=LLMExtractor(llm),
+            entity_types=["Publication", "TextSegment"],
+        )
+        assert extractor.entity_types == ["Publication", "TextSegment"]
+
+    def test_ontology_labels_are_checked_too(self):
+        """The ontology path assigns entity types without going through
+        __init__, so it needs its own guard or the fix is bypassable."""
+        with pytest.raises(ValueError, match="reserved label"):
+            _reject_reserved_labels(["Person", "Document"])
+
+    def test_store_and_extractor_share_one_definition(self):
+        """Two hardcoded copies would drift; the bug returns when they do."""
+        assert GraphStore._STRUCTURAL_LABELS is RESERVED_NODE_LABELS

--- a/graphrag_sdk/tests/test_graph_extraction.py
+++ b/graphrag_sdk/tests/test_graph_extraction.py
@@ -639,6 +639,27 @@ class TestNoiseFiltering:
         assert is_valid_entity_name(name, DEFAULT_ENTITY_TYPES)
         assert is_valid_entity_name(name, ["Person", "date"])
 
+    @pytest.mark.parametrize("name", ["1823.", "(14 January 1904)", "1957,", "'1003 ce'"])
+    def test_specific_dates_with_edge_punctuation_still_rejected(self, name):
+        """Extraction leaves sentence punctuation on a date at a boundary;
+        that must not let it past the gate as a "different" name."""
+        assert not is_valid_entity_name(name, ["Person", "Location"])
+
+    @pytest.mark.parametrize("name", ["Bronze Age", "1990s", "Victorian era", "Ming dynasty"])
+    def test_periods_kept_when_ontology_lacks_date_type(self, name):
+        """A span of time is a topic, not a moment, and stays an entity."""
+        assert is_valid_entity_name(name, ["Person", "Location"])
+
+    @pytest.mark.parametrize("word", ["baggage", "package", "opera", "camera"])
+    def test_period_words_match_whole_words_only(self, word):
+        """`age`/`era` need a leading boundary too, or any word ending in them
+        is misread as a period and exempted from the date rule."""
+        from graphrag_sdk.ingestion.extraction_strategies.entity_extractors import (
+            _DATE_PERIOD_RE,
+        )
+
+        assert _DATE_PERIOD_RE.search(word) is None
+
     @pytest.mark.parametrize("name", ["1823", "1984", "747"])
     def test_dates_kept_without_an_ontology(self, name):
         """No ontology, no date rule: the caller has not said dates are unwanted.

--- a/graphrag_sdk/tests/test_ontology_discovery.py
+++ b/graphrag_sdk/tests/test_ontology_discovery.py
@@ -293,6 +293,17 @@ class TestValidateProposal:
         errors = _validate_proposal(proposal)
         assert any("reserved" in e and "Document" in e for e in errors)
 
+    def test_rejects_reserved_entity_label_with_surrounding_whitespace(self) -> None:
+        """`reject_reserved_labels` strips before matching, so a proposal of
+        `"Document "` must be caught here as a retryable error too -- otherwise
+        it slips past the retry loop and is raised from `register` instead."""
+        proposal = ChunkProposal(
+            entities=[_ProposedEntity(label=" Document ", properties=[])],
+            relations=[],
+        )
+        errors = _validate_proposal(proposal)
+        assert any("reserved" in e and "Document" in e for e in errors)
+
     def test_rejects_bad_attribute_type(self) -> None:
         proposal = ChunkProposal(
             entities=[

--- a/graphrag_sdk/tests/test_ontology_discovery.py
+++ b/graphrag_sdk/tests/test_ontology_discovery.py
@@ -282,6 +282,17 @@ class TestValidateProposal:
         )
         assert _validate_proposal(proposal) == []
 
+    def test_rejects_reserved_entity_label(self) -> None:
+        """An LLM-proposed `Document` type must be sent back for correction
+        here, in the retry loop, rather than persisted and left to break
+        every later ingest."""
+        proposal = ChunkProposal(
+            entities=[_ProposedEntity(label="Document", properties=[])],
+            relations=[],
+        )
+        errors = _validate_proposal(proposal)
+        assert any("reserved" in e and "Document" in e for e in errors)
+
     def test_rejects_bad_attribute_type(self) -> None:
         proposal = ChunkProposal(
             entities=[

--- a/graphrag_sdk/tests/test_ontology_store.py
+++ b/graphrag_sdk/tests/test_ontology_store.py
@@ -167,6 +167,7 @@ class TestRegisterEntityShape:
             ("Person", "age", "INTEGER"),
             ("Person", "birth_place", "STRING"),
         }
+
     @pytest.mark.asyncio
     async def test_reserved_label_is_refused_before_anything_is_written(
         self, store_factory, fake_graph

--- a/graphrag_sdk/tests/test_ontology_store.py
+++ b/graphrag_sdk/tests/test_ontology_store.py
@@ -167,6 +167,19 @@ class TestRegisterEntityShape:
             ("Person", "age", "INTEGER"),
             ("Person", "birth_place", "STRING"),
         }
+    @pytest.mark.asyncio
+    async def test_reserved_label_is_refused_before_anything_is_written(
+        self, store_factory, fake_graph
+    ):
+        """`Document`/`Chunk` are the data graph's bookkeeping labels. A stored
+        reserved label would make every later `ingest()` fail at the extraction
+        step, after the Document and Chunk nodes were already written, so the
+        store refuses it up front -- this also covers `GraphRAG.add_entity`."""
+        store = store_factory()
+        bad = Ontology(entities=[Entity(label="Person"), Entity(label="Document")])
+        with pytest.raises(ValueError, match="reserved label"):
+            await store.register(bad)
+        assert not [c for c in fake_graph.calls if "MERGE" in c[0]]
 
 
 # ── register — relation shape ────────────────────────────────────


### PR DESCRIPTION
## Extraction — entity-name hygiene

Part of FalkorDB/research#88. Stacked on #318. Four cases where a non-entity became a graph node, or a real entity was thrown away, all fixed in code (`is_valid_entity_name` / `_reject_reserved_labels`) rather than by asking the LLM.

### 1. Specific dates are not entities
**Problem:** "1896", "14 January 1904", "1003 CE" became nodes (23 % of the junk that reached the graph).
**Fix:** `is_specific_date()` rejects them as entity names when the ontology has no `Date` type; periods ("1820s", "19th century") are kept, and trailing sentence punctuation ("1823.") does not get a date past the gate. **Precondition:** `DEFAULT_ENTITY_TYPES` declares `Date`, so on the out-of-the-box path the rule never fires and the numbers above (23 % of junk, precision 0.577 → 0.642) apply only to a custom ontology that omits `Date`. Extractors receive the label list without an ontology (`entity_types=None` means "no date rule"); `GraphExtraction._step1` applies the gate once the ontology is known, so grounded discovery's NER anchor labels do not drop "1984" or "747".

### 2. `US`, `UN`, `EU` were dropped as pronouns
**Problem:** the stop-word filter lower-cased first, so `US` matched `us`.
**Fix:** a 2–3 letter all-caps token is read as an acronym and is exempted from the *pronoun* rows of the stop-list only; lower-case `us` is still removed, and `CD`, `ETC`, `MAN` in an all-caps heading are still rejected as the shell tokens and generic nouns they are. Residual: other all-caps pronouns (`HE`, `WE`, `MY`) pass, since they cannot be told apart from `US`/`IT` without context.

### 3. Junk tokens filtered in code
**Problem:** `+=`, `->`, `cd`, `he`, `they` reached the graph whenever the LLM ignored the prompt line asking it to drop them.
**Fix:** a hard rule in `is_valid_entity_name` (operators, shell abbreviations, generic 1–2 char tokens), in addition to the prompt line. Tests now assert behaviour, not prompt wording.

### 4. `Document` and `Chunk` rejected as entity types
**Problem:** the store uses those labels for its own nodes; an entity typed `Document` was stored as a file, invisible to dedup and retrieval (11 files uploaded → graph reported 106 documents).
**Fix:** `RESERVED_NODE_LABELS = {"Document", "Chunk"}`, the single definition shared by `GraphStore`, the Cypher generator and `reject_reserved_labels`. The match is **exact** (like the store's own membership test and FalkorDB labels), so `document` is allowed. The primary guard is in `OntologyStore.register`, before anything is persisted; discovery's `_validate_proposal` returns it as a retryable error so the LLM can pick another label; `backfill_entity` and `GraphExtraction.__init__`/`extract()` keep the check as defence-in-depth. The message names the clashing label.

### Verification
Full suite: **1210 passed, 41 skipped**; `ruff check src` and `ruff format --check src` clean. Note CI does not run on this PR (`ci.yml` triggers on `main`/`staging` only), so the stack's merger should run it on 3.10/3.12.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reserved labels such as `Document` and `Chunk` from being used as custom entity types.
  * Improved entity extraction by filtering noise, invalid names, and unsupported dates according to the configured ontology.
  * Ensured backfilled entities use consistent identifiers and connect correctly to existing mentions.
  * Discovery now reports invalid reserved labels as validation errors, allowing correction without aborting.
  * Prevented invalid ontology registrations and backfills from writing partial data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->